### PR TITLE
Add support for 204 response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
 language: java
 
 jdk:
-- oraclejdk8
+- openjdk8
 
 before_install: 
   - sudo apt-get -y update

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ env:
   global:
     - MAVEN_OPTS=-Dmaven.repo.local=.m2/repository
     - MQTT_WEBSOCKET_VERSION=1.0.1
-    
+
+dist: trusty
+
 cache:
   directories:
   - .jmeter
@@ -11,7 +13,7 @@ cache:
 language: java
 
 jdk:
-- openjdk8
+- oraclejdk8
 
 before_install: 
   - sudo apt-get -y update

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.blazemeter</groupId>
     <artifactId>jmeter-bzm-http2</artifactId>
     <packaging>jar</packaging>
-    <version>1.4</version>
+    <version>1.4.1</version>
     <name>HTTP/2 Sampler</name>
     <description>HTTP/2 protocol sampler</description>
     <licenses>

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2StreamHandler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2StreamHandler.java
@@ -173,6 +173,12 @@ public class HTTP2StreamHandler extends Stream.Listener.Adapter {
         result.setResponseHeaders(responseHeaders);
         result.setHeadersSize(rawHeaders.length());
         result.setHttpFieldsResponse(frame.getMetaData().getFields());
+        // Check if the stream has ended (as in the case of a 204)
+        if (frame.isEndStream()) {
+            result.setSuccessful(isSuccessCode(Integer.parseInt(result.getResponseCode())));
+            result.setResponseData(this.responseBytes);
+            completeStream();
+        }
     }
 
     @Override


### PR DESCRIPTION
In the case where the server returns http status 204, there will be no data frame sent after the header frame. This will cause the sampler to timeout while waiting for the data frame. This change will check to see if the stream has ended in the onHeader method. This flag is set by the server in the case of a 204 status and there will be no data frames sent. If the end of stream is set then the onHeader method will finish the sample and close the stream. This change avoids the timeout and allows the sampler to be used in test scenarios where a http 204 status response is sent from the server.