### PR TITLE
Added buildGetRequest() static method

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/RequestBody.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/RequestBody.java
@@ -6,7 +6,6 @@ import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.protocol.http.util.EncoderCache;
 import org.apache.jmeter.protocol.http.util.HTTPArgument;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
-import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.PropertyIterator;
 import org.apache.jorphan.util.JOrphanUtils;
@@ -30,7 +29,13 @@ public class RequestBody {
 
     public static RequestBody from(String method, String contentEncoding, Arguments args, boolean sendParamsAsBody)
             throws UnsupportedEncodingException {
-        return new RequestBody(buildPostBody(method, contentEncoding, args, sendParamsAsBody), contentEncoding);
+        switch(method) {
+            case HTTPConstants.GET:
+                return new RequestBody(buildGetRequest(contentEncoding, args), contentEncoding);
+            default:
+                return new RequestBody(buildPostBody(method, contentEncoding, args, sendParamsAsBody), contentEncoding);
+
+        }
     }
 
     private static String buildPostBody(String method, String contentEncoding, Arguments args, boolean sendParamsAsBody)
@@ -99,6 +104,33 @@ public class RequestBody {
             }
             return postBodyBuffer.toString();
         }
+    }
+
+    private static String buildGetRequest(String contentEncoding, Arguments args) throws UnsupportedEncodingException {
+        StringBuilder requestBuilder = new StringBuilder();
+        PropertyIterator iter = args.getArguments().iterator();
+
+        while(iter.hasNext()) {
+            HTTPArgument httpArgument = (HTTPArgument) iter.next().getObjectValue();
+            String argName = "",
+                   argValue = "",
+                   queryString = "";
+
+            if(httpArgument.isAlwaysEncoded()) {
+                argName = httpArgument.getEncodedName();
+                argValue = httpArgument.getEncodedValue(contentEncoding);
+            } else {
+                argName = httpArgument.getName();
+                argValue = httpArgument.getValue();
+            }
+
+            queryString = (iter.hasNext())
+                    ? "%s"+ ARG_VAL_SEP +"%s" + QRY_SEP
+                    : "%s"+ ARG_VAL_SEP +"%s";
+            requestBuilder.append(String.format(queryString, argName, argValue));
+        }
+
+        return requestBuilder.toString();
     }
 
     public String getPayload() {

--- a/src/test/java/com/blazemeter/jmeter/http2/sampler/RequestBodyTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/sampler/RequestBodyTest.java
@@ -24,4 +24,17 @@ public class RequestBodyTest {
         assertEquals(text, requestBody.getPayload());
     }
 
+    @Test
+    public void createGetRequestTest() throws UnsupportedEncodingException {
+        String assertText = "toto=test1&tata=test2";
+        Arguments args = new Arguments();
+        HTTPArgument httpArgument1 = new HTTPArgument("toto", "test1");
+        HTTPArgument httpArgument2 = new HTTPArgument("tata", "test2");
+        args.addArgument(httpArgument1);
+        args.addArgument(httpArgument2);
+        RequestBody requestBody = RequestBody.from(HTTPConstants.GET, HTTP2Request.ENCODING, args, false);
+
+        assertEquals(assertText, requestBody.getPayload());
+    }
+
 }


### PR DESCRIPTION
### Issue description
We were encountering an error when building a GET request with query parameters. The URL would build with the parameters, but only the values would show up and it wouldn't append them correctly. In short; here's what a GET request currently results in without my modifications:

`https://some_url?value1value2`

Here's what it is with my changes (and what it should be for the request to work):

`https://some_url?name1=value1&name2=value2`

### What has been done?
* I've added a `private static String buildGetRequest([...])` in the `RequestBody` class. 
* Reworked the method `RequestBody.from()` to use the correct builder according to the `method`
* Added unit tests for the new method.

Thanks!

_Side note: The pom.xml still indicates version 1.4.1 when there's a 1.5.0 release on GitHub._