### PR TITLE
modify PUT method to have data frame

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Connection.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Connection.java
@@ -76,7 +76,7 @@ public class HTTP2Connection {
                                          HTTP2StreamHandler http2StreamHandler, RequestBody requestBody) throws Exception {
         session.newStream(headersFrame, streamPromise, http2StreamHandler);
         LOG.debug("sendMutExc().method= {}", method);
-        if (HTTPConstants.POST.equals(method) || HTTPConstants.PATCH.equals(method)) {
+        if (HTTPConstants.POST.equals(method) || HTTPConstants.PATCH.equals(method)|| HTTPConstants.PUT.equals(method)) {
             Stream actualStream = streamPromise.get();
             actualStream
                 .data(new DataFrame(actualStream.getId(), ByteBuffer.wrap(requestBody.getPayloadBytes()),
@@ -118,7 +118,7 @@ public class HTTP2Connection {
 
     private boolean getEndOfStream(String method) {
         //Currently the end of stream should be true if its GET, DELETE or Default value.
-        return !Arrays.asList(HTTPConstants.PATCH, HTTPConstants.POST)
+        return !Arrays.asList(HTTPConstants.PATCH, HTTPConstants.POST,HTTPConstants.PUT)
             .contains(method);
         
     }

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/RequestBody.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/RequestBody.java
@@ -41,7 +41,8 @@ public class RequestBody {
     private static String buildPostBody(String method, String contentEncoding, Arguments args, boolean sendParamsAsBody)
             throws UnsupportedEncodingException {
         if ((HTTPConstants.POST.equals(method) 
-            || HTTPConstants.PATCH.equals(method) )
+            || HTTPConstants.PATCH.equals(method)
+            || HTTPConstants.PUT.equals(method))
             && !sendParamsAsBody) {
             PropertyIterator iter = args.getArguments().iterator();
             


### PR DESCRIPTION
attached is a tcpdump at port 7010 of a test
[43a.zip](https://github.com/Blazemeter/jmeter-http2-plugin/files/4879445/43a.zip)

the request:
PUT http://136.5.9.43:7010/nchf-spendinglimitcontrol/v1/subscriptions/pcf;7010;00029803;20200706215524378877;0006

PUT data:
{
    "supi": "imsi-460115564020163",
    "gpsi": "msisdn-8615340445579",
    "policyCounterIds": [
        "704534"
    ],
    "notifUri": "http://183.21.2.212:8080/npcf-smpolicycontrol/v1/sm-policies/groupno:238;gpsi:8615340445580;/n28"
}

[no cookies]

and the response..


HTTP/2.0 200 OK
content-length: 167
content-type: application/json
location: /nchf-spendinglimitcontrol/v1/subscriptions/pcf;7010;00029803;20200706215524378877;000

{"gpsi":"msisdn-8615340445579","statusInfos":{"704534":{"currentStatus":"0","policyCounterId":"704534"}},"supi":"imsi-460115564020163","supportedFeatures":"80000000"}