### PR TITLE
MOB-48482: Setup ci-cd

### DIFF
--- a/.github/taurus-constraints.txt
+++ b/.github/taurus-constraints.txt
@@ -1,0 +1,5 @@
+# Pin Taurus to a known-good combination.
+# bzt 1.16.49 currently resolves urwid>=3 and fails at runtime on
+# `from urwid.decoration import Padding`.
+bzt==1.16.40
+urwid==2.1.2

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,0 +1,38 @@
+name: CI Build
+
+on:
+  push:
+
+concurrency:
+  group: ci-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Build and test
+        run: xvfb-run -a mvn -U --batch-mode clean install
+
+      - name: Upload build artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: ci-build-artifacts-${{ github.run_id }}
+          path: |
+            target/jmeter-bzm-http2-*.jar
+            target/jmeter-test
+            target/failsafe-reports
+            target/surefire-reports
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/ci-jmeter-compatibility.yaml
+++ b/.github/workflows/ci-jmeter-compatibility.yaml
@@ -1,0 +1,68 @@
+name: CI JMeter Compatibility
+
+on:
+  push:
+    branches:
+      - development
+      - master
+  workflow_dispatch:
+
+jobs:
+  jmeter_compatibility:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install Taurus
+        run: |
+          python -m pip install --upgrade pip
+          # Install Taurus from pinned constraints to avoid upstream resolver drift.
+          python -m pip install -r .github/taurus-constraints.txt
+          python --version
+          python - <<'PY'
+          import importlib.metadata as metadata
+          for pkg in ("bzt", "urwid"):
+              print(f"{pkg}=={metadata.version(pkg)}")
+          PY
+
+      - name: Restore JMeter cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/.jmeter
+          key: jmeter-${{ runner.os }}-${{ hashFiles('pom.xml', 'src/test/resources/jmeter/**') }}
+          restore-keys: |
+            jmeter-${{ runner.os }}-
+
+      - name: Build project and jmeter-test bundle
+        run: xvfb-run -a mvn -U --batch-mode clean install
+
+      - name: Run compatibility matrix on Java 17
+        working-directory: target/jmeter-test
+        env:
+          JMETER_PATH_BASE: ${{ github.workspace }}/.jmeter
+        run: |
+          JMETER_VERSION=5.5   JMETER_PATH=$JMETER_PATH_BASE/5.5   sh testJMeter.sh
+          JMETER_VERSION=5.6.3 JMETER_PATH=$JMETER_PATH_BASE/5.6.3 sh testJMeter.sh
+
+      - name: Upload compatibility artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: ci-jmeter-compat-failure-${{ github.run_id }}
+          path: target/jmeter-test
+          if-no-files-found: warn
+          retention-days: 1

--- a/pom.xml
+++ b/pom.xml
@@ -417,24 +417,6 @@
         <version>3.0.2</version>
         <executions>
           <execution>
-            <id>copy-jmeter-dependencies</id>
-            <phase>install</phase>
-            <goals>
-              <goal>
-                copy-dependencies
-              </goal>
-            </goals>
-            <configuration>
-              <includeArtifactIds>
-                jetty-http2-client, jetty-client, jetty-http2-client-transport, jetty-http2-common, jetty-http2-hpack,
-                jetty-http, jetty-alpn-client, jetty-alpn-java-client, jetty-io, jetty-util,
-                jetty-http3-client, jetty-quic-client, jetty-compression-gzip, jetty-compression-common, dec
-              </includeArtifactIds>
-              <outputDirectory>${project.build.directory}/jmeter-test/lib</outputDirectory>
-              <stripVersion>true</stripVersion>
-            </configuration>
-          </execution>
-          <execution>
             <id>copy-plugin-to-jmeter-dependencies</id>
             <phase>install</phase>
             <goals>

--- a/src/test/resources/jmeter/testJMeter.sh
+++ b/src/test/resources/jmeter/testJMeter.sh
@@ -1,17 +1,17 @@
-#!/usr/bin/env bash
+#!/bin/bash
+# runs the plugin with the given JMeter version (through taurus)
+# environment variables:
+#   JMETER_VERSION (required)
+#   JMETER_PATH    (optional, defaults to $PWD/.jmeter/$JMETER_VERSION)
+#   JVM_VERSION    (optional, defaults to 8; only used to switch JDKs via update-java-alternatives)
 set -e
 
-export JMETER_VERSION=$1
-export JMETER_PATH=$2/$JMETER_VERSION
-export JMETER_TEST_PATH=${project.basedir}/target/jmeter-test
-export APLN_JAR=$(ls $JMETER_TEST_PATH/lib/ | grep alpn-boot)
-export JVM_ARGS="-Xbootclasspath/p:$JMETER_TEST_PATH/lib/alpn-boot.jar"
-JARS=$(ls $JMETER_TEST_PATH/lib/ | grep -v alpn-boot)
+JMETER_PATH=${JMETER_PATH:-$PWD/.jmeter/$JMETER_VERSION}
+DEFAULT_JVM_VERSION=8
+JVM_VERSION=${JVM_VERSION:-$DEFAULT_JVM_VERSION}
 
-cd $JMETER_TEST_PATH/lib/
-mkdir -p $JMETER_PATH/lib/ext/ && cp -f $JARS $JMETER_PATH/lib/ext/
-cd $JMETER_TEST_PATH
-bzt -o modules.jmeter.path=$JMETER_PATH -o modules.jmeter.version=$JMETER_VERSION testJMeter.yaml || ERROR=$?
-cd $JMETER_PATH/lib/ext/
-rm $JARS
+ERROR=0
+[ "$JVM_VERSION" != "$DEFAULT_JVM_VERSION" ] && update-java-alternatives --set java-1.${JVM_VERSION}.0-openjdk-amd64
+bzt testJMeter.yaml -o modules.jmeter.version=$JMETER_VERSION -o modules.jmeter.path=$JMETER_PATH || ERROR=$?
+[ "$JVM_VERSION" != "$DEFAULT_JVM_VERSION" ] && update-java-alternatives --set java-1.${DEFAULT_JVM_VERSION}.0-openjdk-amd64
 exit $ERROR


### PR DESCRIPTION
This pull request introduces continuous integration (CI) workflows for building and testing the project, with a particular focus on JMeter compatibility and Taurus environment stability. It also removes an unused Maven dependency plugin execution and improves the test script for better flexibility and maintainability.

**CI workflow additions and improvements:**

* Added `.github/workflows/ci-build.yaml` to automate building, testing, and artifact uploading for every push, ensuring consistent build validation.
* Introduced `.github/workflows/ci-jmeter-compatibility.yaml` to run a compatibility matrix against multiple JMeter versions using Taurus, with pinned dependencies for reliability.
* Added `.github/taurus-constraints.txt` to pin Taurus and its dependencies, preventing failures due to upstream package changes.

**Build and test process updates:**

* Removed the unused `copy-jmeter-dependencies` execution from the `maven-dependency-plugin` in `pom.xml`, simplifying the build process.
* Refactored `src/test/resources/jmeter/testJMeter.sh` to use environment variables for configuration, support JDK switching, and streamline Taurus test execution.