### PR TITLE
Fix parent sample with sub-samples and add assertions

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/control/HTTP2Controller.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/control/HTTP2Controller.java
@@ -4,8 +4,10 @@ import com.blazemeter.jmeter.http2.core.HTTP2FutureResponseListener;
 import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
 import com.blazemeter.jmeter.http2.util.BzmHttpPluginProperties;
 import java.io.Serializable;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import org.apache.jmeter.control.GenericController;
 import org.apache.jmeter.control.NextIsNullException;
@@ -290,15 +292,57 @@ public class HTTP2Controller extends GenericController implements Serializable {
     if (vars == null) {
       return null;
     }
-    Object pack = vars.getObject("JMeterThread.pack");
+    Object pack = vars.getObject(JMeterThread.PACKAGE_OBJECT);
     return pack instanceof SamplePackage ? (SamplePackage) pack : null;
   }
 
   private void registerParentSamplePackage(ParentSample sampler) {
-    SamplePackage pack = getSamplePackageFromContext();
-    if (pack == null) {
-      return;
+    SamplePackage childPack = getSamplePackageFromContext();
+    if (childPack == null) {
+      childPack = resolveChildSamplePackageFromCompiler();
     }
+    SamplePackage parentPack = childPack != null
+        ? createParentExecutionPackage(childPack)
+        : createEmptyParentExecutionPackage();
+    parentPack.setSampler(sampler);
+    putSamplerPackageInCompilerMap(sampler, parentPack);
+  }
+
+  private SamplePackage resolveChildSamplePackageFromCompiler() {
+    JMeterThread thread = JMeterContextService.getContext().getThread();
+    if (thread == null) {
+      return null;
+    }
+    try {
+      java.lang.reflect.Field compilerField = JMeterThread.class.getDeclaredField("compiler");
+      compilerField.setAccessible(true);
+      TestCompiler compiler = (TestCompiler) compilerField.get(thread);
+      if (compiler == null) {
+        return null;
+      }
+      java.lang.reflect.Field mapField = TestCompiler.class.getDeclaredField("samplerConfigMap");
+      mapField.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      Map<Object, SamplePackage> map =
+          (Map<Object, SamplePackage>) mapField.get(compiler);
+      if (map == null) {
+        return null;
+      }
+      for (TestElement element : subControllersAndSamplers) {
+        if (element instanceof HTTP2Sampler) {
+          SamplePackage pack = map.get(element);
+          if (pack != null) {
+            return pack;
+          }
+        }
+      }
+    } catch (Exception e) {
+      LOG.debug("Failed to resolve child SamplePackage from compiler", e);
+    }
+    return null;
+  }
+
+  private void putSamplerPackageInCompilerMap(Object sampler, SamplePackage pack) {
     JMeterThread thread = JMeterContextService.getContext().getThread();
     if (thread == null) {
       return;
@@ -313,14 +357,41 @@ public class HTTP2Controller extends GenericController implements Serializable {
       java.lang.reflect.Field mapField = TestCompiler.class.getDeclaredField("samplerConfigMap");
       mapField.setAccessible(true);
       @SuppressWarnings("unchecked")
-      java.util.Map<Object, SamplePackage> map =
-          (java.util.Map<Object, SamplePackage>) mapField.get(compiler);
+      Map<Object, SamplePackage> map =
+          (Map<Object, SamplePackage>) mapField.get(compiler);
       if (map != null) {
         map.put(sampler, pack);
       }
     } catch (Exception e) {
       LOG.debug("Failed to register parent sampler package", e);
     }
+  }
+
+  /**
+   * Parent synthetic sampler must not inherit child assertions/post-processors: JMeter would run
+   * them against the aggregated parent {@link SampleResult}, whose response body is empty.
+   */
+  private static SamplePackage createParentExecutionPackage(SamplePackage childPack) {
+    SamplePackage parentPack = new SamplePackage(
+        childPack.getConfigs(),
+        childPack.getSampleListeners(),
+        childPack.getTimers(),
+        new ArrayList<>(),
+        new ArrayList<>(),
+        new ArrayList<>(),
+        new ArrayList<>());
+    return parentPack;
+  }
+
+  private static SamplePackage createEmptyParentExecutionPackage() {
+    return new SamplePackage(
+        new ArrayList<>(),
+        new ArrayList<>(),
+        new ArrayList<>(),
+        new ArrayList<>(),
+        new ArrayList<>(),
+        new ArrayList<>(),
+        new ArrayList<>());
   }
 
   private SampleResult buildParentSampleResult() {
@@ -435,7 +506,20 @@ public class HTTP2Controller extends GenericController implements Serializable {
         : original.getAssertionResults()) {
       copy.addAssertionResult(assertion);
     }
+    // Sub-samples attached to the async parent must not stay ignored (the child sampler is ignored
+    // only so JMeter does not notify listeners twice). JMeter 5.4 exposes only no-arg setIgnore().
+    clearIgnoreOnSampleResult(copy);
     return copy;
+  }
+
+  private static void clearIgnoreOnSampleResult(SampleResult result) {
+    try {
+      Field ignoreField = SampleResult.class.getDeclaredField("ignore");
+      ignoreField.setAccessible(true);
+      ignoreField.setBoolean(result, false);
+    } catch (Exception e) {
+      LOG.debug("Could not clear ignore flag on async parent sub-sample copy", e);
+    }
   }
 
 }

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/AsyncCompletionSamplePipeline.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/AsyncCompletionSamplePipeline.java
@@ -1,0 +1,166 @@
+package com.blazemeter.jmeter.http2.sampler;
+
+import java.util.List;
+import org.apache.jmeter.assertions.Assertion;
+import org.apache.jmeter.assertions.AssertionResult;
+import org.apache.jmeter.processor.PostProcessor;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.testbeans.TestBeanHelper;
+import org.apache.jmeter.testelement.AbstractScopedAssertion;
+import org.apache.jmeter.testelement.AbstractTestElement;
+import org.apache.jmeter.testelement.TestElement;
+import org.apache.jmeter.threads.JMeterContext;
+import org.apache.jmeter.threads.JMeterContextService;
+import org.apache.jmeter.threads.JMeterThread;
+import org.apache.jmeter.threads.SamplePackage;
+import org.apache.jorphan.util.JMeterError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs the same post-sample steps {@link org.apache.jmeter.threads.JMeterThread} applies when a
+ * sampler returns a non-ignored {@link SampleResult}: thread metadata, {@code previousResult},
+ * post-processors, and assertions. Used when an async HTTP2 sample completes under "Generate
+ * parent sample" and the sampler returns {@code null} to JMeter so listeners stay unchanged, but
+ * child-scoped assertions and extractors still run.
+ */
+final class AsyncCompletionSamplePipeline {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AsyncCompletionSamplePipeline.class);
+
+  private AsyncCompletionSamplePipeline() {}
+
+  /**
+   * Mirrors {@code JMeterThread.executeSamplePackage} for the fragment after a successful sample,
+   * excluding listener notification and {@code compiler.done}.
+   */
+  static void runAfterAsyncSample(SampleResult result, SamplePackage pack, JMeterContext ctx) {
+    if (result == null || pack == null || ctx == null) {
+      return;
+    }
+    JMeterThread thread = ctx.getThread();
+    if (thread == null) {
+      LOG.debug("No JMeterThread in context; skipping async completion pipeline");
+      return;
+    }
+    int nbActiveThreadsInThreadGroup = 0;
+    if (ctx.getThreadGroup() != null) {
+      nbActiveThreadsInThreadGroup = ctx.getThreadGroup().getNumberOfThreads();
+    }
+    int nbTotalActiveThreads = JMeterContextService.getNumberOfThreads();
+    String threadName = thread.getThreadName();
+    if (threadName == null || threadName.isEmpty()) {
+      threadName = Thread.currentThread().getName();
+    }
+    fillThreadInformation(result, threadName, nbActiveThreadsInThreadGroup,
+        nbTotalActiveThreads);
+    SampleResult[] subResults = result.getSubResults();
+    if (subResults != null) {
+      for (SampleResult sub : subResults) {
+        fillThreadInformation(sub, threadName, nbActiveThreadsInThreadGroup,
+            nbTotalActiveThreads);
+      }
+    }
+    ctx.setPreviousResult(result);
+    runPostProcessors(pack.getPostProcessors());
+    checkAssertions(pack.getAssertions(), result, ctx);
+  }
+
+  private static void fillThreadInformation(SampleResult result, String threadName,
+      int nbActiveThreadsInThreadGroup, int nbTotalActiveThreads) {
+    result.setGroupThreads(nbActiveThreadsInThreadGroup);
+    result.setAllThreads(nbTotalActiveThreads);
+    result.setThreadName(threadName);
+  }
+
+  private static void runPostProcessors(List<?> extractors) {
+    if (extractors == null) {
+      return;
+    }
+    for (Object exObj : extractors) {
+      PostProcessor ex = (PostProcessor) exObj;
+      TestBeanHelper.prepare((TestElement) ex);
+      ex.process();
+    }
+  }
+
+  private static void checkAssertions(List<?> assertions, SampleResult parent,
+      JMeterContext threadContext) {
+    if (assertions == null) {
+      return;
+    }
+    for (Object assObj : assertions) {
+      Assertion assertion = (Assertion) assObj;
+      TestBeanHelper.prepare((TestElement) assertion);
+      if (assertion instanceof AbstractScopedAssertion) {
+        AbstractScopedAssertion scopedAssertion = (AbstractScopedAssertion) assertion;
+        String scope = scopedAssertion.fetchScope();
+        if (scopedAssertion.isScopeParent(scope)
+            || scopedAssertion.isScopeAll(scope)
+            || scopedAssertion.isScopeVariable(scope)) {
+          processAssertion(parent, assertion);
+        }
+        if (scopedAssertion.isScopeChildren(scope) || scopedAssertion.isScopeAll(scope)) {
+          recurseAssertionChecks(parent, assertion, 3);
+        }
+      } else {
+        processAssertion(parent, assertion);
+      }
+    }
+    setLastSampleOk(threadContext.getVariables(), parent.isSuccessful());
+  }
+
+  private static void recurseAssertionChecks(SampleResult parent, Assertion assertion, int level) {
+    if (level < 0) {
+      return;
+    }
+    SampleResult[] children = parent.getSubResults();
+    boolean childError = false;
+    if (children != null) {
+      for (SampleResult childSampleResult : children) {
+        processAssertion(childSampleResult, assertion);
+        recurseAssertionChecks(childSampleResult, assertion, level - 1);
+        if (!childSampleResult.isSuccessful()) {
+          childError = true;
+        }
+      }
+    }
+    if (childError && parent.isSuccessful()) {
+      AssertionResult assertionResult =
+          new AssertionResult(((AbstractTestElement) assertion).getName());
+      assertionResult.setResultForFailure("One or more sub-samples failed");
+      parent.addAssertionResult(assertionResult);
+      parent.setSuccessful(false);
+    }
+  }
+
+  private static void processAssertion(SampleResult result, Assertion assertion) {
+    AssertionResult assertionResult;
+    try {
+      assertionResult = assertion.getResult(result);
+    } catch (AssertionError e) {
+      LOG.debug("Error processing Assertion.", e);
+      assertionResult = new AssertionResult("Assertion failed! See log file (debug level, only).");
+      assertionResult.setFailure(true);
+      assertionResult.setFailureMessage(e.toString());
+    } catch (JMeterError e) {
+      LOG.error("Error processing Assertion.", e);
+      assertionResult = new AssertionResult("Assertion failed! See log file.");
+      assertionResult.setError(true);
+      assertionResult.setFailureMessage(e.toString());
+    } catch (Exception e) {
+      LOG.error("Exception processing Assertion.", e);
+      assertionResult = new AssertionResult("Assertion failed! See log file.");
+      assertionResult.setError(true);
+      assertionResult.setFailureMessage(e.toString());
+    }
+    result.setSuccessful(
+        result.isSuccessful() && !(assertionResult.isError() || assertionResult.isFailure()));
+    result.addAssertionResult(assertionResult);
+  }
+
+  private static void setLastSampleOk(org.apache.jmeter.threads.JMeterVariables variables,
+      boolean value) {
+    variables.put(JMeterThread.LAST_SAMPLE_OK, Boolean.toString(value));
+  }
+}

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -43,6 +43,7 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.ThreadListener;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.NullProperty;
+import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterThread;
 import org.apache.jmeter.threads.JMeterVariables;
@@ -435,10 +436,13 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
             this.result = sampleFromListener(
                 this.result, areFollowingRedirect, depth, this.asyncListener);
             if (isAsyncParentSampleEnabled()) {
+              applyAsyncParentCompletionPipeline(this.result);
               this.result.setIgnore();
+              HTTP2Controller.registerAsyncSampleResult(this, this.result, this.asyncListener);
+              return null;
             }
             HTTP2Controller.registerAsyncSampleResult(this, this.result, this.asyncListener);
-            return isAsyncParentSampleEnabled() ? null : this.result;
+            return this.result;
           } finally {
             restoreSuppressedPreProcessors();
           }
@@ -454,6 +458,7 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
       }
       HTTPSampleResult errorResult = buildErrorResult(e, this.result);
       if (isAsyncParentSampleEnabled()) {
+        applyAsyncParentCompletionPipeline(errorResult);
         errorResult.setIgnore();
       }
       HTTP2Controller.registerAsyncSampleResult(this, errorResult, this.asyncListener);
@@ -513,10 +518,62 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
       }
       HTTPSampleResult errorResult = buildErrorResult(e, this.result);
       if (isAsyncParentSampleEnabled()) {
+        applyAsyncParentCompletionPipeline(errorResult);
         errorResult.setIgnore();
       }
       HTTP2Controller.registerAsyncSampleResult(this, errorResult, this.asyncListener);
       return isAsyncParentSampleEnabled() ? null : errorResult;
+    }
+  }
+
+  /**
+   * When {@link #isAsyncParentSampleEnabled()} and this sampler returns {@code null} to JMeter,
+   * run post-processors and assertions here (same order as {@code JMeterThread}) so child elements
+   * still apply; pre-processors already ran on the initial async dispatch and stay suppressed until
+   * {@link #restoreSuppressedPreProcessors()} in {@code finally}.
+   */
+  private void applyAsyncParentCompletionPipeline(HTTPSampleResult res) {
+    if (res == null || !isAsyncParentSampleEnabled()) {
+      return;
+    }
+    JMeterContext ctx = JMeterContextService.getContext();
+    SamplePackage pack = resolveSamplePackageForAsyncCompletion(ctx);
+    if (pack == null) {
+      LOG.warn("Async parent completion pipeline skipped for sampler={}: no SamplePackage",
+          getName());
+      return;
+    }
+    ctx.setCurrentSampler(this);
+    AsyncCompletionSamplePipeline.runAfterAsyncSample(res, pack, ctx);
+  }
+
+  /**
+   * Resolves the {@link SamplePackage} for the in-flight {@code JMeterThread.executeSamplePackage}
+   * call. Prefer the pack captured when pre-processors were suppressed for async completion, then
+   * {@code JMeterThread.PACKAGE_OBJECT}, then the compiler map.
+   */
+  private SamplePackage resolveSamplePackageForAsyncCompletion(JMeterContext ctx) {
+    if (suppressedSamplePackage != null) {
+      return suppressedSamplePackage;
+    }
+    if (ctx != null && ctx.getVariables() != null) {
+      Object packObj = ctx.getVariables().getObject(JMeterThread.PACKAGE_OBJECT);
+      if (packObj instanceof SamplePackage) {
+        return (SamplePackage) packObj;
+      }
+    }
+    try {
+      JMeterThread thread = ctx != null ? ctx.getThread() : null;
+      if (thread == null) {
+        return null;
+      }
+      Field compilerField = JMeterThread.class.getDeclaredField("compiler");
+      compilerField.setAccessible(true);
+      TestCompiler compiler = (TestCompiler) compilerField.get(thread);
+      return getSamplePackageFromCompiler(compiler);
+    } catch (Exception e) {
+      LOG.debug("Failed to resolve SamplePackage for async completion", e);
+      return null;
     }
   }
 

--- a/src/test/java/com/blazemeter/jmeter/http2/sampler/AsyncCompletionSamplePipelineTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/sampler/AsyncCompletionSamplePipelineTest.java
@@ -1,0 +1,90 @@
+package com.blazemeter.jmeter.http2.sampler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import org.apache.jmeter.assertions.ResponseAssertion;
+import org.apache.jmeter.control.LoopController;
+import org.apache.jmeter.processor.PostProcessor;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.testelement.AbstractTestElement;
+import org.apache.jmeter.threads.JMeterContextService;
+import org.apache.jmeter.threads.JMeterThread;
+import org.apache.jmeter.threads.JMeterThreadMonitor;
+import org.apache.jmeter.threads.JMeterVariables;
+import org.apache.jmeter.threads.ListenerNotifier;
+import org.apache.jmeter.threads.SamplePackage;
+import org.apache.jmeter.threads.TestCompiler;
+import org.apache.jorphan.collections.HashTree;
+import org.junit.Test;
+
+public class AsyncCompletionSamplePipelineTest {
+
+  private static class VarPostProcessor extends AbstractTestElement implements PostProcessor {
+    @Override
+    public void process() {
+      JMeterContextService.getContext().getVariables().put("ranPost", "1");
+    }
+  }
+
+  @Test
+  public void runsAssertionsAndPostProcessorsLikeJMeterThread() throws Exception {
+    JMeterTestUtils.setupJmeterEnv();
+
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    VarPostProcessor post = new VarPostProcessor();
+
+    ResponseAssertion assertion = new ResponseAssertion();
+    assertion.addTestString("About Us");
+    assertion.setTestFieldResponseData();
+
+    HashTree testTree = new HashTree();
+    LoopController controller = new LoopController();
+    controller.setLoops(1);
+    controller.initialize();
+    HashTree controllerTree = testTree.add(controller);
+    controllerTree.add(sampler);
+    controllerTree.add(sampler, post);
+    controllerTree.add(sampler, assertion);
+
+    JMeterThreadMonitor monitor = thread -> { };
+    JMeterThread thread = new JMeterThread(testTree, monitor, new ListenerNotifier());
+
+    JMeterVariables threadVars = getThreadVars(thread);
+    JMeterContextService.getContext().setThread(thread);
+    JMeterContextService.getContext().setVariables(threadVars);
+
+    TestCompiler compiler = getCompiler(thread);
+    testTree.traverse(compiler);
+    SamplePackage samplePackage = compiler.configureSampler(sampler);
+
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setSampleLabel("t");
+    result.setHTTPMethod(HTTPConstants.GET);
+    result.sampleStart();
+    result.setResponseData("About Us and more", null);
+    result.setSuccessful(true);
+    result.sampleEnd();
+
+    AsyncCompletionSamplePipeline.runAfterAsyncSample(
+        result, samplePackage, JMeterContextService.getContext());
+
+    assertThat(threadVars.get("ranPost")).isEqualTo("1");
+    assertThat(threadVars.get(JMeterThread.LAST_SAMPLE_OK)).isEqualTo("true");
+    assertThat(result.getAssertionResults()).isNotEmpty();
+    assertThat(result.isSuccessful()).isTrue();
+  }
+
+  private static JMeterVariables getThreadVars(JMeterThread thread) throws Exception {
+    Field f = JMeterThread.class.getDeclaredField("threadVars");
+    f.setAccessible(true);
+    return (JMeterVariables) f.get(thread);
+  }
+
+  private static TestCompiler getCompiler(JMeterThread thread) throws Exception {
+    Field compilerField = JMeterThread.class.getDeclaredField("compiler");
+    compilerField.setAccessible(true);
+    return (TestCompiler) compilerField.get(thread);
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/sampler/HTTP2AsyncParentSampleAssertionTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/sampler/HTTP2AsyncParentSampleAssertionTest.java
@@ -1,0 +1,301 @@
+package com.blazemeter.jmeter.http2.sampler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.control.HTTP2Controller;
+import com.blazemeter.jmeter.http2.core.HTTP2JettyClient;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.List;
+import org.apache.jmeter.assertions.AssertionResult;
+import org.apache.jmeter.assertions.ResponseAssertion;
+import org.apache.jmeter.control.LoopController;
+import org.apache.jmeter.control.TransactionSampler;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.samplers.Sampler;
+import org.apache.jmeter.threads.AbstractThreadGroup;
+import org.apache.jmeter.threads.JMeterContext;
+import org.apache.jmeter.threads.JMeterContextService;
+import org.apache.jmeter.threads.JMeterThread;
+import org.apache.jmeter.threads.JMeterThreadMonitor;
+import org.apache.jmeter.threads.JMeterVariables;
+import org.apache.jmeter.threads.ListenerNotifier;
+import org.apache.jmeter.threads.SamplePackage;
+import org.apache.jmeter.threads.TestCompiler;
+import org.apache.jorphan.collections.HashTree;
+import org.eclipse.jetty.client.Request;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/**
+ * Reproduces GitHub issue #93: async controller with generate parent sample and a child response
+ * assertion must not report {@link AssertionResult#RESPONSE_WAS_NULL}.
+ */
+public class HTTP2AsyncParentSampleAssertionTest extends HTTP2TestBase {
+
+  @org.junit.Rule
+  public final MockitoRule mockito = MockitoJUnit.rule();
+
+  @Mock
+  private HTTP2JettyClient client;
+  @Mock
+  private Request jettyRequest;
+
+  private HTTP2Sampler sampler;
+  private HTTP2Controller asyncController;
+  private ResponseAssertion assertion;
+  private JMeterThread jmeterThread;
+  private JMeterContext jmeterContext;
+  private JMeterVariables threadVars;
+
+  @Before
+  public void setUp() throws Exception {
+    sampler = new HTTP2Sampler(() -> client);
+    sampler.setDomain("demoblaze.com");
+    sampler.setProtocol("https");
+    sampler.setPath("/");
+    sampler.setMethod(HTTPConstants.GET);
+
+    assertion = new ResponseAssertion();
+    assertion.setName("Response Assertion");
+    assertion.addTestString("About Us");
+    assertion.setTestFieldResponseData();
+    assertion.setToContainsType();
+
+    HTTP2Controller asyncController = new HTTP2Controller();
+    asyncController.setGenerateControllerSample(true);
+    this.asyncController = asyncController;
+
+    LoopController loop = new LoopController();
+    loop.setLoops(1);
+    loop.initialize();
+
+    HashTree testTree = new HashTree();
+    HashTree loopTree = testTree.add(loop);
+    HashTree controllerTree = loopTree.add(asyncController);
+    controllerTree.add(sampler);
+    controllerTree.add(sampler, assertion);
+
+    JMeterThreadMonitor monitor = thread -> { };
+    jmeterThread = new JMeterThread(testTree, monitor, new ListenerNotifier());
+    threadVars = getThreadVars(jmeterThread);
+    jmeterContext = JMeterContextService.getContext();
+    jmeterContext.setThread(jmeterThread);
+    jmeterContext.setVariables(threadVars);
+
+    AbstractThreadGroup threadGroup = mock(AbstractThreadGroup.class);
+    when(threadGroup.getNumberOfThreads()).thenReturn(1);
+    Field threadGroupField = JMeterThread.class.getDeclaredField("threadGroup");
+    threadGroupField.setAccessible(true);
+    threadGroupField.set(jmeterThread, threadGroup);
+    jmeterContext.setThreadGroup(threadGroup);
+
+    TestCompiler compiler = getCompiler(jmeterThread);
+    TestCompiler.initialize();
+    testTree.traverse(compiler);
+
+    lenient().when(client.getMaxBufferSize()).thenReturn(2 * 1024 * 1024);
+    lenient().when(client.getRequestTimeout()).thenReturn(60_000);
+    lenient().when(client.sampleAsync(any(), any(), any())).thenReturn(jettyRequest);
+    lenient().when(jettyRequest.getURI())
+        .thenReturn(new URI("https://demoblaze.com/"));
+    lenient().when(client.sampleFromListener(any(), any(), anyBoolean(), anyInt(), any()))
+        .thenAnswer(invocation -> {
+          HTTPSampleResult result = invocation.getArgument(1);
+          if (result.getStartTime() == 0) {
+            result.sampleStart();
+          }
+          result.setResponseData("<html>About Us</html>", null);
+          result.setResponseCode("200");
+          result.setResponseMessage("OK");
+          result.setSuccessful(true);
+          if (result.getEndTime() == 0) {
+            result.sampleEnd();
+          }
+          return result;
+        });
+
+    asyncController.initialize();
+    Sampler fromController = asyncController.next();
+    assertThat(fromController).isSameAs(sampler);
+    assertThat(sampler.isAsyncParentSampleEnabled()).isTrue();
+    assertThat(sampler.isSyncRequest()).isFalse();
+  }
+
+  @Test
+  public void asyncParentSampleRunsChildAssertionOnCompletionPass() throws Exception {
+    runAsyncParentCompletionScenario(true);
+  }
+
+  /**
+   * Guards {@link HTTP2Sampler#resolveSamplePackageForAsyncCompletion}: when the compiler map no
+   * longer contains the sampler, the pack must still be resolved from {@code PACKAGE_OBJECT}.
+   */
+  @Test
+  public void asyncParentSampleResolvesSamplePackageFromThreadVarsWhenCompilerMapMisses()
+      throws Exception {
+    executeSamplePackage(sampler);
+    assertThat(sampler.getFutureResponseListener()).isNotNull();
+
+    SamplePackage pack = (SamplePackage) threadVars.getObject(JMeterThread.PACKAGE_OBJECT);
+    assertThat(pack).isNotNull();
+    removeSamplerFromCompilerMap(sampler);
+    threadVars.putObject(JMeterThread.PACKAGE_OBJECT, pack);
+
+    assertThat(sampler.sample(null)).isNull();
+
+    SampleResult registeredChild = getRegisteredAsyncParentChild();
+    assertThat(registeredChild.getAssertionResults()).isNotEmpty();
+    assertThat(registeredChild.getFirstAssertionFailureMessage())
+        .isNotEqualTo(AssertionResult.RESPONSE_WAS_NULL);
+    assertThat(registeredChild.isSuccessful()).isTrue();
+  }
+
+  private void runAsyncParentCompletionScenario(boolean suppressPreProcessorsBeforeCompletion)
+      throws Exception {
+    executeSamplePackage(sampler);
+    assertThat(sampler.getFutureResponseListener()).isNotNull();
+
+    if (suppressPreProcessorsBeforeCompletion) {
+      sampler.suppressPreProcessorsOnce();
+    } else {
+      removeSamplerFromCompilerMap(sampler);
+    }
+
+    executeSamplePackage(sampler);
+
+    SampleResult registeredChild = getRegisteredAsyncParentChild();
+    assertThat(registeredChild).isNotNull();
+    assertThat(registeredChild.getAssertionResults()).isNotEmpty();
+    assertThat(registeredChild.getFirstAssertionFailureMessage())
+        .isNotEqualTo(AssertionResult.RESPONSE_WAS_NULL);
+    assertThat(registeredChild.isSuccessful()).isTrue();
+  }
+
+  private void removeSamplerFromCompilerMap(HTTP2Sampler target) throws Exception {
+    TestCompiler compiler = getCompiler(jmeterThread);
+    Field mapField = TestCompiler.class.getDeclaredField("samplerConfigMap");
+    mapField.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    java.util.Map<Object, SamplePackage> map =
+        (java.util.Map<Object, SamplePackage>) mapField.get(compiler);
+    map.remove(target);
+    assertThat(map.get(target)).isNull();
+  }
+
+  @Test
+  public void parentSampleExecutionDoesNotReRunChildAssertionsOnEmptyParentBody() throws Exception {
+    runAsyncParentCompletionScenario(true);
+    threadVars.putObject(JMeterThread.PACKAGE_OBJECT, null);
+
+    Method buildParent = HTTP2Controller.class.getDeclaredMethod("buildParentSamplerIfNeeded");
+    buildParent.setAccessible(true);
+    Sampler parentSampler = (Sampler) buildParent.invoke(asyncController);
+    assertThat(parentSampler).isNotNull();
+    assertThat(parentSampler.getClass().getName())
+        .contains("HTTP2Controller$ParentSample");
+
+    executeSamplePackage(parentSampler);
+
+    SamplePackage parentPack = getCompiler(jmeterThread).configureSampler(parentSampler);
+    assertThat(parentPack.getAssertions()).isEmpty();
+
+    SampleResult parentResult = jmeterContext.getPreviousResult();
+    assertThat(parentResult).isNotNull();
+    assertThat(parentResult.getFirstAssertionFailureMessage()).isNull();
+    assertThat(parentResult.isSuccessful()).isTrue();
+  }
+
+  @Test
+  public void childAssertionsRunAgainstEmptyParentBodyReportResponseWasNull() throws Exception {
+    HTTPSampleResult parentBody = new HTTPSampleResult();
+    parentBody.setSampleLabel("parent");
+    parentBody.sampleStart();
+    parentBody.setResponseData(new byte[0]);
+    parentBody.setSuccessful(true);
+    parentBody.sampleEnd();
+
+    SamplePackage childPack = getCompiler(jmeterThread).configureSampler(sampler);
+    AsyncCompletionSamplePipeline.runAfterAsyncSample(parentBody, childPack, jmeterContext);
+
+    assertThat(parentBody.getFirstAssertionFailureMessage())
+        .isEqualTo(AssertionResult.RESPONSE_WAS_NULL);
+    assertThat(parentBody.isSuccessful()).isFalse();
+  }
+
+  @Test
+  public void withoutSamplePackageAssertionsReportResponseWasNull() throws Exception {
+    HTTPSampleResult bareResult = new HTTPSampleResult();
+    bareResult.setSampleLabel("child");
+    bareResult.setHTTPMethod(HTTPConstants.GET);
+    bareResult.sampleStart();
+    bareResult.setResponseData("<html>About Us</html>", null);
+    bareResult.setSuccessful(true);
+    bareResult.sampleEnd();
+
+    AsyncCompletionSamplePipeline.runAfterAsyncSample(
+        bareResult, new SamplePackage(null, null, null, null, null, null, null),
+        jmeterContext);
+
+    assertThat(bareResult.getAssertionResults()).isEmpty();
+
+    AssertionResult direct = assertion.getResult(bareResult);
+    assertThat(direct.isFailure()).isFalse();
+
+    bareResult.setResponseData(new byte[0]);
+    direct = assertion.getResult(bareResult);
+    assertThat(direct.isFailure()).isTrue();
+    assertThat(direct.getFailureMessage()).isEqualTo(AssertionResult.RESPONSE_WAS_NULL);
+  }
+
+  private void executeSamplePackage(Sampler current) throws Exception {
+    Method executeSamplePackage = JMeterThread.class.getDeclaredMethod(
+        "executeSamplePackage",
+        Sampler.class,
+        TransactionSampler.class,
+        SamplePackage.class,
+        JMeterContext.class);
+    executeSamplePackage.setAccessible(true);
+    executeSamplePackage.invoke(jmeterThread, current, null, null, jmeterContext);
+  }
+
+  @SuppressWarnings("unchecked")
+  private SampleResult getRegisteredAsyncParentChild() throws Exception {
+    Field contextField = HTTP2Controller.class.getDeclaredField("ASYNC_PARENT_CONTEXT");
+    contextField.setAccessible(true);
+    ThreadLocal<Object> contextHolder = (ThreadLocal<Object>) contextField.get(null);
+    Object context = contextHolder.get();
+    assertThat(context).isNotNull();
+
+    Field childrenField = context.getClass().getDeclaredField("children");
+    childrenField.setAccessible(true);
+    List<SampleResult> children = (List<SampleResult>) childrenField.get(context);
+    assertThat(children).hasSize(1);
+    return children.get(0);
+  }
+
+  private static JMeterVariables getThreadVars(JMeterThread thread) throws Exception {
+    Field f = JMeterThread.class.getDeclaredField("threadVars");
+    f.setAccessible(true);
+    return (JMeterVariables) f.get(thread);
+  }
+
+  private static TestCompiler getCompiler(JMeterThread thread) throws Exception {
+    Field compilerField = JMeterThread.class.getDeclaredField("compiler");
+    compilerField.setAccessible(true);
+    return (TestCompiler) compilerField.get(thread);
+  }
+}


### PR DESCRIPTION
This pull request implements robust support for running post-processors and assertions for asynchronous HTTP/2 samples when "Generate parent sample" is enabled, ensuring correct behavior even when the sampler returns `null` to JMeter. The changes introduce a new utility pipeline, adjust how sample packages are resolved for async completions, and fix issues with assertion/post-processor inheritance and ignored sub-samples. Comprehensive tests are also added.

**Async sample completion pipeline and sample package handling:**

* Introduced `AsyncCompletionSamplePipeline`, a new utility class that mirrors JMeter's post-sample processing (thread info, post-processors, assertions) for async HTTP/2 samples, ensuring child assertions and extractors are executed even when the sampler returns `null` to JMeter.
* Updated `HTTP2Sampler` to invoke the async completion pipeline and properly resolve the correct `SamplePackage` for post-processing, including fallback strategies if the package is not directly available. [[1]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R439-R445) [[2]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R461) [[3]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R521-R579)

**Sample package creation and inheritance fixes:**

* Modified `HTTP2Controller` to correctly create a parent `SamplePackage` that does not inherit child assertions or post-processors, preventing them from being run against empty parent results. Improved logic for resolving and registering sample packages, including fallback to internal compiler maps via reflection. [[1]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48L293-R345) [[2]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48L316-R361) [[3]](diffhunk://#diff-701ebc101afe5a508ddcc923f0af56f07a6c5acfe37abc424752edc3aa7bda48R370-R396)

**Sub-sample ignore flag correction:**

* Ensured that sub-samples attached to async parent samples are not marked as ignored, so their results are properly reported. This is done by clearing the ignore flag via reflection in the `deepCopySampleResult` method.

**Testing:**

* Added a comprehensive test (`AsyncCompletionSamplePipelineTest`) to verify that post-processors and assertions are executed as expected for async completions, and that thread variables are set correctly.