### PR TITLE
Configure POM for automated Maven Central release

### DIFF
--- a/.github/maven-central-deploy.sh
+++ b/.github/maven-central-deploy.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Deploys release artifacts to Maven Central via the Sonatype Central Portal.
+#
+# Required environment variables: GPG_SECRET_KEYS, GPG_OWNERTRUST, GPG_EXECUTABLE
+
+set -eo pipefail
+
+echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --batch --import
+echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --batch --import-ownertrust
+mvn --batch-mode deploy -Prelease -DskipTests --settings .github/settings.xml

--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -1,0 +1,27 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <servers>
+    <server>
+      <id>central</id>
+      <username>${env.SONATYPE_USERNAME}</username>
+      <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+  </servers>
+
+  <profiles>
+    <profile>
+      <id>central</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <gpg.executable>${env.GPG_EXECUTABLE}</gpg.executable>
+        <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+      </properties>
+    </profile>
+  </profiles>
+
+</settings>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: release
+run-name: release ${{ inputs.version }}
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. 3.0.0)"
+        required: true
+        type: string
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Create release draft
+        uses: ncipollo/release-action@v1
+        with:
+          tag: v${{ inputs.version }}
+          name: ${{ inputs.version }}
+          draft: true
+
+      - name: Set maven project version
+        run: mvn --batch-mode --no-transfer-progress versions:set -DnewVersion=${{ inputs.version }}
+
+      - name: Commit release version
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "[skip ci] Set release version ${{ inputs.version }}"
+          branch: master
+          file_pattern: "pom.xml"
+
+      - name: Build and test
+        run: xvfb-run -a mvn --batch-mode --no-transfer-progress clean install
+
+      - name: Publish to Maven Central
+        run: .github/maven-central-deploy.sh
+        env:
+          GPG_SECRET_KEYS: ${{ secrets.GPG_SECRET_KEYS }}
+          GPG_OWNERTRUST: ${{ secrets.GPG_OWNERTRUST }}
+          GPG_EXECUTABLE: gpg
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+
+      - name: Publish GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: v${{ inputs.version }}
+          allowUpdates: true
+          omitNameDuringUpdate: true
+          omitBodyDuringUpdate: true
+          updateOnlyUnreleased: true
+          draft: false
+          artifacts: "target/jmeter-bzm-http2-${{ inputs.version }}.jar"
+
+      - name: Compute next SNAPSHOT version
+        run: |
+          IFS='.' read -r major minor patch <<< "${{ inputs.version }}"
+          echo "SNAPSHOT_VERSION=${major}.${minor}.$((patch + 1))-SNAPSHOT" >> $GITHUB_ENV
+
+      - name: Update to next SNAPSHOT version
+        run: mvn --batch-mode --no-transfer-progress versions:set -DnewVersion=${{ env.SNAPSHOT_VERSION }}
+
+      - name: Commit SNAPSHOT version
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "[skip ci] Set SNAPSHOT version ${{ env.SNAPSHOT_VERSION }}"
+          branch: master
+          file_pattern: "pom.xml"

--- a/pom.xml
+++ b/pom.xml
@@ -1,16 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <groupId>com.blazemeter.jmeter</groupId>
   <artifactId>jmeter-bzm-http2</artifactId>
   <packaging>jar</packaging>
   <version>3.0.0</version>
   <name>BlazeMeter HTTP Sampler</name>
   <description>BlazeMeter HTTP protocol sampler</description>
-
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <url>https://github.com/Blazemeter/jmeter-http2-plugin</url>
+  <scm>
+    <connection>scm:git:git://github.com/Blazemeter/jmeter-http2-plugin.git</connection>
+    <developerConnection>scm:git:ssh://github.com:Blazemeter/jmeter-http2-plugin.git</developerConnection>
+    <url>https://github.com/Blazemeter/jmeter-http2-plugin/tree/master</url>
+  </scm>
+  <developers>
+    <developer>
+      <id>team</id>
+      <name>blazelabs</name>
+      <email>blazelabs@perforce.com</email>
+    </developer>
+  </developers>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -18,7 +34,6 @@
     <jetty.version>12.1.6</jetty.version>
     <checkstyle.skip>false</checkstyle.skip>
   </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.jmeter</groupId>
@@ -231,7 +246,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
   <build>
     <resources>
       <resource>
@@ -490,6 +504,67 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.3.0</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.5.0</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <source>17</source>
+              <failOnError>false</failOnError>
+              <doclint>none</doclint>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.9.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>jmeter-bzm-http2</artifactId>
   <packaging>jar</packaging>
   <version>3.0.1</version>
-  <name>BlazeMeter HTTP Sampler</name>
+  <name>BlazeMeter HTTP</name>
   <description>BlazeMeter HTTP Plugin for JMeter (HTTP/1.1, HTTP/2, HTTP/3/QUIC)</description>
   <licenses>
     <license>


### PR DESCRIPTION
This pull request introduces a comprehensive setup for publishing the project to Maven Central, including workflow automation, Maven configuration, and enhancements to the `pom.xml` for compliance and artifact signing. The main changes automate the release process, add required metadata, and ensure artifacts are properly signed and published.

**Release automation and workflow:**

* Added a new GitHub Actions workflow (`.github/workflows/release.yml`) to automate the release process, including version bumping, building, testing, deploying to Maven Central, and publishing GitHub releases. The workflow handles both release and next-SNAPSHOT versioning.
* Introduced a shell script (`.github/maven-central-deploy.sh`) to import GPG keys and deploy artifacts to Maven Central using Maven, integrating with the workflow.

**Maven Central publishing configuration:**

* Added Maven settings file (`.github/settings.xml`) to configure authentication and GPG parameters for publishing to Maven Central, using environment variables for credentials and GPG configuration.
* Enhanced `pom.xml` with required metadata for Maven Central (license, SCM, developers, URL) and added plugins for source/javadoc JARs, GPG signing, and publishing via the Sonatype Central plugin. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L2-L21) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R508-R568)

**Other improvements:**

* Minor formatting and whitespace adjustments in `pom.xml` to improve readability and structure.