### PR TITLE
Bootsrap Menu Creator for Java 8+ support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,29 +346,59 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
-        <configuration>
-          <source>17</source>
-          <target>17</target>
-          <!-- Exclude Installer.java from main compilation - it's compiled separately with Java 8 target -->
-          <excludes>
-            <exclude>**/Installer.java</exclude>
-          </excludes>
-        </configuration>
         <executions>
-          <!-- Compile Installer.java with Java 8 target first so it can run on older Java versions to show the message -->
+          <!-- Java 8 bootstrap (SPI + installer) before main sources -->
           <execution>
-            <id>compile-installer-java8</id>
-            <phase>generate-sources</phase>
+            <id>compile-bootstrap-java8</id>
+            <phase>compile</phase>
             <goals>
               <goal>compile</goal>
             </goals>
             <configuration>
+              <compileSourceRoots>
+                <compileSourceRoot>${project.basedir}/src/main/java8</compileSourceRoot>
+              </compileSourceRoots>
               <source>1.8</source>
               <target>1.8</target>
-              <includes>
-                <include>**/Installer.java</include>
-              </includes>
               <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>default-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <compileSourceRoots>
+                <compileSourceRoot>${project.basedir}/src/main/java</compileSourceRoot>
+              </compileSourceRoots>
+              <source>17</source>
+              <target>17</target>
+            </configuration>
+          </execution>
+        </executions>
+        <configuration>
+          <source>17</source>
+          <target>17</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <!-- Expose bootstrap sources to IDEs and test compilation -->
+          <execution>
+            <id>add-bootstrap-java8-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.basedir}/src/main/java8</source>
+              </sources>
             </configuration>
           </execution>
         </executions>

--- a/src/main/java/com/blazemeter/jmeter/http2/gui/BlazeMeterHttpMenuCommand.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/gui/BlazeMeterHttpMenuCommand.java
@@ -31,11 +31,11 @@ import javax.swing.MenuElement;
 import javax.swing.SwingUtilities;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.gui.GuiPackage;
-import org.apache.jmeter.gui.action.AbstractActionWithNoRunningTest;
 import org.apache.jmeter.gui.action.ActionNames;
 import org.apache.jmeter.gui.action.ActionRouter;
 import org.apache.jmeter.gui.action.Restart;
 import org.apache.jmeter.gui.plugin.MenuCreator;
+import org.apache.jmeter.gui.plugin.MenuCreator.MENU_LOCATION;
 import org.apache.jmeter.gui.tree.JMeterTreeModel;
 import org.apache.jmeter.gui.tree.JMeterTreeNode;
 import org.apache.jmeter.protocol.http.sampler.HTTPSampler;
@@ -49,10 +49,13 @@ import org.slf4j.LoggerFactory;
  * Tools → BlazeMeter HTTP: {@link HTTP2SampleCreator} recording toggle,
  * migrating HTTPSamplerProxy / HTTPSampler HTTP Request samplers to BlazeMeter HTTP.
  * Reads the proxy flag from {@link BzmHttpPluginProperties}.
+ *
+ * <p>Not registered via SPI: JMeter also scans {@code lib/ext} for {@link MenuCreator}
+ * and {@link org.apache.jmeter.gui.action.Command} implementations. Only
+ * {@link BlazeMeterHttpMenuCommandBootstrap} is listed in {@code META-INF/services};
+ * this class is instantiated by the bootstrap on Java 17+.
  */
-public class BlazeMeterHttpMenuCommand
-    extends AbstractActionWithNoRunningTest
-    implements MenuCreator {
+public class BlazeMeterHttpMenuCommand {
 
   private static final Logger LOG = LoggerFactory.getLogger(BlazeMeterHttpMenuCommand.class);
 
@@ -111,13 +114,11 @@ public class BlazeMeterHttpMenuCommand
         ProxyRecorderSamplerTypeUi::installRecorderUiHookOnce);
   }
 
-  @Override
   public Set<String> getActionNames() {
     return ACTION_NAMES;
   }
 
-  @Override
-  protected void doActionAfterCheck(ActionEvent e) {
+  public void doActionAfterCheck(ActionEvent e) {
     String cmd = e.getActionCommand();
     if (ACTION_PROXY_TOGGLE.equals(cmd)) {
       doProxyToggle();
@@ -594,7 +595,6 @@ public class BlazeMeterHttpMenuCommand
     return sb.toString().trim();
   }
 
-  @Override
   public JMenuItem[] getMenuItemsAtLocation(MENU_LOCATION location) {
     if (location != MENU_LOCATION.TOOLS) {
       return new JMenuItem[0];
@@ -629,17 +629,14 @@ public class BlazeMeterHttpMenuCommand
     return new JMenuItem[] {root};
   }
 
-  @Override
   public JMenu[] getTopLevelMenus() {
     return new JMenu[0];
   }
 
-  @Override
   public boolean localeChanged(MenuElement menu) {
     return false;
   }
 
-  @Override
   public void localeChanged() {
     // Labels are fixed English strings; no bundle wiring.
   }

--- a/src/main/java8/com/blazemeter/jmeter/http2/Installer.java
+++ b/src/main/java8/com/blazemeter/jmeter/http2/Installer.java
@@ -14,37 +14,34 @@ public class Installer {
   private static final List<String> OLD_DEPENDENCIES_PREFIXES = Arrays.asList(
       "jetty-client", "jetty-util", "jetty-http", "jetty-io", "jetty-alpn-client",
       "http2-client", "http2-common", "http2-hpack", "jetty-osgi-alpn");
-  private static final int JAVA_VERSION_REQUIRED = 17;
   private static final int NEW_DEPENDENCY_MAJOR_VERSION = 12;
 
   /**
    * Checks if JMeter is running in GUI mode.
    * Uses the standard Java method to detect headless mode.
    * This works even before JMeter is fully initialized.
-   * 
+   *
    * @return true if GUI is available, false if running in headless mode
    */
   private static boolean isGuiMode() {
-    // Check both GraphicsEnvironment and system property for headless mode
-    // This is the standard approach used in Java applications
     try {
       return !GraphicsEnvironment.isHeadless();
     } catch (Exception e) {
-      // Fallback: check system property
       String headless = System.getProperty("java.awt.headless");
       return headless == null || !"true".equalsIgnoreCase(headless);
     }
   }
 
   public static void main(String[] args) {
-    if (getVersion() < JAVA_VERSION_REQUIRED) {
-      // Only show dialog if JMeter is running in GUI mode (not headless)
+    if (!PluginJavaRequirements.isRuntimeSupported()) {
       if (isGuiMode()) {
         JOptionPane.showMessageDialog(null,
-            "The BlazeMeter HTTP Plugin requires Java 17 or higher, "
-                + " please upgrade your Java version and "
+            "The BlazeMeter HTTP Plugin requires Java "
+                + PluginJavaRequirements.JAVA_VERSION_REQUIRED
+                + " or higher, please upgrade your Java version and "
                 + "restart JMeter before using the plugin.",
-            "Java 17 is required", JOptionPane.WARNING_MESSAGE);
+            "Java " + PluginJavaRequirements.JAVA_VERSION_REQUIRED + " is required",
+            JOptionPane.WARNING_MESSAGE);
       }
       return;
     }
@@ -54,7 +51,6 @@ public class Installer {
     File dependencyFolder = pluginsFolder.getParentFile();
     if (!(pluginsFolder.canRead() && pluginsFolder.canWrite())
         || !(dependencyFolder.canWrite() && dependencyFolder.canRead())) {
-      // Only show dialog if JMeter is running in GUI mode (not headless)
       if (isGuiMode()) {
         JOptionPane.showMessageDialog(null, "Read or Write permissions denied",
             "Permission Access", JOptionPane.WARNING_MESSAGE);
@@ -78,12 +74,5 @@ public class Installer {
               return false;
             }))
         .forEach(File::delete);
-  }
-
-  private static int getVersion() {
-    String versionString = System.getProperty("java.version");
-    String[] versionElements = versionString.split("\\.");
-    return versionElements[0].equals("1") ? Integer.parseInt(versionElements[1])
-        : Integer.parseInt(versionElements[0]);
   }
 }

--- a/src/main/java8/com/blazemeter/jmeter/http2/PluginJavaRequirements.java
+++ b/src/main/java8/com/blazemeter/jmeter/http2/PluginJavaRequirements.java
@@ -1,0 +1,38 @@
+package com.blazemeter.jmeter.http2;
+
+/**
+ * Runtime Java version checks for code compiled with an older bytecode level so it can
+ * run before the main plugin classes (Java 17+) are loaded.
+ */
+public final class PluginJavaRequirements {
+
+  public static final int JAVA_VERSION_REQUIRED = 17;
+
+  /** Grep-friendly marker shared with the main plugin classes. */
+  public static final String LOG_PREFIX = "[bzm http2 plugin] ";
+
+  private PluginJavaRequirements() {
+  }
+
+  public static int getRuntimeMajorVersion() {
+    String versionString = System.getProperty("java.version");
+    String[] versionElements = versionString.split("\\.");
+    return versionElements[0].equals("1")
+        ? Integer.parseInt(versionElements[1])
+        : Integer.parseInt(versionElements[0]);
+  }
+
+  public static boolean isRuntimeSupported() {
+    return getRuntimeMajorVersion() >= JAVA_VERSION_REQUIRED;
+  }
+
+  public static String unsupportedRuntimeMessage() {
+    return LOG_PREFIX
+        + "The BlazeMeter HTTP Plugin requires Java "
+        + JAVA_VERSION_REQUIRED
+        + " or higher (current: "
+        + System.getProperty("java.version")
+        + "). BlazeMeter HTTP menus and samplers are disabled until you upgrade Java "
+        + "and restart JMeter.";
+  }
+}

--- a/src/main/java8/com/blazemeter/jmeter/http2/gui/BlazeMeterHttpMenuCommandBootstrap.java
+++ b/src/main/java8/com/blazemeter/jmeter/http2/gui/BlazeMeterHttpMenuCommandBootstrap.java
@@ -1,0 +1,197 @@
+package com.blazemeter.jmeter.http2.gui;
+
+import com.blazemeter.jmeter.http2.PluginJavaRequirements;
+import java.awt.event.ActionEvent;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Set;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.MenuElement;
+import org.apache.jmeter.gui.action.AbstractActionWithNoRunningTest;
+import org.apache.jmeter.gui.plugin.MenuCreator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * SPI entry point compiled for Java 8 so JMeter can load it on older runtimes.
+ * When Java 17+ is available, delegates to {@link BlazeMeterHttpMenuCommand};
+ * otherwise logs once and exposes no Tools menu or actions.
+ */
+public class BlazeMeterHttpMenuCommandBootstrap
+    extends AbstractActionWithNoRunningTest
+    implements MenuCreator {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(BlazeMeterHttpMenuCommandBootstrap.class);
+
+  private static final String DELEGATE_CLASS_NAME =
+      "com.blazemeter.jmeter.http2.gui.BlazeMeterHttpMenuCommand";
+
+  private static volatile Object delegate;
+  private static volatile boolean loadAttempted;
+  private static volatile boolean unsupportedLogged;
+
+  static {
+    if (!PluginJavaRequirements.isRuntimeSupported()) {
+      logUnsupportedRuntimeOnce();
+    }
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Set<String> getActionNames() {
+    Object target = resolveDelegate();
+    if (target == null) {
+      return Collections.emptySet();
+    }
+    return invokeDelegate(target, "getActionNames", Set.class);
+  }
+
+  @Override
+  protected void doActionAfterCheck(ActionEvent event) {
+    Object target = resolveDelegate();
+    if (target == null) {
+      return;
+    }
+    try {
+      Method method = target.getClass().getMethod("doActionAfterCheck", ActionEvent.class);
+      method.invoke(target, event);
+    } catch (ReflectiveOperationException e) {
+      LOG.error("BlazeMeter HTTP menu action failed", e);
+    }
+  }
+
+  @Override
+  public JMenuItem[] getMenuItemsAtLocation(MENU_LOCATION location) {
+    Object target = resolveDelegate();
+    if (target == null) {
+      return new JMenuItem[0];
+    }
+    try {
+      Method method =
+          target.getClass().getMethod("getMenuItemsAtLocation", MENU_LOCATION.class);
+      return (JMenuItem[]) method.invoke(target, location);
+    } catch (ReflectiveOperationException e) {
+      LOG.error("BlazeMeter HTTP menu delegate call failed: getMenuItemsAtLocation", e);
+      return new JMenuItem[0];
+    }
+  }
+
+  @Override
+  public JMenu[] getTopLevelMenus() {
+    Object target = resolveDelegate();
+    if (target == null) {
+      return new JMenu[0];
+    }
+    return invokeDelegate(target, "getTopLevelMenus", JMenu[].class);
+  }
+
+  @Override
+  public boolean localeChanged(MenuElement menu) {
+    Object target = resolveDelegate();
+    if (target == null) {
+      return false;
+    }
+    try {
+      Method method = target.getClass().getMethod("localeChanged", MenuElement.class);
+      return (Boolean) method.invoke(target, menu);
+    } catch (ReflectiveOperationException e) {
+      LOG.error("BlazeMeter HTTP menu delegate call failed: localeChanged", e);
+      return false;
+    }
+  }
+
+  @Override
+  public void localeChanged() {
+    Object target = resolveDelegate();
+    if (target == null) {
+      return;
+    }
+    invokeDelegateVoid(target, "localeChanged");
+  }
+
+  private static Object resolveDelegate() {
+    if (!PluginJavaRequirements.isRuntimeSupported()) {
+      return null;
+    }
+    Object loaded = delegate;
+    if (loaded != null) {
+      return loaded;
+    }
+    synchronized (BlazeMeterHttpMenuCommandBootstrap.class) {
+      loaded = delegate;
+      if (loaded != null) {
+        return loaded;
+      }
+      if (loadAttempted) {
+        return null;
+      }
+      loadAttempted = true;
+      try {
+        Class<?> delegateClass = Class.forName(DELEGATE_CLASS_NAME);
+        loaded = delegateClass.getDeclaredConstructor().newInstance();
+        delegate = loaded;
+      } catch (UnsupportedClassVersionError e) {
+        LOG.warn(PluginJavaRequirements.unsupportedRuntimeMessage(), e);
+      } catch (ReflectiveOperationException | LinkageError e) {
+        LOG.error(
+            PluginJavaRequirements.LOG_PREFIX
+                + "Could not initialize BlazeMeter HTTP menu command",
+            e);
+      }
+      return delegate;
+    }
+  }
+
+  private static void logUnsupportedRuntimeOnce() {
+    if (unsupportedLogged) {
+      return;
+    }
+    unsupportedLogged = true;
+    LOG.warn(PluginJavaRequirements.unsupportedRuntimeMessage());
+  }
+
+  private static void invokeDelegateVoid(Object target, String methodName, Object... args) {
+    try {
+      Class<?>[] paramTypes = parameterTypes(args);
+      Method method = target.getClass().getMethod(methodName, paramTypes);
+      method.invoke(target, args);
+    } catch (ReflectiveOperationException e) {
+      LOG.error("BlazeMeter HTTP menu delegate call failed: {}", methodName, e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T invokeDelegate(
+      Object target, String methodName, Class<T> returnType, Object... args) {
+    try {
+      Class<?>[] paramTypes = parameterTypes(args);
+      Method method = target.getClass().getMethod(methodName, paramTypes);
+      return returnType.cast(method.invoke(target, args));
+    } catch (ReflectiveOperationException e) {
+      LOG.error("BlazeMeter HTTP menu delegate call failed: {}", methodName, e);
+      if (returnType == Boolean.TYPE) {
+        return (T) Boolean.FALSE;
+      }
+      if (returnType.isArray()) {
+        return (T) java.lang.reflect.Array.newInstance(returnType.getComponentType(), 0);
+      }
+      if (Set.class.equals(returnType)) {
+        return (T) Collections.emptySet();
+      }
+      return null;
+    }
+  }
+
+  private static Class<?>[] parameterTypes(Object[] args) {
+    if (args == null || args.length == 0) {
+      return new Class<?>[0];
+    }
+    Class<?>[] types = new Class<?>[args.length];
+    for (int i = 0; i < args.length; i++) {
+      types[i] = args[i].getClass();
+    }
+    return types;
+  }
+}

--- a/src/main/resources/META-INF/services/org.apache.jmeter.gui.action.Command
+++ b/src/main/resources/META-INF/services/org.apache.jmeter.gui.action.Command
@@ -1,1 +1,1 @@
-com.blazemeter.jmeter.http2.gui.BlazeMeterHttpMenuCommand
+com.blazemeter.jmeter.http2.gui.BlazeMeterHttpMenuCommandBootstrap

--- a/src/main/resources/META-INF/services/org.apache.jmeter.gui.plugin.MenuCreator
+++ b/src/main/resources/META-INF/services/org.apache.jmeter.gui.plugin.MenuCreator
@@ -1,1 +1,1 @@
-com.blazemeter.jmeter.http2.gui.BlazeMeterHttpMenuCommand
+com.blazemeter.jmeter.http2.gui.BlazeMeterHttpMenuCommandBootstrap

--- a/src/test/java/com/blazemeter/jmeter/http2/PluginJavaRequirementsTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/PluginJavaRequirementsTest.java
@@ -1,0 +1,67 @@
+package com.blazemeter.jmeter.http2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.blazemeter.jmeter.http2.gui.BlazeMeterHttpMenuCommand;
+import java.io.DataInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.Set;
+import org.apache.jmeter.gui.action.Command;
+import org.apache.jmeter.gui.plugin.MenuCreator;
+import org.junit.Test;
+
+public class PluginJavaRequirementsTest {
+
+  @Test
+  public void currentRuntimeIsAtLeastRequiredVersion() {
+    assertTrue(
+        PluginJavaRequirements.getRuntimeMajorVersion()
+            >= PluginJavaRequirements.JAVA_VERSION_REQUIRED);
+    assertTrue(PluginJavaRequirements.isRuntimeSupported());
+  }
+
+  @Test
+  public void unsupportedMessageMentionsRequiredVersion() {
+    String message = PluginJavaRequirements.unsupportedRuntimeMessage();
+    assertTrue(message.contains("Java 17"));
+    assertTrue(message.contains(PluginJavaRequirements.LOG_PREFIX));
+  }
+
+  @Test
+  public void bootstrapClassIsJava8Bytecode() throws Exception {
+    String resource =
+        "com/blazemeter/jmeter/http2/gui/BlazeMeterHttpMenuCommandBootstrap.class";
+    try (InputStream raw = getClass().getClassLoader().getResourceAsStream(resource)) {
+      assertNotNull(resource, raw);
+      DataInputStream in = new DataInputStream(raw);
+      in.readInt(); // magic
+      in.readUnsignedShort(); // minor
+      int major = in.readUnsignedShort();
+      assertEquals(52, major);
+    }
+  }
+
+  @Test
+  public void menuCommandIsNotJmeterPluginType() {
+    assertFalse(MenuCreator.class.isAssignableFrom(BlazeMeterHttpMenuCommand.class));
+    assertFalse(Command.class.isAssignableFrom(BlazeMeterHttpMenuCommand.class));
+  }
+
+  @Test
+  public void bootstrapExposesMenuActionsOnSupportedRuntime() throws Exception {
+    if (!PluginJavaRequirements.isRuntimeSupported()) {
+      return;
+    }
+    Class<?> bootstrapClass =
+        Class.forName("com.blazemeter.jmeter.http2.gui.BlazeMeterHttpMenuCommandBootstrap");
+    Object bootstrap = bootstrapClass.getDeclaredConstructor().newInstance();
+    Method getActionNames = bootstrapClass.getMethod("getActionNames");
+    @SuppressWarnings("unchecked")
+    Set<String> names = (Set<String>) getActionNames.invoke(bootstrap);
+    assertFalse(names.isEmpty());
+  }
+}


### PR DESCRIPTION
This pull request introduces a robust solution for supporting both Java 8 and Java 17+ runtimes for the BlazeMeter HTTP plugin, ensuring compatibility and graceful degradation on older Java versions. The changes implement a Java 8-compiled bootstrap entry point that checks the runtime version before delegating to Java 17+ classes, and refactor the build system and service registration accordingly.

Key changes include:

**Java Version Compatibility and Bootstrap Mechanism:**

* Introduced a new `PluginJavaRequirements` utility class to centralize Java version checks and related messages, enabling runtime detection of Java support.
* Added `BlazeMeterHttpMenuCommandBootstrap`, a Java 8-compiled SPI entry point that checks the Java version and delegates to `BlazeMeterHttpMenuCommand` only on Java 17+, logging a warning and disabling plugin menus on unsupported runtimes.
* Refactored `Installer.java` to use `PluginJavaRequirements` for version checks and moved it to a separate `src/main/java8` source set to ensure Java 8 bytecode compatibility. [[1]](diffhunk://#diff-5c49b59699299691baff6aa4fa4a87f585aaab703de9af5fd9190425607b94caL17) [[2]](diffhunk://#diff-5c49b59699299691baff6aa4fa4a87f585aaab703de9af5fd9190425607b94caL28-R44) [[3]](diffhunk://#diff-5c49b59699299691baff6aa4fa4a87f585aaab703de9af5fd9190425607b94caL57) [[4]](diffhunk://#diff-5c49b59699299691baff6aa4fa4a87f585aaab703de9af5fd9190425607b94caL82-L88)

**Build and Service Registration Updates:**

* Updated `pom.xml` to compile the bootstrap and installer code with Java 8 and the main plugin code with Java 17, using Maven's multi-execution and the `build-helper-maven-plugin` to expose sources correctly for IDEs and tests.
* Changed SPI service registration to point to the new bootstrap class instead of the main menu command, ensuring correct loading on all Java versions. [[1]](diffhunk://#diff-00c3d6d7c13d86048393c36b171b2e042a9d17b141a24b9d2b0528ca1e35da49L1-R1) [[2]](diffhunk://#diff-00c3d6d7c13d86048393c36b171b2e042a9d17b141a24b9d2b0528ca1e35da49L1-R1)

**Plugin Class Refactoring:**

* Removed `MenuCreator` and `Command` interfaces from `BlazeMeterHttpMenuCommand`, making it a plain class only loaded via the bootstrap on Java 17+, and updated method signatures and usages accordingly. [[1]](diffhunk://#diff-00b60516dbbdc3686c5e307b8aadb36d343c5d01e8f38a94f4c81439b60e8ecbL34-R38) [[2]](diffhunk://#diff-00b60516dbbdc3686c5e307b8aadb36d343c5d01e8f38a94f4c81439b60e8ecbR52-R58) [[3]](diffhunk://#diff-00b60516dbbdc3686c5e307b8aadb36d343c5d01e8f38a94f4c81439b60e8ecbL114-R121) [[4]](diffhunk://#diff-00b60516dbbdc3686c5e307b8aadb36d343c5d01e8f38a94f4c81439b60e8ecbL597) [[5]](diffhunk://#diff-00b60516dbbdc3686c5e307b8aadb36d343c5d01e8f38a94f4c81439b60e8ecbL632-L642)

**Testing:**

* Added `PluginJavaRequirementsTest` to verify runtime version checks, bytecode compatibility of the bootstrap class, and correct delegation behavior.

These changes ensure the plugin fails gracefully on unsupported Java versions and maintains full functionality on Java 17+, improving both user experience and maintainability.

**References:**  
[[1]](diffhunk://#diff-731327c6f0d12079cb0fcd056e29a29c173cf937eb3107feaa1e34b271547cb8R1-R38) [[2]](diffhunk://#diff-c5ce54f563b79bf7e2bb5cf2d0e3b37ad8b895a8d262c96a8b21361caa4cff59R1-R197) [[3]](diffhunk://#diff-5c49b59699299691baff6aa4fa4a87f585aaab703de9af5fd9190425607b94caL17) [[4]](diffhunk://#diff-5c49b59699299691baff6aa4fa4a87f585aaab703de9af5fd9190425607b94caL28-R44) [[5]](diffhunk://#diff-5c49b59699299691baff6aa4fa4a87f585aaab703de9af5fd9190425607b94caL57) [[6]](diffhunk://#diff-5c49b59699299691baff6aa4fa4a87f585aaab703de9af5fd9190425607b94caL82-L88) [[7]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R349-R401) [[8]](diffhunk://#diff-00c3d6d7c13d86048393c36b171b2e042a9d17b141a24b9d2b0528ca1e35da49L1-R1) [[9]](diffhunk://#diff-00b60516dbbdc3686c5e307b8aadb36d343c5d01e8f38a94f4c81439b60e8ecbL34-R38) [[10]](diffhunk://#diff-00b60516dbbdc3686c5e307b8aadb36d343c5d01e8f38a94f4c81439b60e8ecbR52-R58) [[11]](diffhunk://#diff-00b60516dbbdc3686c5e307b8aadb36d343c5d01e8f38a94f4c81439b60e8ecbL114-R121) [[12]](diffhunk://#diff-00b60516dbbdc3686c5e307b8aadb36d343c5d01e8f38a94f4c81439b60e8ecbL597) [[13]](diffhunk://#diff-00b60516dbbdc3686c5e307b8aadb36d343c5d01e8f38a94f4c81439b60e8ecbL632-L642) [[14]](diffhunk://#diff-d23a5a2092d5559b93a51fc0a6c2f85b7f872b6f9dcdc4c4843d04bcb023e6efR1-R67)