### PR TITLE
Fix duplicate Request Body with Parent Sample enabled

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/control/HTTP2Controller.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/control/HTTP2Controller.java
@@ -492,7 +492,10 @@ public class HTTP2Controller extends GenericController implements Serializable {
     }
     copy.setRequestHeaders(original.getRequestHeaders());
     copy.setResponseHeaders(original.getResponseHeaders());
-    copy.setSamplerData(original.getSamplerData());
+    // Do not copy sampler data here: clone() already copies the raw field. For HTTPSampleResult,
+    // getSamplerData() is a computed view (method, URL, queryString, cookies, plus raw field);
+    // setSamplerData(getSamplerData()) would store that view in the raw field and duplicate the
+    // request body on the next getSamplerData() call. BlazeMeter HTTP keeps the raw field empty.
     copy.setResponseData(original.getResponseData());
     if (original.getURL() != null) {
       copy.setURL(original.getURL());

--- a/src/test/java/com/blazemeter/jmeter/http2/control/HTTP2ControllerTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/control/HTTP2ControllerTest.java
@@ -16,8 +16,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.jmeter.control.NextIsNullException;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
 import org.apache.jmeter.protocol.http.sampler.HTTPSampler;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
+import java.lang.reflect.Method;
+import java.net.URL;
 import org.apache.jmeter.util.JMeterUtils;
 import org.eclipse.jetty.client.Request;
 
@@ -246,6 +251,40 @@ public class HTTP2ControllerTest extends HTTP2TestBase {
     assertThat(http2Controller.isDone()).isTrue();
   }
   */
+
+  @Test
+  public void deepCopyHttpSampleResultDoesNotDuplicateRequestBodyInSamplerData() throws Exception {
+    HTTPSampleResult original = new HTTPSampleResult();
+    original.setHTTPMethod(HTTPConstants.POST);
+    original.setURL(new URL("https://example.com/api"));
+    original.setQueryString("field=unique-body-token");
+    original.setSamplerData("");
+
+    Method deepCopy = HTTP2Controller.class.getDeclaredMethod(
+        "deepCopySampleResult", SampleResult.class);
+    deepCopy.setAccessible(true);
+    HTTPSampleResult copy = (HTTPSampleResult) deepCopy.invoke(null, original);
+
+    String bodyToken = "unique-body-token";
+    assertThat(countOccurrences(copy.getSamplerData(), bodyToken)).isEqualTo(1);
+    assertThat(countOccurrences(original.getSamplerData(), bodyToken)).isEqualTo(1);
+  }
+
+  private static int countOccurrences(String source, String token) {
+    if (source == null || token == null || token.isEmpty()) {
+      return 0;
+    }
+    int count = 0;
+    int fromIndex = 0;
+    while (true) {
+      int index = source.indexOf(token, fromIndex);
+      if (index < 0) {
+        return count;
+      }
+      count++;
+      fromIndex = index + token.length();
+    }
+  }
 
   /*
   @Test


### PR DESCRIPTION
This pull request addresses an issue with how HTTP sample results are deep-copied, specifically preventing the duplication of request body data within the computed `samplerData` field. The changes ensure that the raw request body is not redundantly stored, which aligns with how BlazeMeter HTTP expects the field to be handled. Additionally, a new unit test is added to verify this behavior.

Key changes:

**Bug fix to deep copy logic:**

* Updated the `deepCopySampleResult` method in `HTTP2Controller.java` to avoid copying the computed `samplerData` field, preventing duplication of the request body in `HTTPSampleResult` instances.

**Testing improvements:**

* Added a unit test in `HTTP2ControllerTest.java` to verify that deep copying an `HTTPSampleResult` does not duplicate the request body in `samplerData`. The test checks that the unique body token appears exactly once in both the original and the copy.
* Imported additional classes required for the new test, such as `HTTPSampleResult`, `HTTPConstants`, and `SampleResult`.