### PR TITLE
Fix multi-platform distribution for Brotli

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jmeter.version>5.4.1</jmeter.version>
     <jetty.version>12.1.6</jetty.version>
+    <!-- Matches jetty-project ${brotli4j.version} for Jetty 12.1.6 -->
+    <brotli4j.version>1.20.0</brotli4j.version>
     <checkstyle.skip>false</checkstyle.skip>
   </properties>
 
@@ -113,6 +115,37 @@
       <groupId>org.eclipse.jetty.compression</groupId>
       <artifactId>jetty-compression-brotli</artifactId>
       <version>${jetty.version}</version>
+    </dependency>
+    <!-- brotli4j pulls one native-* for the build OS only; add the rest for cross-platform shaded jar -->
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-linux-x86_64</artifactId>
+      <version>${brotli4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-linux-aarch64</artifactId>
+      <version>${brotli4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-windows-x86_64</artifactId>
+      <version>${brotli4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-windows-aarch64</artifactId>
+      <version>${brotli4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-osx-x86_64</artifactId>
+      <version>${brotli4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-osx-aarch64</artifactId>
+      <version>${brotli4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.compression</groupId>

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2DependenciesIntegrationTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2DependenciesIntegrationTest.java
@@ -82,6 +82,19 @@ public class HTTP2DependenciesIntegrationTest extends HTTP2TestBase {
   private static final String SHADED_QUIC_CLIENT_RESOURCE =
       "com/blazemeter/jmeter/http2/shaded/org/eclipse/jetty/quic/client/QuicClientConnector.class";
 
+  /**
+   * Brotli4j native libraries under {@code lib/<os>-<arch>/}; must be present for every
+   * platform we ship, independent of the OS used to run {@code mvn package}.
+   */
+  private static final List<String> SHADED_BROTLI_NATIVE_RESOURCES = Arrays.asList(
+      "lib/linux-x86_64/libbrotli.so",
+      "lib/linux-aarch64/libbrotli.so",
+      "lib/windows-x86_64/brotli.dll",
+      "lib/windows-aarch64/brotli.dll",
+      "lib/osx-x86_64/libbrotli.dylib",
+      "lib/osx-aarch64/libbrotli.dylib"
+  );
+
   @BeforeClass
   public static void once() {
     HTTP2TestBase.once();
@@ -213,6 +226,16 @@ public class HTTP2DependenciesIntegrationTest extends HTTP2TestBase {
     assertJarContainsClass(pluginJar,
       "com/aayushatharva/brotli4j/decoder/BrotliInputStream.class",
       "Shaded jar should include Brotli4j decoder class");
+  }
+
+  @Test
+  public void shouldBundleBrotliNativesForAllSupportedPlatforms() {
+    Path pluginJar = requireShadedJar();
+
+    for (String resource : SHADED_BROTLI_NATIVE_RESOURCES) {
+      assertJarContainsClass(pluginJar, resource,
+          "Shaded jar must include Brotli4j native for all shipped platforms: " + resource);
+    }
   }
 
   @Test


### PR DESCRIPTION
This pull request updates the Brotli compression dependencies to ensure that native Brotli libraries for all major platforms are included in the shaded JAR, improving cross-platform compatibility. It also adds a test to verify that these native libraries are bundled for each supported platform.

**Dependency updates:**

* Added the `brotli4j.version` property to `pom.xml` to manage Brotli native library versions consistently.
* Added explicit dependencies for all Brotli4j native libraries (`native-linux-x86_64`, `native-linux-aarch64`, `native-windows-x86_64`, `native-windows-aarch64`, `native-osx-x86_64`, `native-osx-aarch64`) to the `pom.xml` to ensure the shaded JAR contains native libraries for all major platforms.

**Testing improvements:**

* Defined a list of expected Brotli4j native resources in `SHADED_BROTLI_NATIVE_RESOURCES` in `HTTP2DependenciesIntegrationTest.java` for use in validation tests.
* Added a new test, `shouldBundleBrotliNativesForAllSupportedPlatforms`, to check that the shaded JAR contains Brotli native libraries for all supported platforms.