### PR TITLE
Improvements and alignment to JMeter for SSL KeyStore and TrustStore support.

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListener.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListener.java
@@ -498,6 +498,7 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
       if (request.getBody() != null) {
         http11Request.body(request.getBody());
       }
+      SslClientCertAliasSupport.copyFromRequest(request, http11Request);
       lowLevelDebug("Retrying request with HTTP/1.1 in listener fallback: {}", request.getURI());
       return http11Request.send();
     } catch (Exception e) {

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -2541,7 +2541,9 @@ public class HTTP2JettyClient {
       client.setDestinationIdleTimeout(idleTimeout);
     }
     client.setIdleTimeout(idleTimeout);
-    addConnectionLogging(client);
+    if (LowLevelDebugLog.isEnabled()) {
+      addConnectionLogging(client);
+    }
   }
 
   private static void addConnectionLogging(HttpClient client) {
@@ -2589,6 +2591,9 @@ public class HTTP2JettyClient {
   }
 
   private static void logAlpnLine(String message) {
+    if (!LowLevelDebugLog.isEnabled()) {
+      return;
+    }
     try {
       Path parent = ALPN_DEBUG_LOG_PATH.getParent();
       if (parent != null) {

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -1206,6 +1206,7 @@ public class HTTP2JettyClient {
       if (originalRequest.getBody() != null) {
         http11Request.body(originalRequest.getBody());
       }
+      SslClientCertAliasSupport.copyFromRequest(originalRequest, http11Request);
 
       // Send request and wait for response
       lowLevelDebug("Sending HTTP/1.1 fallback request");
@@ -2511,6 +2512,7 @@ public class HTTP2JettyClient {
     if (originalRequest.getBody() != null) {
       request.body(originalRequest.getBody());
     }
+    SslClientCertAliasSupport.copyFromRequest(originalRequest, request);
     configureContentDecoders(client, request);
     return request;
   }
@@ -2893,6 +2895,10 @@ public class HTTP2JettyClient {
     boolean http3Attempted = enableHttp3 && client == httpClient && shouldAttemptHttp3(uri);
     request.attribute(ATTR_HTTP3_ATTEMPTED, http3Attempted);
     request.attribute(ATTR_ORIGIN_KEY, originKey(uri));
+    if ("https".equalsIgnoreCase(uri.getScheme())) {
+      String clientCertAlias = JMeterSslAliasResolver.resolveForRequest();
+      SslClientCertAliasSupport.bindToRequest(request, clientCertAlias);
+    }
     request.onRequestBegin(r -> result.connectEnd());
     request.onRequestContent(
         (r, c) -> result.setSentBytes(result.getSentBytes() + c.limit()));

--- a/src/main/java/com/blazemeter/jmeter/http2/core/JMeterJettySslContextFactory.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/JMeterJettySslContextFactory.java
@@ -24,7 +24,9 @@ public class JMeterJettySslContextFactory extends SslContextFactory.Client {
     setTrustAll(true);
     String keyStorePath = System.getProperty("javax.net.ssl.keyStore");
     if (keyStorePath != null && !keyStorePath.isEmpty()) {
-      setKeyStorePath("file://" + keyStorePath);
+      if (SslStorePathResolver.isFileBasedStoreLocation(keyStorePath)) {
+        setKeyStorePath(SslStorePathResolver.toJettyFileUri(keyStorePath));
+      }
       keys = getKeyStore((JsseSSLManager) SSLManager.getInstance());
       /*
        we need to set password after getting keystore since getKeystore may ask the user for the
@@ -37,7 +39,9 @@ public class JMeterJettySslContextFactory extends SslContextFactory.Client {
 
     String truststore = System.getProperty("javax.net.ssl.trustStore");
     if (truststore != null && !truststore.isEmpty()) {
-      setTrustStorePath("file://" + truststore);
+      if (SslStorePathResolver.isFileBasedStoreLocation(truststore)) {
+        setTrustStorePath(SslStorePathResolver.toJettyFileUri(truststore));
+      }
       getTrustStore((JsseSSLManager) SSLManager.getInstance());
       /*
        we need to set password after getting truststore since getTrustStore may ask the user for the

--- a/src/main/java/com/blazemeter/jmeter/http2/core/JMeterJettySslContextFactory.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/JMeterJettySslContextFactory.java
@@ -20,8 +20,12 @@ import org.apache.jmeter.util.JsseSSLManager;
 import org.apache.jmeter.util.SSLManager;
 import org.apache.jmeter.util.keystore.JmeterKeyStore;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JMeterJettySslContextFactory extends SslContextFactory.Client {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JMeterJettySslContextFactory.class);
 
   private final JmeterKeyStore keys;
 
@@ -39,8 +43,7 @@ public class JMeterJettySslContextFactory extends SslContextFactory.Client {
         lowLevelDebug(
             "SSL keyStore type resolved: javax.net.ssl.keyStoreType='{}' -> jettyType='{}'",
             System.getProperty("javax.net.ssl.keyStoreType"), keyStoreType);
-        setKeyStorePath(jettyKeyStoreUri);
-        setKeyStoreType(keyStoreType);
+        configureKeyStorePathForJetty(keyStorePath, jettyKeyStoreUri, keyStoreType);
       }
       keys = getKeyStore((JsseSSLManager) SSLManager.getInstance());
       /*
@@ -63,8 +66,7 @@ public class JMeterJettySslContextFactory extends SslContextFactory.Client {
         lowLevelDebug(
             "SSL trustStore type resolved: javax.net.ssl.trustStoreType='{}' -> jettyType='{}'",
             System.getProperty("javax.net.ssl.trustStoreType"), trustStoreType);
-        setTrustStorePath(jettyTrustStoreUri);
-        setTrustStoreType(trustStoreType);
+        configureTrustStorePathForJetty(truststore, jettyTrustStoreUri, trustStoreType);
       }
       getTrustStore((JsseSSLManager) SSLManager.getInstance());
       /*
@@ -72,6 +74,30 @@ public class JMeterJettySslContextFactory extends SslContextFactory.Client {
        password.
       */
       setTrustStorePassword(System.getProperty("javax.net.ssl.trustStorePassword"));
+    }
+  }
+
+  void configureKeyStorePathForJetty(String originalPath, String jettyUri, String storeType) {
+    try {
+      setKeyStorePath(jettyUri);
+      setKeyStoreType(storeType);
+    } catch (RuntimeException e) {
+      LOG.warn("Could not set Jetty keyStore path for '{}': {}. "
+              + "Client certificate authentication may not work.",
+          originalPath, e.getMessage());
+      lowLevelDebug("Could not set Jetty keyStore path for '{}'", originalPath, e);
+    }
+  }
+
+  void configureTrustStorePathForJetty(String originalPath, String jettyUri, String storeType) {
+    try {
+      setTrustStorePath(jettyUri);
+      setTrustStoreType(storeType);
+    } catch (RuntimeException e) {
+      LOG.warn("Could not set Jetty trustStore path for '{}': {}. "
+              + "Trust-all SSL configuration will still be used.",
+          originalPath, e.getMessage());
+      lowLevelDebug("Could not set Jetty trustStore path for '{}'", originalPath, e);
     }
   }
 

--- a/src/main/java/com/blazemeter/jmeter/http2/core/JMeterJettySslContextFactory.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/JMeterJettySslContextFactory.java
@@ -1,14 +1,19 @@
 package com.blazemeter.jmeter.http2.core;
 
+import static com.blazemeter.jmeter.http2.core.LowLevelDebugLog.lowLevelDebug;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.Socket;
 import java.security.KeyStore;
 import java.security.Principal;
 import java.security.PrivateKey;
+import java.security.cert.CRL;
 import java.security.cert.X509Certificate;
+import java.util.Collection;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509KeyManager;
 import org.apache.jmeter.util.JsseSSLManager;
@@ -22,10 +27,20 @@ public class JMeterJettySslContextFactory extends SslContextFactory.Client {
 
   public JMeterJettySslContextFactory() {
     setTrustAll(true);
+    setValidatePeerCerts(false);
     String keyStorePath = System.getProperty("javax.net.ssl.keyStore");
     if (keyStorePath != null && !keyStorePath.isEmpty()) {
       if (SslStorePathResolver.isFileBasedStoreLocation(keyStorePath)) {
-        setKeyStorePath(SslStorePathResolver.toJettyFileUri(keyStorePath));
+        String jettyKeyStoreUri = SslStorePathResolver.toJettyFileUri(keyStorePath);
+        String keyStoreType = SslStorePathResolver.resolveKeyStoreType(keyStorePath);
+        lowLevelDebug(
+            "SSL keyStore path resolved: javax.net.ssl.keyStore='{}' -> jettyUri='{}'",
+            keyStorePath, jettyKeyStoreUri);
+        lowLevelDebug(
+            "SSL keyStore type resolved: javax.net.ssl.keyStoreType='{}' -> jettyType='{}'",
+            System.getProperty("javax.net.ssl.keyStoreType"), keyStoreType);
+        setKeyStorePath(jettyKeyStoreUri);
+        setKeyStoreType(keyStoreType);
       }
       keys = getKeyStore((JsseSSLManager) SSLManager.getInstance());
       /*
@@ -40,7 +55,16 @@ public class JMeterJettySslContextFactory extends SslContextFactory.Client {
     String truststore = System.getProperty("javax.net.ssl.trustStore");
     if (truststore != null && !truststore.isEmpty()) {
       if (SslStorePathResolver.isFileBasedStoreLocation(truststore)) {
-        setTrustStorePath(SslStorePathResolver.toJettyFileUri(truststore));
+        String jettyTrustStoreUri = SslStorePathResolver.toJettyFileUri(truststore);
+        String trustStoreType = SslStorePathResolver.resolveTrustStoreType(truststore);
+        lowLevelDebug(
+            "SSL trustStore path resolved: javax.net.ssl.trustStore='{}' -> jettyUri='{}'",
+            truststore, jettyTrustStoreUri);
+        lowLevelDebug(
+            "SSL trustStore type resolved: javax.net.ssl.trustStoreType='{}' -> jettyType='{}'",
+            System.getProperty("javax.net.ssl.trustStoreType"), trustStoreType);
+        setTrustStorePath(jettyTrustStoreUri);
+        setTrustStoreType(trustStoreType);
       }
       getTrustStore((JsseSSLManager) SSLManager.getInstance());
       /*
@@ -79,6 +103,18 @@ public class JMeterJettySslContextFactory extends SslContextFactory.Client {
   // Overwritten to avoid warning logging
   @Override
   protected void checkEndPointIdentificationAlgorithm() {
+  }
+
+  // JMeter HTTP uses CustomX509TrustManager which does not validate server certificates.
+  // Jetty still runs PKIX when a keyStore is configured unless trust managers are overridden.
+  @Override
+  protected TrustManager[] getTrustManagers(KeyStore trustStore,
+      Collection<? extends CRL> crls) throws Exception {
+    if (isTrustAll()) {
+      lowLevelDebug("SSL trust managers: using TRUST_ALL_CERTS (JMeter HTTP parity)");
+      return TRUST_ALL_CERTS;
+    }
+    return super.getTrustManagers(trustStore, crls);
   }
 
   // Overwritten to provide jmeter SSLManager configured keyManagers

--- a/src/main/java/com/blazemeter/jmeter/http2/core/JMeterJettySslContextFactory.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/JMeterJettySslContextFactory.java
@@ -11,19 +11,24 @@ import java.security.PrivateKey;
 import java.security.cert.CRL;
 import java.security.cert.X509Certificate;
 import java.util.Collection;
+import java.util.Map;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509KeyManager;
+import org.apache.jmeter.threads.JMeterContextService;
+import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JsseSSLManager;
 import org.apache.jmeter.util.SSLManager;
 import org.apache.jmeter.util.keystore.JmeterKeyStore;
+import org.eclipse.jetty.io.ssl.SslClientConnectionFactory;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class JMeterJettySslContextFactory extends SslContextFactory.Client {
+public class JMeterJettySslContextFactory extends SslContextFactory.Client
+    implements SslClientConnectionFactory.SslEngineFactory {
 
   private static final Logger LOG = LoggerFactory.getLogger(JMeterJettySslContextFactory.class);
 
@@ -143,6 +148,20 @@ public class JMeterJettySslContextFactory extends SslContextFactory.Client {
     return super.getTrustManagers(trustStore, crls);
   }
 
+  @Override
+  public SSLEngine newSslEngine(String host, int port, Map<String, Object> context) {
+    SSLEngine engine = super.newSSLEngine(host, port);
+    bindAliasFromContext(engine, context);
+    return engine;
+  }
+
+  private static void bindAliasFromContext(SSLEngine engine, Map<String, Object> context) {
+    String alias = SslClientCertAliasContext.readAlias(context);
+    if (alias != null) {
+      SslClientCertAliasContext.bindEngine(engine, alias);
+    }
+  }
+
   // Overwritten to provide jmeter SSLManager configured keyManagers
   @Override
   protected KeyManager[] getKeyManagers(KeyStore keyStore) throws Exception {
@@ -192,12 +211,33 @@ public class JMeterJettySslContextFactory extends SslContextFactory.Client {
 
     @Override
     public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
-      return store.getAlias();
+      return resolveClientAlias(null);
     }
 
+    @Override
     public String chooseEngineClientAlias(String[] keyType, Principal[] issuers,
                                           SSLEngine engine) {
-      return store.getAlias();
+      return resolveClientAlias(engine);
+    }
+
+    private String resolveClientAlias(SSLEngine engine) {
+      String boundAlias = SslClientCertAliasContext.resolveFromEngine(engine);
+      if (boundAlias != null) {
+        return boundAlias;
+      }
+      JMeterVariables variables = JMeterContextService.getContext().getVariables();
+      if (variables != null) {
+        return store.getAlias();
+      }
+      return firstConfiguredAlias();
+    }
+
+    private String firstConfiguredAlias() {
+      String[] aliases = store.getClientAliases("RSA", null);
+      if (aliases == null || aliases.length == 0) {
+        aliases = store.getClientAliases("EC", null);
+      }
+      return aliases != null && aliases.length > 0 ? aliases[0] : null;
     }
 
     @Override

--- a/src/main/java/com/blazemeter/jmeter/http2/core/JMeterSslAliasResolver.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/JMeterSslAliasResolver.java
@@ -1,0 +1,39 @@
+package com.blazemeter.jmeter.http2.core;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import org.apache.jmeter.util.SSLManager;
+import org.apache.jmeter.util.keystore.JmeterKeyStore;
+
+/**
+ * Resolves the client certificate alias on the current JMeter thread, where
+ * {@link JMeterContextService} variables are available.
+ */
+public final class JMeterSslAliasResolver {
+
+  private JMeterSslAliasResolver() {
+  }
+
+  /**
+   * Returns the alias to use for the next HTTPS client authentication, or {@code null} when no
+   * client keystore is configured.
+   */
+  public static String resolveForRequest() {
+    String keyStorePath = System.getProperty(SSLManager.JAVAX_NET_SSL_KEY_STORE);
+    if (keyStorePath == null || keyStorePath.isEmpty()) {
+      return null;
+    }
+    return getKeyStore().getAlias();
+  }
+
+  private static JmeterKeyStore getKeyStore() {
+    try {
+      Method keystoreMethod = SSLManager.class.getDeclaredMethod("getKeyStore");
+      keystoreMethod.setAccessible(true);
+      return (JmeterKeyStore) keystoreMethod.invoke(SSLManager.getInstance());
+    } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+      throw new IllegalStateException("Could not access JMeter keystore", e);
+    }
+  }
+
+}

--- a/src/main/java/com/blazemeter/jmeter/http2/core/SslClientCertAliasContext.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/SslClientCertAliasContext.java
@@ -1,0 +1,48 @@
+package com.blazemeter.jmeter.http2.core;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.net.ssl.SSLEngine;
+
+/**
+ * Holds the client certificate alias resolved on the JMeter thread and bound to the
+ * {@link SSLEngine} used during the async Jetty TLS handshake.
+ */
+final class SslClientCertAliasContext {
+
+  static final String CONNECTION_CONTEXT_KEY = "bzm.jmeter.ssl.clientCertAlias";
+  static final String REQUEST_ATTRIBUTE = CONNECTION_CONTEXT_KEY;
+
+  private static final Map<SSLEngine, String> ENGINE_ALIASES = new ConcurrentHashMap<>();
+
+  private SslClientCertAliasContext() {
+  }
+
+  static void bindEngine(SSLEngine engine, String alias) {
+    if (engine != null && alias != null && !alias.isEmpty()) {
+      ENGINE_ALIASES.put(engine, alias);
+    }
+  }
+
+  static String resolveFromEngine(SSLEngine engine) {
+    if (engine == null) {
+      return null;
+    }
+    return ENGINE_ALIASES.get(engine);
+  }
+
+  static void clearEngine(SSLEngine engine) {
+    if (engine != null) {
+      ENGINE_ALIASES.remove(engine);
+    }
+  }
+
+  static String readAlias(Map<String, Object> context) {
+    if (context == null) {
+      return null;
+    }
+    Object alias = context.get(CONNECTION_CONTEXT_KEY);
+    return alias instanceof String ? (String) alias : null;
+  }
+
+}

--- a/src/main/java/com/blazemeter/jmeter/http2/core/SslClientCertAliasSupport.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/SslClientCertAliasSupport.java
@@ -1,0 +1,35 @@
+package com.blazemeter.jmeter.http2.core;
+
+import org.eclipse.jetty.client.Request;
+
+/**
+ * Binds a client certificate alias resolved on the JMeter thread to a Jetty {@link Request}.
+ */
+public final class SslClientCertAliasSupport {
+
+  private SslClientCertAliasSupport() {
+  }
+
+  public static void bindToRequest(Request request, String alias) {
+    if (request == null || alias == null || alias.isEmpty()) {
+      return;
+    }
+    request.attribute(SslClientCertAliasContext.REQUEST_ATTRIBUTE, alias);
+    request.tag(new SslClientCertAliasTag(alias));
+  }
+
+  public static void copyFromRequest(Request source, Request target) {
+    if (source == null || target == null) {
+      return;
+    }
+    Object tag = source.getTag();
+    if (tag != null) {
+      target.tag(tag);
+    }
+    Object alias = source.getAttributes().get(SslClientCertAliasContext.REQUEST_ATTRIBUTE);
+    if (alias != null) {
+      target.attribute(SslClientCertAliasContext.REQUEST_ATTRIBUTE, alias);
+    }
+  }
+
+}

--- a/src/main/java/com/blazemeter/jmeter/http2/core/SslClientCertAliasTag.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/SslClientCertAliasTag.java
@@ -1,0 +1,58 @@
+package com.blazemeter.jmeter.http2.core;
+
+import java.io.IOException;
+import java.util.Objects;
+import org.eclipse.jetty.io.ClientConnectionFactory;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.EndPoint;
+
+/**
+ * Request tag that routes HTTPS connections through a per-alias destination and injects the
+ * resolved client certificate alias into the Jetty connection context for TLS handshakes.
+ */
+final class SslClientCertAliasTag implements ClientConnectionFactory.Decorator {
+
+  private final String alias;
+
+  SslClientCertAliasTag(String alias) {
+    this.alias = Objects.requireNonNull(alias, "alias");
+  }
+
+  String getAlias() {
+    return alias;
+  }
+
+  @Override
+  public ClientConnectionFactory apply(ClientConnectionFactory factory) {
+    return new ClientConnectionFactory() {
+      @Override
+      public Connection newConnection(EndPoint endPoint, java.util.Map<String, Object> context)
+          throws IOException {
+        context.put(SslClientCertAliasContext.CONNECTION_CONTEXT_KEY, alias);
+        return factory.newConnection(endPoint, context);
+      }
+    };
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof SslClientCertAliasTag)) {
+      return false;
+    }
+    return alias.equals(((SslClientCertAliasTag) other).alias);
+  }
+
+  @Override
+  public int hashCode() {
+    return alias.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "SslClientCertAliasTag[" + alias + "]";
+  }
+
+}

--- a/src/main/java/com/blazemeter/jmeter/http2/core/SslStorePathResolver.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/SslStorePathResolver.java
@@ -1,0 +1,36 @@
+package com.blazemeter.jmeter.http2.core;
+
+import java.io.File;
+
+/**
+ * Converts {@code javax.net.ssl.*} store paths to Jetty {@code file:} URIs.
+ */
+public final class SslStorePathResolver {
+
+  /** JSSE / JMeter sentinel for non-file keystores (e.g. PKCS#11). */
+  public static final String NON_FILE_KEYSTORE_LOCATION = "NONE";
+
+  private SslStorePathResolver() {
+    // Utility class.
+  }
+
+  /**
+   * Whether the property points at a filesystem keystore (not PKCS#11 {@code NONE}).
+   */
+  public static boolean isFileBasedStoreLocation(final String storePath) {
+    return storePath != null
+        && !storePath.isEmpty()
+        && !NON_FILE_KEYSTORE_LOCATION.equalsIgnoreCase(storePath);
+  }
+
+  /**
+   * Same as JMeter ({@code new File(path)}), then {@link File#toURI()} for Jetty.
+   *
+   * @param storePath filesystem path from {@code javax.net.ssl.keyStore} or trustStore
+   * @return Jetty-compatible {@code file:} URI
+   */
+  public static String toJettyFileUri(final String storePath) {
+    return new File(storePath).getAbsoluteFile().toURI().toString();
+  }
+
+}

--- a/src/main/java/com/blazemeter/jmeter/http2/core/SslStorePathResolver.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/SslStorePathResolver.java
@@ -1,6 +1,7 @@
 package com.blazemeter.jmeter.http2.core;
 
 import java.io.File;
+import java.util.Locale;
 
 /**
  * Converts {@code javax.net.ssl.*} store paths to Jetty {@code file:} URIs.
@@ -9,6 +10,11 @@ public final class SslStorePathResolver {
 
   /** JSSE / JMeter sentinel for non-file keystores (e.g. PKCS#11). */
   public static final String NON_FILE_KEYSTORE_LOCATION = "NONE";
+
+  private static final String KEY_STORE_TYPE_PROPERTY = "javax.net.ssl.keyStoreType";
+  private static final String TRUST_STORE_TYPE_PROPERTY = "javax.net.ssl.trustStoreType";
+  private static final String PKCS12 = "pkcs12";
+  private static final String JKS = "JKS";
 
   private SslStorePathResolver() {
     // Utility class.
@@ -31,6 +37,41 @@ public final class SslStorePathResolver {
    */
   public static String toJettyFileUri(final String storePath) {
     return new File(storePath).getAbsoluteFile().toURI().toString();
+  }
+
+  /**
+   * Resolves the Jetty key store type from {@link #KEY_STORE_TYPE_PROPERTY}, matching
+   * {@link org.apache.jmeter.util.SSLManager} when unset (.p12 → PKCS12, else JKS).
+   *
+   * @param keyStorePath filesystem path from {@code javax.net.ssl.keyStore}
+   * @return type string for {@link org.eclipse.jetty.util.ssl.SslContextFactory#setKeyStoreType}
+   */
+  public static String resolveKeyStoreType(final String keyStorePath) {
+    return resolveStoreType(KEY_STORE_TYPE_PROPERTY, keyStorePath, false);
+  }
+
+  /**
+   * Resolves the Jetty trust store type from {@link #TRUST_STORE_TYPE_PROPERTY}, or by file
+   * extension when unset (.p12 / .pfx → PKCS12, else JKS).
+   *
+   * @param trustStorePath filesystem path from {@code javax.net.ssl.trustStore}
+   * @return type string for {@link org.eclipse.jetty.util.ssl.SslContextFactory#setTrustStoreType}
+   */
+  public static String resolveTrustStoreType(final String trustStorePath) {
+    return resolveStoreType(TRUST_STORE_TYPE_PROPERTY, trustStorePath, true);
+  }
+
+  private static String resolveStoreType(final String typeProperty, final String storePath,
+                                         final boolean inferPfxAsPkcs12) {
+    String explicit = System.getProperty(typeProperty);
+    if (explicit != null && !explicit.isEmpty()) {
+      return explicit;
+    }
+    String lower = storePath.toLowerCase(Locale.ENGLISH);
+    if (lower.endsWith(".p12") || (inferPfxAsPkcs12 && lower.endsWith(".pfx"))) {
+      return PKCS12;
+    }
+    return JKS;
   }
 
 }

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
@@ -73,6 +73,7 @@ import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.protocol.http.util.HTTPFileArg;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jmeter.util.SSLManager;
 import org.assertj.core.api.JUnitSoftAssertions;
 import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.client.ContentResponse;
@@ -1391,6 +1392,7 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
     } finally {
       System.setProperty(keyStorePropertyName, "");
       System.setProperty(keyStorePasswordPropertyName, "");
+      SSLManager.reset();
     }
   }
 

--- a/src/test/java/com/blazemeter/jmeter/http2/core/JMeterJettySslContextFactoryTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/JMeterJettySslContextFactoryTest.java
@@ -1,0 +1,71 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.jmeter.util.SSLManager;
+import org.junit.After;
+import org.junit.Test;
+
+public class JMeterJettySslContextFactoryTest extends HTTP2TestBase {
+
+  private String previousKeyStore;
+  private String previousKeyStorePassword;
+  private Path tempKeystore;
+
+  @After
+  public void restoreSystemProperties() throws IOException {
+    restoreProperty("javax.net.ssl.keyStore", previousKeyStore);
+    restoreProperty("javax.net.ssl.keyStorePassword", previousKeyStorePassword);
+    SSLManager.reset();
+    if (tempKeystore != null) {
+      Files.deleteIfExists(tempKeystore);
+      tempKeystore = null;
+    }
+  }
+
+  @Test
+  public void shouldConstructWithFileBasedKeyStorePath() throws IOException {
+    tempKeystore = Files.createTempFile("jmeter-jetty-ssl", ".p12");
+    try (InputStream in = getClass().getResourceAsStream("keystore.p12")) {
+      if (in == null) {
+        throw new IllegalStateException("classpath resource keystore.p12 not found");
+      }
+      in.transferTo(Files.newOutputStream(tempKeystore));
+    }
+
+    previousKeyStore = System.getProperty("javax.net.ssl.keyStore");
+    previousKeyStorePassword = System.getProperty("javax.net.ssl.keyStorePassword");
+
+    SSLManager.reset();
+    System.setProperty("javax.net.ssl.keyStore", tempKeystore.toString());
+    System.setProperty("javax.net.ssl.keyStorePassword", ServerBuilder.KEYSTORE_PASSWORD);
+
+    assertThatCode(JMeterJettySslContextFactory::new).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void shouldConstructWhenKeyStoreIsPkcs11None() {
+    previousKeyStore = System.getProperty("javax.net.ssl.keyStore");
+    previousKeyStorePassword = System.getProperty("javax.net.ssl.keyStorePassword");
+
+    SSLManager.reset();
+    System.setProperty("javax.net.ssl.keyStore",
+        SslStorePathResolver.NON_FILE_KEYSTORE_LOCATION);
+
+    assertThatCode(JMeterJettySslContextFactory::new).doesNotThrowAnyException();
+  }
+
+  private static void restoreProperty(String key, String value) {
+    if (value == null) {
+      System.clearProperty(key);
+    } else {
+      System.setProperty(key, value);
+    }
+  }
+
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/JMeterJettySslContextFactoryTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/JMeterJettySslContextFactoryTest.java
@@ -1,5 +1,6 @@
 package com.blazemeter.jmeter.http2.core;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.blazemeter.jmeter.http2.HTTP2TestBase;
@@ -7,7 +8,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.cert.CRL;
+import java.util.Collection;
+import javax.net.ssl.TrustManager;
 import org.apache.jmeter.util.SSLManager;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.After;
 import org.junit.Test;
 
@@ -49,6 +54,29 @@ public class JMeterJettySslContextFactoryTest extends HTTP2TestBase {
   }
 
   @Test
+  public void shouldUseTrustAllManagersWhenKeyStoreIsConfigured() throws Exception {
+    tempKeystore = Files.createTempFile("jmeter-jetty-ssl-trust", ".p12");
+    try (InputStream in = getClass().getResourceAsStream("keystore.p12")) {
+      if (in == null) {
+        throw new IllegalStateException("classpath resource keystore.p12 not found");
+      }
+      in.transferTo(Files.newOutputStream(tempKeystore));
+    }
+
+    previousKeyStore = System.getProperty("javax.net.ssl.keyStore");
+    previousKeyStorePassword = System.getProperty("javax.net.ssl.keyStorePassword");
+
+    SSLManager.reset();
+    System.setProperty("javax.net.ssl.keyStore", tempKeystore.toString());
+    System.setProperty("javax.net.ssl.keyStorePassword", ServerBuilder.KEYSTORE_PASSWORD);
+
+    TestableJMeterJettySslContextFactory factory = new TestableJMeterJettySslContextFactory();
+    TrustManager[] trustManagers = factory.getTrustManagersForTest(null, null);
+
+    assertThat(trustManagers).isSameAs(SslContextFactory.TRUST_ALL_CERTS);
+  }
+
+  @Test
   public void shouldConstructWhenKeyStoreIsPkcs11None() {
     previousKeyStore = System.getProperty("javax.net.ssl.keyStore");
     previousKeyStorePassword = System.getProperty("javax.net.ssl.keyStorePassword");
@@ -58,6 +86,15 @@ public class JMeterJettySslContextFactoryTest extends HTTP2TestBase {
         SslStorePathResolver.NON_FILE_KEYSTORE_LOCATION);
 
     assertThatCode(JMeterJettySslContextFactory::new).doesNotThrowAnyException();
+  }
+
+  private static final class TestableJMeterJettySslContextFactory
+      extends JMeterJettySslContextFactory {
+
+    TrustManager[] getTrustManagersForTest(java.security.KeyStore trustStore,
+        Collection<? extends CRL> crls) throws Exception {
+      return getTrustManagers(trustStore, crls);
+    }
   }
 
   private static void restoreProperty(String key, String value) {

--- a/src/test/java/com/blazemeter/jmeter/http2/core/JMeterJettySslContextFactoryTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/JMeterJettySslContextFactoryTest.java
@@ -20,12 +20,16 @@ public class JMeterJettySslContextFactoryTest extends HTTP2TestBase {
 
   private String previousKeyStore;
   private String previousKeyStorePassword;
+  private String previousTrustStore;
+  private String previousTrustStorePassword;
   private Path tempKeystore;
 
   @After
   public void restoreSystemProperties() throws IOException {
     restoreProperty("javax.net.ssl.keyStore", previousKeyStore);
     restoreProperty("javax.net.ssl.keyStorePassword", previousKeyStorePassword);
+    restoreProperty("javax.net.ssl.trustStore", previousTrustStore);
+    restoreProperty("javax.net.ssl.trustStorePassword", previousTrustStorePassword);
     SSLManager.reset();
     if (tempKeystore != null) {
       Files.deleteIfExists(tempKeystore);
@@ -88,12 +92,70 @@ public class JMeterJettySslContextFactoryTest extends HTTP2TestBase {
     assertThatCode(JMeterJettySslContextFactory::new).doesNotThrowAnyException();
   }
 
+  @Test
+  public void shouldNotThrowWhenJettyKeyStorePathDoesNotExist() {
+    String missingPath = "certs/nonexistent-jmeter-jetty-keystore.p12";
+    TestableJMeterJettySslContextFactory factory = new TestableJMeterJettySslContextFactory();
+
+    assertThatCode(() -> factory.configureKeyStorePathForJetty(
+        missingPath,
+        SslStorePathResolver.toJettyFileUri(missingPath),
+        "pkcs12"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void shouldNotThrowWhenJettyTrustStorePathDoesNotExist() {
+    String missingPath = "certs/nonexistent-jmeter-jetty-truststore.jks";
+    TestableJMeterJettySslContextFactory factory = new TestableJMeterJettySslContextFactory();
+
+    assertThatCode(() -> factory.configureTrustStorePathForJetty(
+        missingPath,
+        SslStorePathResolver.toJettyFileUri(missingPath),
+        "JKS"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void shouldNotThrowWhenSetKeyStorePathFails() {
+    FailingKeyStorePathFactory factory = new FailingKeyStorePathFactory();
+
+    assertThatCode(() -> factory.configureKeyStorePathForJetty(
+        "certs/keystore.p12", "file:///certs/keystore.p12", "pkcs12"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void shouldNotThrowWhenSetTrustStorePathFails() {
+    FailingTrustStorePathFactory factory = new FailingTrustStorePathFactory();
+
+    assertThatCode(() -> factory.configureTrustStorePathForJetty(
+        "certs/truststore.jks", "file:///certs/truststore.jks", "JKS"))
+        .doesNotThrowAnyException();
+  }
+
   private static final class TestableJMeterJettySslContextFactory
       extends JMeterJettySslContextFactory {
 
     TrustManager[] getTrustManagersForTest(java.security.KeyStore trustStore,
         Collection<? extends CRL> crls) throws Exception {
       return getTrustManagers(trustStore, crls);
+    }
+  }
+
+  private static final class FailingKeyStorePathFactory extends JMeterJettySslContextFactory {
+
+    @Override
+    public void setKeyStorePath(String path) {
+      throw new IllegalArgumentException("Could not find keyStore at " + path);
+    }
+  }
+
+  private static final class FailingTrustStorePathFactory extends JMeterJettySslContextFactory {
+
+    @Override
+    public void setTrustStorePath(String path) {
+      throw new IllegalArgumentException("Could not find trustStore at " + path);
     }
   }
 

--- a/src/test/java/com/blazemeter/jmeter/http2/core/ServerBuilder.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/ServerBuilder.java
@@ -106,6 +106,8 @@ public class ServerBuilder {
   private final TeardownableServer server = new TeardownableServer();
   private final HttpConfiguration httpsConfig = new HttpConfiguration();
   private boolean withSSL;
+  private String serverKeyStorePathOverride;
+  private String serverKeyStoreTypeOverride;
   private HTTP2ServerConnectionFactory http2ConnectionFactory;
   private HttpConnectionFactory http1ConnectionFactory;
   private HTTP2CServerConnectionFactory http2cConnectionFactory;
@@ -136,6 +138,15 @@ public class ServerBuilder {
 
   public ServerBuilder withSSL() {
     this.withSSL = true;
+    return this;
+  }
+
+  /**
+   * Uses a filesystem keystore for the server TLS certificate (e.g. an untrusted JKS in tests).
+   */
+  public ServerBuilder withServerKeyStorePath(String keyStorePath, String keyStoreType) {
+    this.serverKeyStorePathOverride = keyStorePath;
+    this.serverKeyStoreTypeOverride = keyStoreType;
     return this;
   }
 
@@ -244,7 +255,13 @@ public class ServerBuilder {
 
   private SslContextFactory.Server buildServerSslContextFactory() {
     SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
-    sslContextFactory.setKeyStorePath(getKeyStorePathAsUriPathInSSLContextFactoryFormat());
+    if (serverKeyStorePathOverride != null) {
+      sslContextFactory.setKeyStorePath(
+          SslStorePathResolver.toJettyFileUri(serverKeyStorePathOverride));
+      sslContextFactory.setKeyStoreType(serverKeyStoreTypeOverride);
+    } else {
+      sslContextFactory.setKeyStorePath(getKeyStorePathAsUriPathInSSLContextFactoryFormat());
+    }
     sslContextFactory.setKeyStorePassword(KEYSTORE_PASSWORD);
     return sslContextFactory;
   }

--- a/src/test/java/com/blazemeter/jmeter/http2/core/SslClientCertAliasSupportTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/SslClientCertAliasSupportTest.java
@@ -1,0 +1,149 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.X509ExtendedKeyManager;
+import org.apache.jmeter.threads.JMeterContextService;
+import org.apache.jmeter.threads.JMeterVariables;
+import org.apache.jmeter.util.SSLManager;
+import org.eclipse.jetty.io.ClientConnectionFactory;
+import org.eclipse.jetty.io.ssl.SslClientConnectionFactory;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SslClientCertAliasSupportTest extends HTTP2TestBase {
+
+  private static final String CERT_ALIAS_VAR = "certAlias";
+  private static final String KEY_ALIAS = "client";
+
+  private String previousKeyStore;
+  private String previousKeyStorePassword;
+  private String previousKeyStoreType;
+  private Path clientKeystore;
+
+  @Before
+  public void setUpKeystore() throws Exception {
+    clientKeystore = TestSslKeyStores.createJks(KEY_ALIAS, "CN=client, O=SslAliasTest, C=US");
+
+    previousKeyStore = System.getProperty("javax.net.ssl.keyStore");
+    previousKeyStorePassword = System.getProperty("javax.net.ssl.keyStorePassword");
+    previousKeyStoreType = System.getProperty("javax.net.ssl.keyStoreType");
+
+    SSLManager.reset();
+    System.setProperty("javax.net.ssl.keyStore", clientKeystore.toString());
+    System.setProperty("javax.net.ssl.keyStorePassword", TestSslKeyStores.PASSWORD);
+    System.setProperty("javax.net.ssl.keyStoreType", "JKS");
+    SSLManager.getInstance().configureKeystore(true, 0, -1, CERT_ALIAS_VAR);
+
+    JMeterVariables variables = new JMeterVariables();
+    variables.put(CERT_ALIAS_VAR, KEY_ALIAS);
+    JMeterContextService.getContext().setVariables(variables);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    restoreProperty("javax.net.ssl.keyStore", previousKeyStore);
+    restoreProperty("javax.net.ssl.keyStorePassword", previousKeyStorePassword);
+    restoreProperty("javax.net.ssl.keyStoreType", previousKeyStoreType);
+    JMeterContextService.getContext().setVariables(null);
+    SSLManager.reset();
+    if (clientKeystore != null) {
+      Files.deleteIfExists(clientKeystore);
+      Path parent = clientKeystore.getParent();
+      if (parent != null) {
+        Files.deleteIfExists(parent);
+      }
+      clientKeystore = null;
+    }
+  }
+
+  @Test
+  public void shouldResolveAliasOnJMeterThreadWhenVariableIsConfigured() {
+    assertThat(JMeterSslAliasResolver.resolveForRequest()).isEqualTo(KEY_ALIAS);
+  }
+
+  @Test
+  public void shouldInjectAliasIntoConnectionContextFromRequestTag() throws Exception {
+    SslClientCertAliasTag tag = new SslClientCertAliasTag(KEY_ALIAS);
+    ClientConnectionFactory decorated = tag.apply((endPoint, context) -> null);
+    Map<String, Object> context = new HashMap<>();
+
+    decorated.newConnection(null, context);
+
+    assertThat(SslClientCertAliasContext.readAlias(context)).isEqualTo(KEY_ALIAS);
+  }
+
+  @Test
+  public void shouldChooseBoundAliasOnJettyThreadWithoutJMeterVariables() throws Exception {
+    String alias = JMeterSslAliasResolver.resolveForRequest();
+    JMeterContextService.getContext().setVariables(null);
+
+    JMeterJettySslContextFactory factory = new JMeterJettySslContextFactory();
+    factory.start();
+    try {
+      Method getKeyManagers = SslContextFactory.class
+          .getDeclaredMethod("getKeyManagers", KeyStore.class);
+      getKeyManagers.setAccessible(true);
+      KeyStore keyStore = KeyStore.getInstance("JKS");
+      try (InputStream in = Files.newInputStream(clientKeystore)) {
+        keyStore.load(in, TestSslKeyStores.PASSWORD.toCharArray());
+      }
+      KeyManager keyManager = ((KeyManager[]) getKeyManagers.invoke(factory, keyStore))[0];
+      assertThat(keyManager).isInstanceOf(X509ExtendedKeyManager.class);
+
+      SSLEngine engine = factory.getSslContext().createSSLEngine();
+      SslClientCertAliasContext.bindEngine(engine, alias);
+
+      assertThatCode(() -> ((X509ExtendedKeyManager) keyManager)
+          .chooseEngineClientAlias(new String[] {"RSA"}, new Principal[0], engine))
+          .doesNotThrowAnyException();
+      assertThat(((X509ExtendedKeyManager) keyManager)
+          .chooseEngineClientAlias(new String[] {"RSA"}, new Principal[0], engine))
+          .isEqualTo(KEY_ALIAS);
+    } finally {
+      factory.stop();
+    }
+  }
+
+  @Test
+  public void shouldBindAliasFromSslEngineFactoryContext() throws Exception {
+    JMeterJettySslContextFactory factory = new JMeterJettySslContextFactory();
+    factory.start();
+    try {
+      Map<String, Object> context = new HashMap<>();
+      context.put(SslClientCertAliasContext.CONNECTION_CONTEXT_KEY, KEY_ALIAS);
+
+      Method method = SslClientConnectionFactory.SslEngineFactory.class
+          .getMethod("newSslEngine", String.class, int.class, Map.class);
+      SSLEngine engine = (SSLEngine) method.invoke(factory, "localhost", 443, context);
+
+      assertThat(SslClientCertAliasContext.resolveFromEngine(engine)).isEqualTo(KEY_ALIAS);
+    } finally {
+      factory.stop();
+    }
+  }
+
+  private static void restoreProperty(String key, String value) {
+    if (value == null) {
+      System.clearProperty(key);
+    } else {
+      System.setProperty(key, value);
+    }
+  }
+
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/SslPkixSimulationTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/SslPkixSimulationTest.java
@@ -1,0 +1,216 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import com.blazemeter.jmeter.http2.sampler.JMeterTestUtils;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLSocket;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jmeter.util.SSLManager;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Reproduces BlazeMeter-like PKIX failures: client {@code javax.net.ssl.keyStore} configured
+ * (JKS) while the server presents a certificate that is not in the JVM trust store.
+ */
+public class SslPkixSimulationTest extends HTTP2TestBase {
+
+  private static final String KEY_STORE_PROPERTY = "javax.net.ssl.keyStore";
+  private static final String KEY_STORE_PASSWORD_PROPERTY = "javax.net.ssl.keyStorePassword";
+  private static final String KEY_STORE_TYPE_PROPERTY = "javax.net.ssl.keyStoreType";
+
+  private String previousKeyStore;
+  private String previousKeyStorePassword;
+  private String previousKeyStoreType;
+  private String previousSharedThreadPoolProperty;
+
+  private Path serverKeystore;
+  private Path clientKeystore;
+  private TeardownableServer server;
+  private int serverPort = -1;
+  private HTTP2JettyClient client;
+  private HTTP2Sampler sampler;
+
+  @Before
+  public void setUp() throws Exception {
+    JMeterTestUtils.setupJmeterEnv();
+    previousKeyStore = System.getProperty(KEY_STORE_PROPERTY);
+    previousKeyStorePassword = System.getProperty(KEY_STORE_PASSWORD_PROPERTY);
+    previousKeyStoreType = System.getProperty(KEY_STORE_TYPE_PROPERTY);
+    previousSharedThreadPoolProperty = JMeterUtils.getProperty("httpJettyClient.sharedThreadPool");
+    JMeterUtils.setProperty("httpJettyClient.sharedThreadPool", "false");
+
+    serverKeystore = TestSslKeyStores.createJks("server", "CN=localhost, O=SslSim, C=US");
+    clientKeystore = TestSslKeyStores.createJks("client", "CN=client, O=SslSim, C=US");
+
+    configureClientKeyStoreLikeBlazeMeter(clientKeystore);
+    startUntrustedHttpsServer();
+
+    sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.GET);
+    sampler.setDomain(ServerBuilder.HOST_NAME);
+    sampler.setProtocol(HTTPConstants.PROTOCOL_HTTPS);
+    sampler.setPort(serverPort);
+    sampler.setPath("");
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (client != null) {
+      client.stop();
+      client = null;
+    }
+    if (sampler != null) {
+      sampler.threadFinished();
+      sampler = null;
+    }
+    if (server != null) {
+      server.stop();
+      server = null;
+    }
+    restoreProperty(KEY_STORE_PROPERTY, previousKeyStore);
+    restoreProperty(KEY_STORE_PASSWORD_PROPERTY, previousKeyStorePassword);
+    restoreProperty(KEY_STORE_TYPE_PROPERTY, previousKeyStoreType);
+    SSLManager.reset();
+    if (previousSharedThreadPoolProperty == null) {
+      JMeterUtils.getJMeterProperties().remove("httpJettyClient.sharedThreadPool");
+    } else {
+      JMeterUtils.setProperty("httpJettyClient.sharedThreadPool", previousSharedThreadPoolProperty);
+    }
+    deleteIfExists(serverKeystore);
+    deleteIfExists(clientKeystore);
+  }
+
+  @Test
+  public void shouldReproducePkixWhenTrustAllIsSetButTrustManagersAreNotOverridden() {
+    TrustAllWithoutTrustManagerOverride factory = new TrustAllWithoutTrustManagerOverride();
+
+    assertThatThrownBy(() -> performTlsHandshake(factory))
+        .isInstanceOf(SSLHandshakeException.class)
+        .hasMessageContaining("PKIX path building failed");
+  }
+
+  @Test
+  public void shouldHandshakeWhenJMeterJettySslContextFactoryIsUsed() {
+    assertThatCode(() -> performTlsHandshake(new JMeterJettySslContextFactory()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void shouldCompleteHttp2RequestWhenClientKeyStoreConfiguredAgainstUntrustedServer()
+      throws Exception {
+    client = new HTTP2JettyClient();
+    client.start();
+
+    HTTPSampleResult result = client.sample(
+        sampler,
+        buildBaseResult(createUrl(ServerBuilder.SERVER_PATH_200), HTTPConstants.GET),
+        false,
+        0);
+
+    assertThat(result.isSuccessful()).isTrue();
+    assertThat(result.getResponseDataAsString()).isEqualTo(ServerBuilder.SERVER_RESPONSE);
+  }
+
+  private void startUntrustedHttpsServer() throws Exception {
+    server = new ServerBuilder()
+        .withHTTP1()
+        .withHTTP2()
+        .withALPN()
+        .withHTTP2C()
+        .withSSL()
+        .withServerKeyStorePath(serverKeystore.toString(), "JKS")
+        .buildServer();
+    server.start();
+  }
+
+  private void configureClientKeyStoreLikeBlazeMeter(Path keyStorePath) {
+    SSLManager.reset();
+    System.setProperty(KEY_STORE_PROPERTY, keyStorePath.toString());
+    System.setProperty(KEY_STORE_PASSWORD_PROPERTY, TestSslKeyStores.PASSWORD);
+    System.setProperty(KEY_STORE_TYPE_PROPERTY, "JKS");
+  }
+
+  private void performTlsHandshake(SslContextFactory.Client factory) throws Exception {
+    if (serverPort < 0) {
+      ServerConnector connector = (ServerConnector) server.getConnectors()[0];
+      serverPort = connector.getLocalPort();
+    }
+    factory.start();
+    try {
+      try (SSLSocket socket = (SSLSocket) factory.getSslContext().getSocketFactory()
+          .createSocket(ServerBuilder.HOST_NAME, serverPort)) {
+        socket.setSoTimeout(10_000);
+        socket.startHandshake();
+      }
+    } finally {
+      factory.stop();
+    }
+  }
+
+  private URL createUrl(String path) throws Exception {
+    if (serverPort < 0) {
+      ServerConnector connector = (ServerConnector) server.getConnectors()[0];
+      serverPort = connector.getLocalPort();
+    }
+    sampler.setPort(serverPort);
+    return new URI(HTTPConstants.PROTOCOL_HTTPS, null, ServerBuilder.HOST_NAME, serverPort, path,
+        null, null).toURL();
+  }
+
+  private static HTTPSampleResult buildBaseResult(URL url, String method) {
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setURL(url);
+    result.setHTTPMethod(method);
+    return result;
+  }
+
+  private static void restoreProperty(String key, String value) {
+    if (value == null) {
+      System.clearProperty(key);
+    } else {
+      System.setProperty(key, value);
+    }
+  }
+
+  private static void deleteIfExists(Path path) throws IOException {
+    if (path != null) {
+      Files.deleteIfExists(path);
+    }
+  }
+
+  /**
+   * Mirrors {@code setTrustAll(true)} plus client keyStore configuration, but without the
+   * {@link JMeterJettySslContextFactory#getTrustManagers} override (pre-fix Jetty behaviour).
+   */
+  private static final class TrustAllWithoutTrustManagerOverride extends SslContextFactory.Client {
+
+    private TrustAllWithoutTrustManagerOverride() {
+      setTrustAll(true);
+      String keyStorePath = System.getProperty(KEY_STORE_PROPERTY);
+      if (keyStorePath != null && !keyStorePath.isEmpty()
+          && SslStorePathResolver.isFileBasedStoreLocation(keyStorePath)) {
+        setKeyStorePath(SslStorePathResolver.toJettyFileUri(keyStorePath));
+        setKeyStoreType(SslStorePathResolver.resolveKeyStoreType(keyStorePath));
+        setKeyStorePassword(System.getProperty(KEY_STORE_PASSWORD_PROPERTY));
+      }
+    }
+  }
+
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/SslStorePathResolverTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/SslStorePathResolverTest.java
@@ -1,0 +1,64 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assume.assumeTrue;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Paths;
+import org.junit.Test;
+
+public class SslStorePathResolverTest {
+
+  private static final String RELATIVE_STORE = "certs/keystore.p12";
+
+  @Test
+  public void naiveFilePrefixOnRelativePathTreatsFirstSegmentAsUriAuthority() {
+    URI malformed = URI.create("file://" + RELATIVE_STORE);
+    assertThat(malformed.getAuthority()).isEqualTo("certs");
+    assertThat(malformed.getPath()).isEqualTo("/keystore.p12");
+  }
+
+  @Test
+  public void naiveFilePrefixOnRelativePathRejectsAuthorityOnUnix() {
+    assumeTrue(!isWindows());
+    assertThatThrownBy(() -> Paths.get(URI.create("file://" + RELATIVE_STORE)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("authority");
+  }
+
+  @Test
+  public void toJettyFileUriMatchesFileToUriForRelativePath() {
+    assertThat(SslStorePathResolver.toJettyFileUri(RELATIVE_STORE))
+        .isEqualTo(new File(RELATIVE_STORE).getAbsoluteFile().toURI().toString());
+  }
+
+  @Test
+  public void toJettyFileUriMatchesFileToUriForAbsolutePath() {
+    String absolute = new File(System.getProperty("user.dir"), RELATIVE_STORE)
+        .getAbsolutePath();
+    assertThat(SslStorePathResolver.toJettyFileUri(absolute))
+        .isEqualTo(new File(absolute).getAbsoluteFile().toURI().toString());
+  }
+
+  @Test
+  public void toJettyFileUriHasNoUriAuthorityForRelativePath() {
+    URI jettyUri = URI.create(SslStorePathResolver.toJettyFileUri(RELATIVE_STORE));
+    assertThat(jettyUri.getAuthority()).isNull();
+    assertThat(Paths.get(jettyUri))
+        .isEqualTo(new File(RELATIVE_STORE).getAbsoluteFile().toPath());
+  }
+
+  @Test
+  public void noneIsNotAFileBasedStoreLocation() {
+    assertThat(SslStorePathResolver.isFileBasedStoreLocation("NONE")).isFalse();
+    assertThat(SslStorePathResolver.isFileBasedStoreLocation("none")).isFalse();
+    assertThat(SslStorePathResolver.isFileBasedStoreLocation(RELATIVE_STORE)).isTrue();
+  }
+
+  private static boolean isWindows() {
+    return File.separatorChar == '\\';
+  }
+
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/SslStorePathResolverTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/SslStorePathResolverTest.java
@@ -57,6 +57,66 @@ public class SslStorePathResolverTest {
     assertThat(SslStorePathResolver.isFileBasedStoreLocation(RELATIVE_STORE)).isTrue();
   }
 
+  @Test
+  public void resolveKeyStoreTypeUsesPropertyWhenSet() {
+    String previous = System.getProperty("javax.net.ssl.keyStoreType");
+    try {
+      System.setProperty("javax.net.ssl.keyStoreType", "PKCS12");
+      assertThat(SslStorePathResolver.resolveKeyStoreType("certs/keystore.jks"))
+          .isEqualTo("PKCS12");
+    } finally {
+      restoreProperty("javax.net.ssl.keyStoreType", previous);
+    }
+  }
+
+  @Test
+  public void resolveKeyStoreTypeInfersPkcs12FromP12ExtensionLikeJMeter() {
+    String previous = System.getProperty("javax.net.ssl.keyStoreType");
+    try {
+      System.clearProperty("javax.net.ssl.keyStoreType");
+      assertThat(SslStorePathResolver.resolveKeyStoreType(RELATIVE_STORE)).isEqualTo("pkcs12");
+      assertThat(SslStorePathResolver.resolveKeyStoreType("certs/keystore.jks")).isEqualTo("JKS");
+      assertThat(SslStorePathResolver.resolveKeyStoreType("certs/keystore.pfx")).isEqualTo("JKS");
+    } finally {
+      restoreProperty("javax.net.ssl.keyStoreType", previous);
+    }
+  }
+
+  @Test
+  public void resolveTrustStoreTypeUsesPropertyWhenSet() {
+    String previous = System.getProperty("javax.net.ssl.trustStoreType");
+    try {
+      System.setProperty("javax.net.ssl.trustStoreType", "JKS");
+      assertThat(SslStorePathResolver.resolveTrustStoreType("certs/trust.p12"))
+          .isEqualTo("JKS");
+    } finally {
+      restoreProperty("javax.net.ssl.trustStoreType", previous);
+    }
+  }
+
+  @Test
+  public void resolveTrustStoreTypeInfersPkcs12FromP12OrPfxWhenUnset() {
+    String previous = System.getProperty("javax.net.ssl.trustStoreType");
+    try {
+      System.clearProperty("javax.net.ssl.trustStoreType");
+      assertThat(SslStorePathResolver.resolveTrustStoreType("certs/trust.p12"))
+          .isEqualTo("pkcs12");
+      assertThat(SslStorePathResolver.resolveTrustStoreType("certs/trust.pfx"))
+          .isEqualTo("pkcs12");
+      assertThat(SslStorePathResolver.resolveTrustStoreType("certs/trust.jks")).isEqualTo("JKS");
+    } finally {
+      restoreProperty("javax.net.ssl.trustStoreType", previous);
+    }
+  }
+
+  private static void restoreProperty(String key, String value) {
+    if (value == null) {
+      System.clearProperty(key);
+    } else {
+      System.setProperty(key, value);
+    }
+  }
+
   private static boolean isWindows() {
     return File.separatorChar == '\\';
   }

--- a/src/test/java/com/blazemeter/jmeter/http2/core/TestSslKeyStores.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/TestSslKeyStores.java
@@ -1,0 +1,61 @@
+package com.blazemeter.jmeter.http2.core;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Generates ephemeral JKS keystores for SSL handshake simulations.
+ */
+final class TestSslKeyStores {
+
+  static final String PASSWORD = ServerBuilder.KEYSTORE_PASSWORD;
+  private static final String KEYTOOL = resolveKeytoolExecutable();
+
+  private TestSslKeyStores() {
+  }
+
+  static Path createJks(String alias, String distinguishedName) throws IOException, InterruptedException {
+    Path keystore = Files.createTempDirectory("ssl-sim-").resolve(alias + ".jks");
+    runKeytool(List.of(
+        KEYTOOL,
+        "-genkeypair",
+        "-alias", alias,
+        "-keyalg", "RSA",
+        "-keysize", "2048",
+        "-validity", "365",
+        "-keystore", keystore.toAbsolutePath().toString(),
+        "-storetype", "JKS",
+        "-storepass", PASSWORD,
+        "-keypass", PASSWORD,
+        "-dname", distinguishedName
+    ));
+    return keystore;
+  }
+
+  private static void runKeytool(List<String> command) throws IOException, InterruptedException {
+    Process process = new ProcessBuilder(command)
+        .redirectErrorStream(true)
+        .start();
+    String output = new String(process.getInputStream().readAllBytes());
+    int exitCode = process.waitFor();
+    if (exitCode != 0) {
+      throw new IOException("keytool failed (exit " + exitCode + "): " + output);
+    }
+  }
+
+  private static String resolveKeytoolExecutable() {
+    String javaHome = System.getProperty("java.home");
+    Path candidate = Path.of(javaHome, "bin", isWindows() ? "keytool.exe" : "keytool");
+    if (Files.isRegularFile(candidate)) {
+      return candidate.toString();
+    }
+    return isWindows() ? "keytool.exe" : "keytool";
+  }
+
+  private static boolean isWindows() {
+    return System.getProperty("os.name", "").toLowerCase().contains("win");
+  }
+
+}


### PR DESCRIPTION
This pull request enhances SSL/TLS handling in the HTTP Jetty client for JMeter, focusing on robust and accurate support for filesystem keystore/truststore configuration, improved parity with JMeter’s SSLManager, and better test coverage for PKIX and trust-all scenarios. The main changes include introducing a utility for keystore path/type resolution, updating the SSL context factory to use this utility and override trust manager behavior, and adding comprehensive tests to verify these behaviors.

**Keystore and Truststore Path/Type Resolution:**
- Introduced the `SslStorePathResolver` utility to convert `javax.net.ssl.*` store paths to Jetty-compatible `file:` URIs and to resolve keystore/truststore types based on file extension or system properties, matching JMeter’s logic.
- Updated `JMeterJettySslContextFactory` to use `SslStorePathResolver` for setting keystore/truststore paths and types, including logging for debugging and handling of PKCS#11/NONE sentinel values. [[1]](diffhunk://#diff-fe7c1e1bc27e7334acc004814a33cf8fae829cda240f247de4d20d6019e67c63R30-R44) [[2]](diffhunk://#diff-fe7c1e1bc27e7334acc004814a33cf8fae829cda240f247de4d20d6019e67c63L40-R68)

**Trust Manager Handling and JMeter Parity:**
- Overrode `getTrustManagers` in `JMeterJettySslContextFactory` to ensure that when "trust all" is enabled, Jetty uses `TRUST_ALL_CERTS`, preventing unwanted PKIX validation even when a keystore is configured, thus matching JMeter’s behavior.

**Logging and Debugging Improvements:**
- Added conditional logging for connection and ALPN lines based on the debug log setting, reducing unnecessary log output. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR2544-R2547) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR2594-R2596)

**Test Coverage and Infrastructure:**
- Added new tests for `JMeterJettySslContextFactory` to verify correct construction with file-based and PKCS#11 keystores, and to check trust manager behavior.
- Added a simulation test (`SslPkixSimulationTest`) to reproduce PKIX failures and verify that the new trust manager override logic prevents them, ensuring successful handshakes and HTTP/2 requests when expected.
- Updated test server builder to allow explicit filesystem keystore configuration for more flexible test scenarios. [[1]](diffhunk://#diff-0750017c903d358c844cb5f71203bcdf1bac07bc5fe9b86cb4ef798c56d7fe5dR109-R110) [[2]](diffhunk://#diff-0750017c903d358c844cb5f71203bcdf1bac07bc5fe9b86cb4ef798c56d7fe5dR144-R152) [[3]](diffhunk://#diff-0750017c903d358c844cb5f71203bcdf1bac07bc5fe9b86cb4ef798c56d7fe5dR258-R264)
- Ensured SSLManager is reset after relevant tests to avoid cross-test contamination. [[1]](diffhunk://#diff-ecc5436f1e468983f5a6e6c8ccc9d551ff7052cd40f589248596fbde0406a407R76) [[2]](diffhunk://#diff-ecc5436f1e468983f5a6e6c8ccc9d551ff7052cd40f589248596fbde0406a407R1395)

These changes significantly improve the reliability and correctness of SSL/TLS configuration and validation in the HTTP/2 Jetty client for JMeter, particularly in complex or edge-case environments.

**References:**  
[[1]](diffhunk://#diff-165fc53b3a8803c335f6c305661be62a6173e88377ef8f27a12c15379f73a119R1-R77) [[2]](diffhunk://#diff-fe7c1e1bc27e7334acc004814a33cf8fae829cda240f247de4d20d6019e67c63R30-R44) [[3]](diffhunk://#diff-fe7c1e1bc27e7334acc004814a33cf8fae829cda240f247de4d20d6019e67c63L40-R68) [[4]](diffhunk://#diff-fe7c1e1bc27e7334acc004814a33cf8fae829cda240f247de4d20d6019e67c63R108-R119) [[5]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR2544-R2547) [[6]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR2594-R2596) [[7]](diffhunk://#diff-43df01cf3b5b88e0665876baf9f41d2d1eec40e0ff2afd803037e7120a060715R1-R108) [[8]](diffhunk://#diff-2c740c704cde22e7aab679bd22cd0c214511b7a09966d3abe801b652472167eaR1-R216) [[9]](diffhunk://#diff-0750017c903d358c844cb5f71203bcdf1bac07bc5fe9b86cb4ef798c56d7fe5dR109-R110) [[10]](diffhunk://#diff-0750017c903d358c844cb5f71203bcdf1bac07bc5fe9b86cb4ef798c56d7fe5dR144-R152) [[11]](diffhunk://#diff-0750017c903d358c844cb5f71203bcdf1bac07bc5fe9b86cb4ef798c56d7fe5dR258-R264) [[12]](diffhunk://#diff-ecc5436f1e468983f5a6e6c8ccc9d551ff7052cd40f589248596fbde0406a407R76) [[13]](diffhunk://#diff-ecc5436f1e468983f5a6e6c8ccc9d551ff7052cd40f589248596fbde0406a407R1395)