### PR TITLE
Gracefully handle keystore load failures and reinitialize SSLManager

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/JMeterJettySslContextFactory.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/JMeterJettySslContextFactory.java
@@ -50,7 +50,7 @@ public class JMeterJettySslContextFactory extends SslContextFactory.Client
             System.getProperty("javax.net.ssl.keyStoreType"), keyStoreType);
         configureKeyStorePathForJetty(keyStorePath, jettyKeyStoreUri, keyStoreType);
       }
-      keys = getKeyStore((JsseSSLManager) SSLManager.getInstance());
+      keys = loadJMeterKeyStore(keyStorePath);
       /*
        we need to set password after getting keystore since getKeystore may ask the user for the
        password.
@@ -79,6 +79,18 @@ public class JMeterJettySslContextFactory extends SslContextFactory.Client
        password.
       */
       setTrustStorePassword(System.getProperty("javax.net.ssl.trustStorePassword"));
+    }
+  }
+
+  private JmeterKeyStore loadJMeterKeyStore(String keyStorePath) {
+    try {
+      return getKeyStore((JsseSSLManager) SSLManager.getInstance());
+    } catch (RuntimeException e) {
+      LOG.warn("Could not load JMeter keyStore from '{}': {}. "
+              + "Client certificate alias selection may be unavailable.",
+          keyStorePath, e.getMessage());
+      lowLevelDebug("Could not load JMeter keyStore from '{}'", keyStorePath, e);
+      return null;
     }
   }
 

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
@@ -1383,15 +1383,24 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
     String keyStorePasswordPropertyName = "javax.net.ssl.keyStorePassword";
     System.setProperty(keyStorePropertyName, getKeyStorePathAsUriPathWithNetSslKeyStoreFormat());
     System.setProperty(keyStorePasswordPropertyName, KEYSTORE_PASSWORD);
+    System.setProperty("javax.net.ssl.keyStoreType", "PKCS12");
+    SSLManager.reset();
     client.stop();
-    client = new HTTP2JettyClient();
+    client = new HTTP2JettyClient(false, "client-cert-test",
+        HTTP2ClientProfileConfig.builder()
+            .enableHttp1(true)
+            .enableHttp2(false)
+            .enableHttp3(false)
+            .alpnEnabled(false)
+            .build());
     client.start();
     try {
       HTTPSampleResult result = sampleWithGet();
       assertThat(result.getResponseDataAsString()).isEqualTo(SERVER_RESPONSE);
     } finally {
-      System.setProperty(keyStorePropertyName, "");
-      System.setProperty(keyStorePasswordPropertyName, "");
+      System.clearProperty(keyStorePropertyName);
+      System.clearProperty(keyStorePasswordPropertyName);
+      System.clearProperty("javax.net.ssl.keyStoreType");
       SSLManager.reset();
     }
   }


### PR DESCRIPTION
This pull request improves the handling of keystore loading and client certificate configuration in the HTTP/2 Jetty client. The main changes include better error handling when loading the JMeter keystore, improved test setup and cleanup for keystore properties, and more explicit client configuration in tests.

### Keystore loading improvements
* Added a new `loadJMeterKeyStore` method to handle keystore loading with error logging and fallback if loading fails, enhancing robustness and debuggability (`JMeterJettySslContextFactory.java`). [[1]](diffhunk://#diff-fe7c1e1bc27e7334acc004814a33cf8fae829cda240f247de4d20d6019e67c63L53-R53) [[2]](diffhunk://#diff-fe7c1e1bc27e7334acc004814a33cf8fae829cda240f247de4d20d6019e67c63R85-R96)

### Test enhancements
* Updated the client certificate test to explicitly set the keystore type to `PKCS12`, reset the `SSLManager`, and use a more configurable `HTTP2JettyClient` constructor for better test isolation and clarity (`HTTP2JettyClientTest.java`).
* Improved test cleanup by using `System.clearProperty` instead of setting properties to empty strings, ensuring environment variables are properly cleared after tests (`HTTP2JettyClientTest.java`).