### PR TITLE
Update Jetty version from 12.1.6 to 12.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jmeter.version>5.4.1</jmeter.version>
-    <jetty.version>12.1.6</jetty.version>
-    <!-- Matches jetty-project ${brotli4j.version} for Jetty 12.1.6 -->
+    <jetty.version>12.1.7</jetty.version>
+    <!-- Matches jetty-project ${brotli4j.version} for Jetty 12.1.7 -->
     <brotli4j.version>1.20.0</brotli4j.version>
     <checkstyle.skip>false</checkstyle.skip>
   </properties>


### PR DESCRIPTION
This pull request updates the Jetty server dependency version in the `pom.xml` file to ensure the project uses the latest Jetty release.

Dependency version update:

* Updated the `jetty.version` property from `12.1.6` to `12.1.7` in `pom.xml` to match the latest Jetty release and maintain compatibility with `brotli4j.version`.