### PR TITLE
Implement support for HEAD HTTP method

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -133,8 +133,8 @@ public class HTTP2JettyClient {
       "HTTP2JettyClient build: host-header-filter+http3-always-v2026-01-26";
   private static final boolean FORCE_HTTP2_ONLY = false;
   private static final Set<String> SUPPORTED_METHODS = new HashSet<>(Arrays
-      .asList(HTTPConstants.GET, HTTPConstants.POST, HTTPConstants.PUT, HTTPConstants.PATCH,
-          HTTPConstants.OPTIONS, HTTPConstants.DELETE));
+      .asList(HTTPConstants.GET, HTTPConstants.HEAD, HTTPConstants.POST, HTTPConstants.PUT,
+          HTTPConstants.PATCH, HTTPConstants.OPTIONS, HTTPConstants.DELETE));
   private static final Set<String> METHODS_WITH_BODY = new HashSet<>(Arrays
       .asList(HTTPConstants.POST, HTTPConstants.PUT, HTTPConstants.PATCH));
   private static final Path ALPN_DEBUG_LOG_PATH = resolveAlpnLogPath();

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
@@ -185,6 +185,47 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
     assertThat(result.getResponseDataAsString()).isEqualTo(SERVER_RESPONSE);
   }
 
+  @Test
+  public void shouldSucceedWhenHeadMethodIsSent() throws Exception {
+    buildStartedServer();
+    sampler.setMethod(HTTPConstants.HEAD);
+    HTTPSampleResult result = sample(SERVER_PATH_200, HTTPConstants.HEAD);
+    softly.assertThat(result.isSuccessful()).isTrue();
+    softly.assertThat(result.getResponseCode()).isEqualTo("200");
+    softly.assertThat(result.getHTTPMethod()).isEqualTo(HTTPConstants.HEAD);
+    // HEAD responses must not carry a body.
+    softly.assertThat(result.getResponseDataAsString()).isEmpty();
+  }
+
+  @Test
+  public void shouldNotSendBodyWhenHeadMethodWithArguments() throws Exception {
+    buildStartedServer();
+    sampler.setMethod(HTTPConstants.HEAD);
+    sampler.addArgument("test1", TEST_ARGUMENT_1);
+    sampler.addArgument("test2", TEST_ARGUMENT_2);
+    HTTPSampleResult result = sample(SERVER_PATH_200, HTTPConstants.HEAD);
+    softly.assertThat(result.isSuccessful()).isTrue();
+    softly.assertThat(result.getResponseCode()).isEqualTo("200");
+    softly.assertThat(result.getResponseDataAsString()).isEmpty();
+    // HEAD is not a body method; arguments must not become a request entity.
+    softly.assertThat(result.getQueryString()).isNullOrEmpty();
+    softly.assertThat(result.getRequestHeaders()).doesNotContain("Content-Length");
+  }
+
+  @Test
+  public void shouldFollowRedirectWhenHeadMethodAndFollowRedirectEnabled() throws Exception {
+    buildStartedServer();
+    sampler.setMethod(HTTPConstants.HEAD);
+    sampler.setFollowRedirects(true);
+    HTTPSampleResult result = sample(SERVER_PATH_302, HTTPConstants.HEAD);
+    softly.assertThat(result.isSuccessful()).isTrue();
+    softly.assertThat(result.getResponseCode()).isEqualTo("200");
+    softly.assertThat(result.getSubResults().length).isGreaterThan(0);
+    softly.assertThat(result.getRedirectLocation())
+        .isEqualTo("https://localhost:" + getActivePort() + SERVER_PATH_200);
+    softly.assertThat(result.getResponseDataAsString()).isEmpty();
+  }
+
   private void buildStartedServer() throws Exception {
     server = new ServerBuilder()
         .withHTTP2()

--- a/src/test/java/com/blazemeter/jmeter/http2/core/ServerBuilder.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/ServerBuilder.java
@@ -298,7 +298,10 @@ public class ServerBuilder {
           case SERVER_PATH_200:
             resp.setStatus(HttpStatus.OK_200);
             resp.setContentType(MimeTypes.MIME_TEXT_HTML + ";" + StandardCharsets.UTF_8.name());
-            resp.getWriter().write(SERVER_RESPONSE);
+            // HEAD must not include a response body (RFC 9110).
+            if (!"HEAD".equalsIgnoreCase(req.getMethod())) {
+              resp.getWriter().write(SERVER_RESPONSE);
+            }
             break;
           case SERVER_PATH_SLOW:
             try {


### PR DESCRIPTION
This pull request adds support for the HTTP `HEAD` method in the HTTP/2 Jetty client and improves test coverage to ensure correct handling of `HEAD` requests. It also updates the test server to comply with HTTP standards for `HEAD` responses.

**HTTP/2 Client Enhancements:**

* Added `HTTPConstants.HEAD` to the list of supported methods in `HTTP2JettyClient`, enabling the client to send `HEAD` requests.

**Test Coverage Improvements:**

* Added three new tests in `HTTP2JettyClientTest`:
  - Verifies successful `HEAD` requests return status 200 with no response body.
  - Ensures that arguments with `HEAD` do not result in a request body or `Content-Length` header.
  - Confirms that redirects with `HEAD` and follow-redirect enabled are handled correctly, with no response body.

**Test Server Compliance:**

* Updated `ServerBuilder` so that, when handling `HEAD` requests, no response body is sent, in accordance with RFC 9110.