### PR TITLE
Add user agent when default_user_agent_disabled is false

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/JmeterRequestHeadersSupport.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/JmeterRequestHeadersSupport.java
@@ -1,6 +1,8 @@
 package com.blazemeter.jmeter.http2.core;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.util.JMeterUtils;
 import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
@@ -16,6 +18,11 @@ final class JmeterRequestHeadersSupport {
 
   static final String ATTR_USE_KEEPALIVE = "bzm.useKeepAlive";
 
+  static final String DEFAULT_USER_AGENT_PROPERTY =
+      "httpclient4.default_user_agent_disabled";
+
+  private static final String DEFAULT_USER_AGENT = buildDefaultUserAgent();
+
   private JmeterRequestHeadersSupport() {
   }
 
@@ -28,8 +35,7 @@ final class JmeterRequestHeadersSupport {
     }
     request.attribute(ATTR_USE_KEEPALIVE, useKeepAlive);
     applyConnectionHeader(request, useKeepAlive);
-    // TODO: HC4 sends explicit empty User-Agent when none is configured (disableDefaultUserAgent).
-    // prepareEmptyUserAgentHeader(request);
+    applyDefaultUserAgentHeader(request);
   }
 
   /**
@@ -54,7 +60,6 @@ final class JmeterRequestHeadersSupport {
     }
     HttpFields.Mutable merged = HttpFields.build(request.getHeaders());
     restoreConnectionHeaderForSample(request, merged);
-    // restoreEmptyUserAgentForSample(request, merged);
     return merged;
   }
 
@@ -71,6 +76,39 @@ final class JmeterRequestHeadersSupport {
     } else {
       mutableHeaders.put(HTTPConstants.HEADER_CONNECTION, HTTPConstants.CONNECTION_CLOSE);
     }
+  }
+
+
+  /**
+   * Matches {@code HTTPHC4Impl}: when no {@code User-Agent} is configured, send a plugin default
+   * unless {@code httpclient4.default_user_agent_disabled=true}.
+   */
+  private static void applyDefaultUserAgentHeader(Request request) {
+    if (isDefaultUserAgentDisabled()) {
+      return;
+    }
+    HttpFields.Mutable mutableHeaders = mutableHeaders(request);
+    if (mutableHeaders == null || mutableHeaders.contains(HttpHeader.USER_AGENT)) {
+      return;
+    }
+    mutableHeaders.put(HttpHeader.USER_AGENT, DEFAULT_USER_AGENT);
+  }
+
+  static boolean isDefaultUserAgentDisabled() {
+    return JMeterUtils.getPropDefault(DEFAULT_USER_AGENT_PROPERTY, false);
+  }
+
+  static String defaultUserAgent() {
+    return DEFAULT_USER_AGENT;
+  }
+
+  private static String buildDefaultUserAgent() {
+    Package pkg = JmeterRequestHeadersSupport.class.getPackage();
+    String version = pkg != null ? pkg.getImplementationVersion() : null;
+    if (StringUtils.isBlank(version)) {
+      return "BlazeMeter HTTP";
+    }
+    return "BlazeMeter HTTP/" + version;
   }
 
   private static void restoreConnectionHeaderForSample(

--- a/src/test/java/com/blazemeter/jmeter/http2/core/JmeterRequestHeadersSupportTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/JmeterRequestHeadersSupportTest.java
@@ -4,17 +4,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.util.JMeterUtils;
 import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpVersion;
+import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class JmeterRequestHeadersSupportTest {
+public class JmeterRequestHeadersSupportTest extends HTTP2TestBase {
+
+  private static final String UA_DISABLED_PROP =
+      JmeterRequestHeadersSupport.DEFAULT_USER_AGENT_PROPERTY;
+
+  @After
+  public void clearUserAgentProperty() {
+    JMeterUtils.getJMeterProperties().remove(UA_DISABLED_PROP);
+  }
 
   private static Request mockRequest(HttpFields.Mutable headers) {
     Map<String, Object> attributes = new HashMap<>();
@@ -73,5 +84,51 @@ public class JmeterRequestHeadersSupportTest {
     JmeterRequestHeadersSupport.prepareFromSampler(request, true);
 
     assertThat(headers.get(HttpHeader.CONNECTION)).isEqualTo("Upgrade");
+  }
+
+  @Test
+  public void prepareFromSamplerAddsDefaultUserAgentWhenMissing() {
+    HttpFields.Mutable headers = HttpFields.build();
+    Request request = mockRequest(headers);
+
+    JmeterRequestHeadersSupport.prepareFromSampler(request, true);
+
+    assertThat(headers.get(HttpHeader.USER_AGENT))
+        .isEqualTo(JmeterRequestHeadersSupport.defaultUserAgent());
+    assertThat(headers.get(HttpHeader.USER_AGENT)).startsWith("BlazeMeter HTTP");
+  }
+
+  @Test
+  public void prepareFromSamplerDoesNotOverrideConfiguredUserAgent() {
+    HttpFields.Mutable headers = HttpFields.build()
+        .add(HttpHeader.USER_AGENT, "CustomAgent/1.0");
+    Request request = mockRequest(headers);
+
+    JmeterRequestHeadersSupport.prepareFromSampler(request, true);
+
+    assertThat(headers.get(HttpHeader.USER_AGENT)).isEqualTo("CustomAgent/1.0");
+  }
+
+  @Test
+  public void prepareFromSamplerKeepsEmptyUserAgentFromHeaderManager() {
+    HttpFields.Mutable headers = HttpFields.build()
+        .add(HttpHeader.USER_AGENT, "");
+    Request request = mockRequest(headers);
+
+    JmeterRequestHeadersSupport.prepareFromSampler(request, true);
+
+    assertThat(headers.contains(HttpHeader.USER_AGENT)).isTrue();
+    assertThat(headers.get(HttpHeader.USER_AGENT)).isEmpty();
+  }
+
+  @Test
+  public void prepareFromSamplerOmitsDefaultUserAgentWhenPropertyDisabled() {
+    JMeterUtils.setProperty(UA_DISABLED_PROP, "true");
+    HttpFields.Mutable headers = HttpFields.build();
+    Request request = mockRequest(headers);
+
+    JmeterRequestHeadersSupport.prepareFromSampler(request, true);
+
+    assertThat(headers.contains(HttpHeader.USER_AGENT)).isFalse();
   }
 }


### PR DESCRIPTION
This pull request enhances how the HTTP/2 plugin sets the `User-Agent` header by introducing logic to add a default `User-Agent` when none is configured, unless explicitly disabled via a property. It also adds comprehensive tests to verify this behavior, ensuring compatibility with legacy behavior and configurability.

**User-Agent header handling improvements:**

* Added logic in `JmeterRequestHeadersSupport` to automatically set a default `User-Agent` header (`"BlazeMeter HTTP"` or `"BlazeMeter HTTP/<version>"`) if none is provided, unless the `httpclient4.default_user_agent_disabled` property is set to `true`. This matches the legacy behavior of `HTTPHC4Impl` and improves interoperability. [[1]](diffhunk://#diff-d0d6ee51c4126e862840d746676eee7e187628d391513406b437c8811ad4db18R21-R25) [[2]](diffhunk://#diff-d0d6ee51c4126e862840d746676eee7e187628d391513406b437c8811ad4db18R81-R113)
* Introduced helper methods and constants in `JmeterRequestHeadersSupport` to support the new default `User-Agent` logic, including property checks and default value construction. [[1]](diffhunk://#diff-d0d6ee51c4126e862840d746676eee7e187628d391513406b437c8811ad4db18R21-R25) [[2]](diffhunk://#diff-d0d6ee51c4126e862840d746676eee7e187628d391513406b437c8811ad4db18R81-R113)

**Testing enhancements:**

* Added new tests in `JmeterRequestHeadersSupportTest` to verify that the default `User-Agent` is set when missing, not overridden if already present (including empty values), and omitted when the disabling property is set.
* Improved test setup and teardown by clearing the relevant property after each test to avoid side effects.

**Dependency and import updates:**

* Added necessary imports for `JMeterUtils`, `StringUtils`, and test utilities to support the new logic and tests. [[1]](diffhunk://#diff-d0d6ee51c4126e862840d746676eee7e187628d391513406b437c8811ad4db18R3-R5) [[2]](diffhunk://#diff-860ec1f675aa52c2cf72ed9bb89c12838b990f44268b60e363b659e6b4bdbdeeR7-R28)