### PR TITLE
Delegate cached-resource sample result to JMeter HTTPHC4Impl

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/JettyCacheManager.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/JettyCacheManager.java
@@ -17,11 +17,12 @@ import org.apache.http.client.methods.HttpTrace;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.jmeter.protocol.http.control.CacheManager;
+import org.apache.jmeter.protocol.http.sampler.HTTPHC4Impl;
 import org.apache.jmeter.protocol.http.sampler.HTTPHC4Impl.HttpDelete;
 import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase;
 import org.apache.jmeter.protocol.http.sampler.HttpWebdav;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
-import org.apache.jmeter.util.JMeterUtils;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.http.HttpFields;
@@ -94,35 +95,29 @@ public class JettyCacheManager {
   }
 
   public HTTPSampleResult buildCachedSampleResult(HTTPSampleResult res) {
-    CachedResourceMode cachedResourceMode = CachedResourceMode.valueOf(
-        JMeterUtils.getPropDefault("cache_manager.cached_resource_mode",
-            CachedResourceMode.RETURN_NO_SAMPLE.toString()));
-    switch (cachedResourceMode) {
-      case RETURN_NO_SAMPLE:
-        return null;
-      case RETURN_200_CACHE:
-        res.sampleEnd();
-        res.setResponseCodeOK();
-        res.setResponseMessage(
-            JMeterUtils.getPropDefault("RETURN_200_CACHE.message", "(ex cache)"));
-        res.setSuccessful(true);
-        return res;
-      case RETURN_CUSTOM_STATUS:
-        res.sampleEnd();
-        res.setResponseCode(JMeterUtils.getProperty("RETURN_CUSTOM_STATUS.code"));
-        res.setResponseMessage(
-            JMeterUtils.getPropDefault("RETURN_CUSTOM_STATUS.message", "(ex cache)"));
-        res.setSuccessful(true);
-        return res;
-      default:
-        throw new IllegalStateException("Unknown CACHED_RESOURCE_MODE");
+    // Match HttpClient4: HTTPAbstractImpl snapshots cache_manager.cached_resource_mode once.
+    return CachedResourceResultBridge.forCachedResource(res);
+  }
+
+  private static final class CachedResourceResultBridge extends HTTPHC4Impl {
+    private static final CachedResourceResultBridge INSTANCE =
+        new CachedResourceResultBridge(new BridgeSampler());
+
+    private CachedResourceResultBridge(HTTPSamplerBase sampler) {
+      super(sampler);
+    }
+
+    private static HTTPSampleResult forCachedResource(HTTPSampleResult res) {
+      return INSTANCE.updateSampleResultForResourceInCache(res);
     }
   }
 
-  private enum CachedResourceMode {
-    RETURN_200_CACHE,
-    RETURN_NO_SAMPLE,
-    RETURN_CUSTOM_STATUS
+  private static final class BridgeSampler extends HTTPSamplerBase {
+    @Override
+    protected HTTPSampleResult sample(URL url, String method, boolean areFollowingRedirect,
+        int depth) {
+      throw new UnsupportedOperationException("cache bridge");
+    }
   }
 
   public void saveDetails(ContentResponse contentResponse, HTTPSampleResult result) {

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
@@ -1006,6 +1006,7 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
     JMeterUtils.setProperty("cache_manager.cached_resource_mode", "RETURN_CUSTOM_STATUS");
     JMeterUtils.setProperty("RETURN_CUSTOM_STATUS.message", message);
     JMeterUtils.setProperty("RETURN_CUSTOM_STATUS.code", responseCode);
+    JmeterCachedResourceModeSupport.refreshSnapshotFromProperties();
     configureCacheManagerToSampler(true, false);
     HTTPSampleResult firstRequestExpected = buildResult(true, Code.OK,
       hostHeader(), null, null, createURL(SERVER_PATH_200_EMBEDDED), HTTPConstants.GET);
@@ -1036,6 +1037,7 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
     String message = "message";
     JMeterUtils.setProperty("cache_manager.cached_resource_mode", "RETURN_200_CACHE");
     JMeterUtils.setProperty("RETURN_200_CACHE.message", message);
+    JmeterCachedResourceModeSupport.refreshSnapshotFromProperties();
     configureCacheManagerToSampler(true, false);
     // First request must connect to the server
     HTTPSampleResult expected = buildResult(true, Code.OK,

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HttpKeepAliveSampleHeadersTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HttpKeepAliveSampleHeadersTest.java
@@ -37,6 +37,9 @@ public class HttpKeepAliveSampleHeadersTest {
       executor.awaitTermination(5, TimeUnit.SECONDS);
       executor = null;
     }
+    JMeterUtils.getJMeterProperties().remove("blazemeter.http.enableHttp2");
+    JMeterUtils.getJMeterProperties().remove("blazemeter.http.enableHttp3");
+    JMeterUtils.getJMeterProperties().remove("blazemeter.http.profile");
   }
 
   @Test

--- a/src/test/java/com/blazemeter/jmeter/http2/core/JettyCacheManagerTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/JettyCacheManagerTest.java
@@ -1,0 +1,103 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import org.apache.jmeter.protocol.http.control.CacheManager;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.util.JMeterUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * {@link JettyCacheManager#buildCachedSampleResult} delegates to JMeter's own
+ * {@code HTTPAbstractImpl#updateSampleResultForResourceInCache}, so its behaviour for each
+ * {@code cache_manager.cached_resource_mode} matches {@code HTTPHC4Impl} exactly instead of a
+ * hand-rolled reimplementation.
+ */
+public class JettyCacheManagerTest extends HTTP2TestBase {
+
+  private static final String MODE_PROPERTY = "cache_manager.cached_resource_mode";
+  private static final String RETURN_200_MESSAGE_PROPERTY = "RETURN_200_CACHE.message";
+  private static final String CUSTOM_STATUS_CODE_PROPERTY = "RETURN_CUSTOM_STATUS.code";
+  private static final String CUSTOM_STATUS_MESSAGE_PROPERTY = "RETURN_CUSTOM_STATUS.message";
+
+  private final JettyCacheManager jettyCacheManager =
+      JettyCacheManager.fromCacheManager(new CacheManager());
+
+  @Before
+  @After
+  public void resetCacheModeProperties() throws ReflectiveOperationException {
+    // Other test classes (e.g. HTTP2JettyClientTest) set these same JMeter properties without
+    // cleaning up; clear them both before and after so this test never depends on run order.
+    JMeterUtils.getJMeterProperties().remove(MODE_PROPERTY);
+    JMeterUtils.getJMeterProperties().remove(RETURN_200_MESSAGE_PROPERTY);
+    JMeterUtils.getJMeterProperties().remove(CUSTOM_STATUS_CODE_PROPERTY);
+    JMeterUtils.getJMeterProperties().remove(CUSTOM_STATUS_MESSAGE_PROPERTY);
+    JmeterCachedResourceModeSupport.refreshSnapshotFromProperties();
+  }
+
+  private static HTTPSampleResult newSampleResult() {
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.sampleStart();
+    return result;
+  }
+
+  private static void setCacheMode(String mode) throws ReflectiveOperationException {
+    JMeterUtils.setProperty(MODE_PROPERTY, mode);
+    JmeterCachedResourceModeSupport.refreshSnapshotFromProperties();
+  }
+
+  @Test
+  public void returnsNoSampleWhenModeIsReturnNoSample() throws Exception {
+    setCacheMode("RETURN_NO_SAMPLE");
+
+    HTTPSampleResult result = jettyCacheManager.buildCachedSampleResult(newSampleResult());
+
+    assertThat(result).isNull();
+  }
+
+  @Test
+  public void returns200OkWithConfigurableMessageWhenModeIsReturn200Cache() throws Exception {
+    JMeterUtils.setProperty(RETURN_200_MESSAGE_PROPERTY, "(from cache)");
+    setCacheMode("RETURN_200_CACHE");
+    HTTPSampleResult sample = newSampleResult();
+
+    HTTPSampleResult result = jettyCacheManager.buildCachedSampleResult(sample);
+
+    assertThat(result).isSameAs(sample);
+    assertThat(result.getResponseCode()).isEqualTo("200");
+    assertThat(result.getResponseMessage()).isEqualTo("(from cache)");
+    assertThat(result.isSuccessful()).isTrue();
+  }
+
+  @Test
+  public void return200CacheFallsBackToDefaultMessageWhenPropertyUnset() throws Exception {
+    setCacheMode("RETURN_200_CACHE");
+
+    HTTPSampleResult result = jettyCacheManager.buildCachedSampleResult(newSampleResult());
+
+    assertThat(result.getResponseMessage()).isEqualTo("(ex cache)");
+  }
+
+  @Test
+  public void returnsCustomStatusWhenModeIsReturnCustomStatus() throws Exception {
+    JMeterUtils.setProperty(CUSTOM_STATUS_CODE_PROPERTY, "304");
+    JMeterUtils.setProperty(CUSTOM_STATUS_MESSAGE_PROPERTY, "Not Modified (cached)");
+    setCacheMode("RETURN_CUSTOM_STATUS");
+    HTTPSampleResult sample = newSampleResult();
+
+    HTTPSampleResult result = jettyCacheManager.buildCachedSampleResult(sample);
+
+    assertThat(result).isSameAs(sample);
+    assertThat(result.getResponseCode()).isEqualTo("304");
+    assertThat(result.getResponseMessage()).isEqualTo("Not Modified (cached)");
+    assertThat(result.isSuccessful()).isTrue();
+  }
+
+  @Test
+  public void fromCacheManagerReturnsNullWhenNoCacheManagerConfigured() {
+    assertThat(JettyCacheManager.fromCacheManager(null)).isNull();
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/JmeterCachedResourceModeSupport.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/JmeterCachedResourceModeSupport.java
@@ -1,0 +1,48 @@
+package com.blazemeter.jmeter.http2.core;
+
+import java.lang.reflect.Field;
+import org.apache.jmeter.util.JMeterUtils;
+import sun.misc.Unsafe;
+
+/**
+ * JMeter snapshots {@code cache_manager.cached_resource_mode} in static final fields on
+ * {@code HTTPAbstractImpl} class init. Tests that change the property must refresh that snapshot.
+ */
+public final class JmeterCachedResourceModeSupport {
+
+  private static final String HTTP_ABSTRACT_IMPL =
+      "org.apache.jmeter.protocol.http.sampler.HTTPAbstractImpl";
+  private static final String CACHED_RESOURCE_MODE_ENUM =
+      "org.apache.jmeter.protocol.http.sampler.HTTPAbstractImpl$CachedResourceMode";
+
+  private JmeterCachedResourceModeSupport() {
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public static void refreshSnapshotFromProperties() throws ReflectiveOperationException {
+    Class<?> abstractImpl = Class.forName(HTTP_ABSTRACT_IMPL);
+    Class<Enum> modeEnum = (Class<Enum>) Class.forName(CACHED_RESOURCE_MODE_ENUM);
+    String modeName = JMeterUtils.getPropDefault("cache_manager.cached_resource_mode",
+        "RETURN_NO_SAMPLE");
+    setStaticFinal(abstractImpl, "CACHED_RESOURCE_MODE",
+        Enum.valueOf(modeEnum, modeName));
+    setStaticFinal(abstractImpl, "RETURN_200_CACHE_MESSAGE",
+        JMeterUtils.getPropDefault("RETURN_200_CACHE.message", "(ex cache)"));
+    setStaticFinal(abstractImpl, "RETURN_CUSTOM_STATUS_CODE",
+        JMeterUtils.getProperty("RETURN_CUSTOM_STATUS.code"));
+    setStaticFinal(abstractImpl, "RETURN_CUSTOM_STATUS_MESSAGE",
+        JMeterUtils.getPropDefault("RETURN_CUSTOM_STATUS.message", "(ex cache)"));
+  }
+
+  private static void setStaticFinal(Class<?> clazz, String name, Object value)
+      throws ReflectiveOperationException {
+    Field field = clazz.getDeclaredField(name);
+    field.setAccessible(true);
+    Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
+    unsafeField.setAccessible(true);
+    Unsafe unsafe = (Unsafe) unsafeField.get(null);
+    Object base = unsafe.staticFieldBase(field);
+    long offset = unsafe.staticFieldOffset(field);
+    unsafe.putObject(base, offset, value);
+  }
+}


### PR DESCRIPTION

This pull request refactors how `JettyCacheManager` handles cached HTTP sample results to delegate directly to JMeter's internal logic, ensuring consistent behavior with the core JMeter HTTP client. It also introduces improved test support for property-driven modes, preventing test interference, and adds comprehensive unit tests for cache behavior.

**Core refactor and behavior alignment:**

* Refactored `JettyCacheManager#buildCachedSampleResult` to delegate to JMeter’s `HTTPHC4Impl.updateSampleResultForResourceInCache`, ensuring exact behavior for all `cache_manager.cached_resource_mode` values and removing the hand-rolled implementation.
* Removed the local `CachedResourceMode` enum and related property lookups from `JettyCacheManager`, relying instead on JMeter’s implementation.

**Test infrastructure improvements:**

* Added `JmeterCachedResourceModeSupport` utility to forcibly refresh JMeter’s static cached resource mode fields, allowing tests to safely change cache mode properties without cross-test contamination.
* Updated existing tests (`HTTP2JettyClientTest`) to call `JmeterCachedResourceModeSupport.refreshSnapshotFromProperties()` after property changes, ensuring correct test isolation. [[1]](diffhunk://#diff-ecc5436f1e468983f5a6e6c8ccc9d551ff7052cd40f589248596fbde0406a407R1009) [[2]](diffhunk://#diff-ecc5436f1e468983f5a6e6c8ccc9d551ff7052cd40f589248596fbde0406a407R1040)

**New unit tests:**

* Added `JettyCacheManagerTest` to verify that `buildCachedSampleResult` matches JMeter’s expected behavior for all cache modes, including property-based configuration and correct handling of unset properties.