### PR TITLE
Decode both zlib-wrapped and raw deflate content

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/DeflateContentDecoderFactory.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/DeflateContentDecoderFactory.java
@@ -12,6 +12,14 @@ import org.eclipse.jetty.io.content.ContentSourceTransformer;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.IO;
 
+/**
+ * Jetty's compression module ({@code org.eclipse.jetty.compression.*}) ships gzip, brotli, and
+ * zstd decoders but no deflate one, so this streams deflate content through {@link Inflater}
+ * directly. Note this only handles zlib-wrapped deflate (RFC 1950); it is not registered as a
+ * per-request decoder in {@link HTTP2JettyClient} because retrying as raw/headerless deflate
+ * (RFC 1951) requires the fully buffered response body - see
+ * {@link HTTP2JettyClient#decodeDeflate}.
+ */
 public class DeflateContentDecoderFactory extends ContentDecoder.Factory {
 
   private final ByteBufferPool bufferPool;

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -48,6 +48,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import java.util.stream.StreamSupport;
 import java.util.zip.GZIPInputStream;
+import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.protocol.http.control.AuthManager;
@@ -214,6 +215,10 @@ public class HTTP2JettyClient {
   private CompressionContentDecoderFactory brotliDecoderFactory;
   private CompressionContentDecoderFactory zstdDecoderFactory;
   private ContentDecoder.Factory gzipDecoderFactory;
+  // Jetty's compression module ships gzip/brotli/zstd decoders but no deflate one, so
+  // DeflateContentDecoderFactory is our own Inflater-based implementation (not a Jetty class).
+  // Kept initialized for the disableDeflateDecoder diagnostic toggle, but no longer registered
+  // per-request; see the comment in configureContentDecoders() below.
   private DeflateContentDecoderFactory deflateDecoderFactory;
   private boolean decoderFactoriesInitialized = false;
   private int quicMaxIdleTimeout = 30000;
@@ -2104,9 +2109,14 @@ public class HTTP2JettyClient {
     } else if (addGzip && disableGzipDecoder) {
       lowLevelDebug("Gzip decoder disabled by blazemeter.http.disableGzipDecoder");
     }
-    if (addDeflate && deflateDecoderFactory != null && !disableDeflateDecoder) {
-      factories.put(deflateDecoderFactory);
-    } else if (addDeflate && disableDeflateDecoder) {
+    // Not registering deflateDecoderFactory here on purpose. It decodes per-chunk as bytes
+    // arrive off the wire, so if the first bytes don't inflate as zlib-wrapped (RFC 1950) there's
+    // no clean way to rewind and retry as raw/headerless deflate (RFC 1951) - some servers send
+    // "Content-Encoding: deflate" as raw deflate despite the RFC implying zlib. getDecodedContent()
+    // below instead decodes the fully buffered response body, where retrying with a fresh
+    // Inflater is trivial, so all deflate decoding is funneled through decodeDeflate() there to
+    // match HttpClient4 (which also tries zlib first, then raw).
+    if (addDeflate && disableDeflateDecoder) {
       lowLevelDebug("Deflate decoder disabled by blazemeter.http.disableDeflateDecoder");
     }
 
@@ -3788,7 +3798,11 @@ public class HTTP2JettyClient {
     // should have handled it and re-decoding only adds CPU/alloc pressure.
     boolean skipRedundantManualDecode = Boolean.parseBoolean(
         System.getProperty(PROP_SKIP_REDUNDANT_MANUAL_DECODE, "true"));
+    // deflate is excluded from this fast path: it is never registered as a per-request Jetty
+    // decoder (see configureContentDecoders() above), so it must always go through decodeDeflate()
+    // below, which is the only place that tries both deflate variants.
     if (skipRedundantManualDecode
+        && !"deflate".equals(encodingToken)
         && requestAdvertisedEncoding(contentResponse.getRequest(), encodingToken)) {
       return content;
     }
@@ -3860,15 +3874,33 @@ public class HTTP2JettyClient {
     }
   }
 
+  /**
+   * "Content-Encoding: deflate" is ambiguous in practice: the RFC implies zlib-wrapped deflate
+   * (RFC 1950), but plenty of real servers send raw/headerless deflate (RFC 1951) under the same
+   * header. Try zlib first, then raw, before giving up - matching HttpClient4's behavior.
+   */
   private byte[] decodeDeflate(byte[] content, String contentEncoding) {
-    try (InputStream input = new InflaterInputStream(new ByteArrayInputStream(content));
+    byte[] zlibDecoded = tryInflateDeflate(content, false);
+    if (zlibDecoded != null) {
+      return zlibDecoded;
+    }
+    byte[] rawDecoded = tryInflateDeflate(content, true);
+    if (rawDecoded != null) {
+      return rawDecoded;
+    }
+    lowLevelDebug("Failed to decode deflate content ({}), keeping original bytes",
+        contentEncoding);
+    return content;
+  }
+
+  private byte[] tryInflateDeflate(byte[] content, boolean nowrap) {
+    try (InflaterInputStream input = new InflaterInputStream(
+        new ByteArrayInputStream(content), new Inflater(nowrap));
          ByteArrayOutputStream output = new ByteArrayOutputStream(content.length)) {
       copy(input, output);
       return output.toByteArray();
     } catch (IOException e) {
-      lowLevelDebug("Failed to decode deflate content ({}), keeping original bytes",
-          contentEncoding, e);
-      return content;
+      return null;
     }
   }
 

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientDeflateDecodeTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientDeflateDecodeTest.java
@@ -1,0 +1,69 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
+import org.junit.Test;
+
+/**
+ * {@link HTTP2JettyClient}'s manual deflate decode must accept both zlib-wrapped (RFC 1950,
+ * what {@link java.util.zip.Deflater} produces by default) and raw/headerless (RFC 1951) deflate
+ * streams, matching HttpClient4 (some servers send raw deflate under a {@code Content-Encoding:
+ * deflate} header).
+ */
+public class HTTP2JettyClientDeflateDecodeTest extends HTTP2TestBase {
+
+  private static final String PLAIN_TEXT =
+      "HttpClient4 accepts both zlib-wrapped and raw deflate streams.";
+
+  @Test
+  public void decodesZlibWrappedDeflateContent() throws Exception {
+    byte[] compressed = deflate(PLAIN_TEXT, false);
+
+    byte[] decoded = decodeDeflate(compressed);
+
+    assertThat(new String(decoded, StandardCharsets.UTF_8)).isEqualTo(PLAIN_TEXT);
+  }
+
+  @Test
+  public void decodesRawHeaderlessDeflateContent() throws Exception {
+    byte[] compressed = deflate(PLAIN_TEXT, true);
+
+    byte[] decoded = decodeDeflate(compressed);
+
+    assertThat(new String(decoded, StandardCharsets.UTF_8)).isEqualTo(PLAIN_TEXT);
+  }
+
+  @Test
+  public void returnsOriginalBytesWhenContentIsNotValidDeflate() throws Exception {
+    byte[] garbage = "not compressed at all".getBytes(StandardCharsets.UTF_8);
+
+    byte[] decoded = decodeDeflate(garbage);
+
+    assertThat(decoded).isEqualTo(garbage);
+  }
+
+  private static byte[] deflate(String text, boolean nowrap) throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    Deflater deflater = new Deflater(Deflater.DEFAULT_COMPRESSION, nowrap);
+    try (DeflaterOutputStream deflaterOut = new DeflaterOutputStream(out, deflater)) {
+      deflaterOut.write(text.getBytes(StandardCharsets.UTF_8));
+    } finally {
+      deflater.end();
+    }
+    return out.toByteArray();
+  }
+
+  private static byte[] decodeDeflate(byte[] content) throws Exception {
+    HTTP2JettyClient client = new HTTP2JettyClient(false, "deflate-decode-test");
+    Method method = HTTP2JettyClient.class
+        .getDeclaredMethod("decodeDeflate", byte[].class, String.class);
+    method.setAccessible(true);
+    return (byte[]) method.invoke(client, content, "deflate");
+  }
+}


### PR DESCRIPTION
This pull request improves how "deflate" (compressed) HTTP response bodies are handled in `HTTP2JettyClient`. Previously, the client only supported zlib-wrapped deflate streams (RFC 1950), but in practice, many servers send raw/headerless deflate (RFC 1951) under the same `Content-Encoding: deflate` header. The changes ensure both variants are supported, matching the behavior of `HttpClient4`. Additionally, the deflate decoder is no longer registered for per-chunk decoding, but handled after the full response is buffered. Unit tests are added to verify this behavior.

**Deflate decoding improvements:**

- The `decodeDeflate` method now tries to decode both zlib-wrapped (RFC 1950) and raw/headerless (RFC 1951) deflate streams, returning the original bytes if both fail. This ensures compatibility with real-world servers and matches `HttpClient4`'s behavior.
- The deflate decoder is no longer registered as a per-request Jetty decoder. Instead, all deflate decoding is funneled through the new logic in `decodeDeflate`, allowing safe retries between zlib and raw decoding. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL2107-R2119) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR218-R221) [[3]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR3801-R3805)

**Documentation and code clarity:**

- Added detailed Javadoc comments explaining the ambiguity of "Content-Encoding: deflate" and the rationale for the new decoding approach in both `DeflateContentDecoderFactory` and `HTTP2JettyClient`. [[1]](diffhunk://#diff-b303bd4c1fb293bb1567e0f67fcf7bb8df494c3e1ee01b110e8b7ff33dc1f71bR15-R22) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR218-R221) [[3]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL2107-R2119)

**Testing:**

- Introduced a new test class, `HTTP2JettyClientDeflateDecodeTest`, which verifies that both zlib-wrapped and raw deflate streams are correctly decoded, and that invalid data is left unchanged.