### PR TITLE
Harden HTTP/2 cleartext (h2c) upgrade negotiation and fallback

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -21,6 +21,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -146,6 +147,7 @@ public class HTTP2JettyClient {
   private static final String DEFAULT_FILE_MIME_TYPE = "application/octet-stream";
   private static final String ALT_SVC_HEADER = "alt-svc";
   private static final String ATTR_HTTP3_ATTEMPTED = "bzm.http3.attempted";
+  private static final String ATTR_H2C_FALLBACK_ATTEMPTED = "bzm.h2cFallbackAttempted";
   private static final String ATTR_ORIGIN_KEY = "bzm.http3.origin";
   private static final String ATTR_REQUEST_HEADERS_SERIALIZED = "bzm.request.headers.serialized";
   private static final String PROP_SKIP_REDUNDANT_MANUAL_DECODE =
@@ -1186,56 +1188,143 @@ public class HTTP2JettyClient {
     lowLevelDebug("Retrying request with HTTP/1.1 only: method={}, URI={}",
         originalRequest.getMethod(), uri);
 
-    clearContentDecoders(httpClientHttp1Only);
-
     try {
-      // Rebuild the request with the shared HTTP/1.1-only client
-      Request http11Request = httpClientHttp1Only.newRequest(uri)
-          .method(originalRequest.getMethod())
-          .timeout(requestTimeout, TimeUnit.MILLISECONDS)
-          .followRedirects(originalRequest.isFollowRedirects());
-
-      // Copy headers from original request
-      if (originalRequest.getHeaders() != null) {
-        HttpFields originalHeaders = originalRequest.getHeaders();
-        HttpFields requestHeaders = http11Request.getHeaders();
-        if (requestHeaders instanceof HttpFields.Mutable) {
-          HttpFields.Mutable newHeaders = (HttpFields.Mutable) requestHeaders;
-          originalHeaders.forEach(field -> {
-            // Skip HTTP/2 pseudo-headers (they don't exist in HTTP/1.1)
-            String name = field.getName();
-            if (!name.startsWith(":")) {
-              newHeaders.put(name, field.getValue());
-            }
-          });
-        }
-        // Note: In Jetty 12, Request headers are typically mutable.
-        // If they're not mutable, the headers from the original request
-        // will be lost, but this is an edge case.
-      }
-      ensureHostHeader(http11Request, uri);
-      JmeterRequestHeadersSupport.copySamplerHeaderState(originalRequest, http11Request);
-
-      configureContentDecodersAndCapture(httpClientHttp1Only, http11Request);
-
-      // Copy body if present
-      if (originalRequest.getBody() != null) {
-        http11Request.body(originalRequest.getBody());
-      }
-      SslClientCertAliasSupport.copyFromRequest(originalRequest, http11Request);
-
-      // Send request and wait for response
+      Request http11Request = buildHttp11FallbackRequest(originalRequest);
       lowLevelDebug("Sending HTTP/1.1 fallback request");
       ContentResponse response = http11Request.send();
-
       lowLevelDebug("HTTP/1.1 fallback request succeeded: status={}, version={}",
           response.getStatus(), response.getVersion());
-
       return response;
     } catch (Exception e) {
       LOG.error("HTTP/1.1 fallback also failed for URI: {}", uri, e);
       throw new ExecutionException("HTTP/1.1 fallback failed", e);
     }
+  }
+
+  private Request buildHttp11FallbackRequest(Request originalRequest) {
+    URI uri = originalRequest.getURI();
+    clearContentDecoders(httpClientHttp1Only);
+    Request http11Request = httpClientHttp1Only.newRequest(uri)
+        .method(originalRequest.getMethod())
+        .timeout(requestTimeout, TimeUnit.MILLISECONDS)
+        .followRedirects(originalRequest.isFollowRedirects());
+    JmeterRequestHeadersSupport.copySamplerHeaderState(originalRequest, http11Request);
+    http11Request.attribute(ATTR_H2C_FALLBACK_ATTEMPTED, Boolean.TRUE);
+    if (originalRequest.getHeaders() != null) {
+      HttpFields originalHeaders = originalRequest.getHeaders();
+      HttpFields requestHeaders = http11Request.getHeaders();
+      if (requestHeaders instanceof HttpFields.Mutable) {
+        HttpFields.Mutable newHeaders = (HttpFields.Mutable) requestHeaders;
+        originalHeaders.forEach(field -> {
+          // Skip HTTP/2 pseudo-headers and h2c upgrade headers - neither exists in HTTP/1.1,
+          // and re-sending them would trigger another (futile) upgrade attempt on this retry.
+          String name = field.getName();
+          if (name.startsWith(":") || isH2cUpgradeHeader(name, field.getValue())) {
+            return;
+          }
+          newHeaders.put(name, field.getValue());
+        });
+      }
+    }
+    ensureHostHeader(http11Request, uri);
+    Object useKeepAlive =
+        http11Request.getAttributes().get(JmeterRequestHeadersSupport.ATTR_USE_KEEPALIVE);
+    if (useKeepAlive instanceof Boolean) {
+      JmeterRequestHeadersSupport.prepareFromSampler(http11Request, (Boolean) useKeepAlive);
+    }
+    configureContentDecodersAndCapture(httpClientHttp1Only, http11Request);
+    if (originalRequest.getBody() != null) {
+      http11Request.body(originalRequest.getBody());
+    }
+    SslClientCertAliasSupport.copyFromRequest(originalRequest, http11Request);
+    return http11Request;
+  }
+
+  private static boolean isH2cUpgradeHeader(String name, String value) {
+    if (HttpHeader.UPGRADE.is(name) || HttpHeader.HTTP2_SETTINGS.is(name)) {
+      return true;
+    }
+    if (HttpHeader.CONNECTION.is(name) && value != null) {
+      String lower = value.toLowerCase(Locale.ROOT);
+      return lower.contains("upgrade") || lower.contains("http2-settings");
+    }
+    return false;
+  }
+
+  /** True if {@code request} carried an {@code Upgrade: h2c} header or attribute. */
+  private boolean wasH2cUpgradeAttempt(Request request) {
+    if (request == null) {
+      return false;
+    }
+    Object protocol = request.getAttributes().get(HttpUpgrader.PROTOCOL_ATTRIBUTE);
+    if ("h2c".equals(protocol)) {
+      return true;
+    }
+    HttpFields headers = request.getHeaders();
+    if (headers == null) {
+      return false;
+    }
+    String upgrade = headers.get(HttpHeader.UPGRADE);
+    return upgrade != null && upgrade.toLowerCase(Locale.ROOT).contains("h2c");
+  }
+
+  /**
+   * The server answered (no timeout/error) but never actually negotiated HTTP/2 despite our
+   * {@code Upgrade: h2c} attempt - e.g. it silently ignored the header, as a compliant HTTP/1.1
+   * server that doesn't support h2c is allowed to do. Retry once with a plain HTTP/1.1 request.
+   */
+  private boolean shouldRetryAfterFailedH2cUpgrade(Request request, ContentResponse response) {
+    if (!enableHttp1 || !http1UpgradeRequired || request == null || response == null) {
+      return false;
+    }
+    URI uri = request.getURI();
+    if (uri == null || !"http".equalsIgnoreCase(uri.getScheme())) {
+      return false;
+    }
+    if (Boolean.TRUE.equals(
+        request.getAttributes().get(ATTR_H2C_FALLBACK_ATTEMPTED))) {
+      return false;
+    }
+    if (!wasH2cUpgradeAttempt(request)) {
+      return false;
+    }
+    return response.getVersion() != HttpVersion.HTTP_2;
+  }
+
+  private void markCleartextHttp1Only(URI uri) {
+    if (!enableHttp1 || !http1OnlyCacheEnabled || http1OnlyCooldownMs <= 0 || uri == null) {
+      return;
+    }
+    if (!"http".equalsIgnoreCase(uri.getScheme())) {
+      return;
+    }
+    markHttp1OnlyOrigin(originKey(uri));
+  }
+
+  /**
+   * Retries a request that timed out or failed while attempting an h2c upgrade, as plain
+   * HTTP/1.1. Returns {@code null} (instead of throwing) when the failure isn't h2c-related, or
+   * when a fallback was already attempted for this request, so callers can fall through to their
+   * existing (non-h2c) handling.
+   */
+  private ContentResponse tryCleartextHttp11FallbackAfterH2cFailure(
+      Request request, HTTP2FutureResponseListener listener)
+      throws InterruptedException, TimeoutException, ExecutionException {
+    if (!enableHttp1 || request == null) {
+      return null;
+    }
+    URI uri = request.getURI();
+    if (uri == null || !"http".equalsIgnoreCase(uri.getScheme())
+        || !wasH2cUpgradeAttempt(request)) {
+      return null;
+    }
+    if (Boolean.TRUE.equals(
+        request.getAttributes().get(ATTR_H2C_FALLBACK_ATTEMPTED))) {
+      return null;
+    }
+    lowLevelDebug("Falling back to HTTP/1.1 after failed H2C upgrade for {}", uri);
+    markCleartextHttp1Only(uri);
+    return sendWithHTTP11Only(request, listener);
   }
 
   private ContentResponse sendWithH2cPriorKnowledge(Request originalRequest)
@@ -1437,9 +1526,9 @@ public class HTTP2JettyClient {
       }
       throw e;
     } catch (ExecutionException e) {
-      if (protocolErrorFallbackEnabled && enableHttp1
-          && ProtocolErrorException.isProtocolError(e)) {
-        LOG.warn("Protocol error during send(), retrying with HTTP/1.1 only");
+      Throwable cause = e.getCause();
+      if (shouldFallbackToHttp11AfterTransportFailure(cause, e)) {
+        LOG.warn("Transport failure during send(), retrying with HTTP/1.1 only");
         return retryWithHTTP11Only(sampler, result);
       }
       throw e;
@@ -1583,6 +1672,14 @@ public class HTTP2JettyClient {
     } catch (TimeoutException e) {
       if (http1UpgradeRequired && "http".equalsIgnoreCase(uri.getScheme())) {
         try {
+          ContentResponse fallback = tryCleartextHttp11FallbackAfterH2cFailure(request, listener);
+          if (fallback != null) {
+            return fallback;
+          }
+        } catch (Exception fallbackException) {
+          LOG.error("HTTP/1.1 fallback after H2C timeout failed", fallbackException);
+        }
+        try {
           LOG.warn("H2C upgrade timed out; retrying with prior knowledge");
           return sendWithH2cPriorKnowledge(request);
         } catch (Exception retryException) {
@@ -1616,10 +1713,8 @@ public class HTTP2JettyClient {
           throw e;
         }
       }
-      if ((cause instanceof ProtocolErrorException
-          || ProtocolErrorException.isProtocolError(cause))
-          && protocolErrorFallbackEnabled) {
-        LOG.warn("HTTP/2 protocol_error detected in send()! Attempting fallback to HTTP/1.1");
+      if (shouldFallbackToHttp11AfterTransportFailure(cause, e)) {
+        LOG.warn("Transport failure detected in send()! Attempting fallback to HTTP/1.1");
         LOG.warn("Error details: message='{}', exception={}",
             cause != null ? cause.getMessage() : e.getMessage(),
             cause != null ? cause.getClass().getName() : "unknown");
@@ -1836,6 +1931,17 @@ public class HTTP2JettyClient {
             response.getStatus(), response.getVersion(), elapsed, contentLength);
         int headerCount = response.getHeaders() != null ? response.getHeaders().size() : 0;
         lowLevelDebug("Response headers: {}", headerCount);
+        if (originalRequest != null
+            && shouldRetryAfterFailedH2cUpgrade(originalRequest, response)) {
+          lowLevelDebug("H2C upgrade did not negotiate HTTP/2; retrying with HTTP/1.1 for {}",
+              originalRequest.getURI());
+          markCleartextHttp1Only(originalRequest.getURI());
+          ContentResponse fallbackResponse = sendWithHTTP11Only(originalRequest, listener);
+          updateHttp1OnlyCache(originalRequest, fallbackResponse);
+          updateH2cCache(originalRequest, fallbackResponse);
+          updateAltSvcCache(originalRequest, fallbackResponse.getHeaders());
+          return fallbackResponse;
+        }
         if (originalRequest != null && response.getVersion() == HttpVersion.HTTP_3) {
           recordHttp3Success(originalRequest.getURI());
         }
@@ -1850,6 +1956,21 @@ public class HTTP2JettyClient {
       long endGet = System.currentTimeMillis();
       long elapsed = endGet - getStart;
       LOG.error("Request timeout after {}ms: {}", elapsed, e.getMessage());
+      if (originalRequest != null) {
+        try {
+          ContentResponse fallback =
+              tryCleartextHttp11FallbackAfterH2cFailure(originalRequest, listener);
+          if (fallback != null) {
+            updateHttp1OnlyCache(originalRequest, fallback);
+            updateH2cCache(originalRequest, fallback);
+            updateAltSvcCache(originalRequest, fallback.getHeaders());
+            return fallback;
+          }
+        } catch (Exception fallbackException) {
+          LOG.error("HTTP/1.1 fallback after H2C timeout in getContent() failed",
+              fallbackException);
+        }
+      }
       throw new TimeoutException("The request took more than " + elapsed
           + " milliseconds to complete");
     } catch (ExecutionException e) {
@@ -1881,10 +2002,8 @@ public class HTTP2JettyClient {
           }
         }
       }
-      if ((cause instanceof ProtocolErrorException
-          || ProtocolErrorException.isProtocolError(cause))
-          && protocolErrorFallbackEnabled) {
-        LOG.warn("HTTP/2 protocol_error detected in getContent()! "
+      if (shouldFallbackToHttp11AfterTransportFailure(cause, e)) {
+        LOG.warn("Transport failure detected in getContent()! "
             + "Attempting fallback to HTTP/1.1");
         LOG.warn("Error details: message='{}', exception={}",
             cause != null ? cause.getMessage() : e.getMessage(),
@@ -2132,6 +2251,10 @@ public class HTTP2JettyClient {
 
   private HttpClient selectHttpClient(URI uri) {
     if (uri != null && "http".equalsIgnoreCase(uri.getScheme())) {
+      if (enableHttp1 && isHttp1Only(uri)) {
+        lowLevelDebug("HTTP/1.1-only cache hit for cleartext origin {}", originKey(uri));
+        return httpClientHttp1Only;
+      }
       if (!enableHttp2 && enableHttp1) {
         return httpClientHttp1Only;
       }
@@ -2379,21 +2502,32 @@ public class HTTP2JettyClient {
       return;
     }
     URI uri = request.getURI();
-    if (uri == null || !"https".equalsIgnoreCase(uri.getScheme())) {
+    if (uri == null) {
       return;
     }
     String origin = originKey(uri);
     HttpVersion version = response.getVersion();
-    if (version == HttpVersion.HTTP_1_1) {
-      Http1OnlyEntry entry = new Http1OnlyEntry();
-      entry.expiresAt = System.currentTimeMillis() + http1OnlyCooldownMs;
-      HTTP1_ONLY_CACHE.put(origin, entry);
-      lowLevelDebug("HTTP/1.1-only cache set for origin {} until {}", origin, entry.expiresAt);
-    } else if (version != null) {
-      if (HTTP1_ONLY_CACHE.remove(origin) != null) {
+    if ("https".equalsIgnoreCase(uri.getScheme())) {
+      if (version == HttpVersion.HTTP_1_1) {
+        markHttp1OnlyOrigin(origin);
+      } else if (version != null && HTTP1_ONLY_CACHE.remove(origin) != null) {
         lowLevelDebug("HTTP/1.1-only cache cleared for origin {}", origin);
       }
+      return;
     }
+    // Cleartext origin that attempted an h2c upgrade but didn't get HTTP/2 back: cache it as
+    // HTTP/1.1-only too, so later requests to the same origin skip the futile upgrade attempt.
+    if ("http".equalsIgnoreCase(uri.getScheme()) && wasH2cUpgradeAttempt(request)
+        && version != HttpVersion.HTTP_2) {
+      markHttp1OnlyOrigin(origin);
+    }
+  }
+
+  private void markHttp1OnlyOrigin(String origin) {
+    Http1OnlyEntry entry = new Http1OnlyEntry();
+    entry.expiresAt = System.currentTimeMillis() + http1OnlyCooldownMs;
+    HTTP1_ONLY_CACHE.put(origin, entry);
+    lowLevelDebug("HTTP/1.1-only cache set for origin {} until {}", origin, entry.expiresAt);
   }
 
   private void updateH2cCache(Request request, Response response) {
@@ -2455,6 +2589,31 @@ public class HTTP2JettyClient {
       current = current.getCause();
     }
     return null;
+  }
+
+  /**
+   * Unifies the two failure modes that warrant an HTTP/1.1 fallback: an explicit HTTP/2
+   * {@code protocol_error}, and a {@link ClosedChannelException} anywhere in the cause chain -
+   * some servers drop the connection outright instead of returning a clean protocol error when
+   * they don't like the request (e.g. a failed h2c upgrade attempt).
+   */
+  private boolean shouldFallbackToHttp11AfterTransportFailure(Throwable cause,
+      Throwable wrapped) {
+    if (!protocolErrorFallbackEnabled || !enableHttp1) {
+      return false;
+    }
+    return ProtocolErrorException.isProtocolError(wrapped)
+        || ProtocolErrorException.isProtocolError(cause)
+        || isClosedChannelFailure(cause != null ? cause : wrapped);
+  }
+
+  private static boolean isClosedChannelFailure(Throwable throwable) {
+    for (Throwable current = throwable; current != null; current = current.getCause()) {
+      if (current instanceof ClosedChannelException) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private ContentResponse retryAfterGoAway(Request originalRequest)
@@ -3018,7 +3177,7 @@ public class HTTP2JettyClient {
     // 1. The connection is already HTTP/2 (negotiated via ALPN)
     // 2. Upgrade headers are for cleartext HTTP, not HTTPS
     // 3. It violates the HTTP/2 protocol (RFC 7540)
-    if (http1UpgradeRequired && !"https".equalsIgnoreCase(url.getProtocol())
+    if (http1UpgradeRequired && enableHttp2 && !"https".equalsIgnoreCase(url.getProtocol())
         && !shouldUseH2cPriorKnowledge(request.getURI())) {
       Mutable headers = ((Mutable) request.getHeaders());
       addHeaderIfMissing(HttpHeader.UPGRADE, "h2c", headers);
@@ -3190,7 +3349,7 @@ public class HTTP2JettyClient {
     // For HTTPS connections, we assume HTTP/2 if ALPN negotiated it
     // For HTTP connections, we check if upgrade headers are present
     boolean isHTTP2 = "https".equalsIgnoreCase(request.getURI().getScheme())
-        || (http1UpgradeRequired && headers.contains(HttpHeader.UPGRADE));
+        || (enableHttp2 && http1UpgradeRequired && headers.contains(HttpHeader.UPGRADE));
 
     if (isHTTP2) {
       // HTTP/2 does not support Connection header except for upgrade (which we handle separately)

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientH2cFallbackTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientH2cFallbackTest.java
@@ -1,0 +1,170 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URL;
+import java.nio.channels.ClosedChannelException;
+import java.util.concurrent.ExecutionException;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * A cleartext ({@code http://}) server that never negotiates {@code h2c} shouldn't ever surface
+ * as a sample error or a hung request - {@link HTTP2JettyClient} must detect the failed upgrade
+ * and retry as plain HTTP/1.1, exactly like a compliant client talking to an HTTP/1.1-only
+ * server.
+ */
+public class HTTP2JettyClientH2cFallbackTest extends HTTP2TestBase {
+
+  private TeardownableServer server;
+  private HttpClient probeClient;
+
+  @After
+  public void tearDown() throws Exception {
+    if (server != null) {
+      server.stop();
+    }
+    if (probeClient != null) {
+      probeClient.stop();
+    }
+  }
+
+  @Test
+  public void sampleAgainstHttp1OnlyServerSucceedsDespiteAttemptedH2cUpgrade() throws Exception {
+    int port = startHttp1OnlyServer();
+    // http1UpgradeRequired=true: the client already believes this origin needs the explicit
+    // Upgrade: h2c header dance (e.g. a prior response on this origin wasn't HTTP/2).
+    HTTP2JettyClient client = new HTTP2JettyClient(true, "h2c-fallback-test");
+    client.start();
+    try {
+      HTTPSampleResult result = sampleGet(client, port);
+      assertThat(result.isSuccessful()).isTrue();
+      assertThat(result.getResponseCode()).isEqualTo("200");
+    } finally {
+      client.stop();
+    }
+  }
+
+  @Test
+  public void secondRequestToSameOriginSkipsRepeatedFailedH2cUpgrade() throws Exception {
+    int port = startHttp1OnlyServer();
+    HTTP2JettyClient client = new HTTP2JettyClient(true, "h2c-fallback-cache-test");
+    client.start();
+    try {
+      sampleGet(client, port);
+      URI origin = URI.create("http://localhost:" + port);
+      assertThat((Boolean) invokePrivate(client, "isHttp1Only", new Class<?>[] {URI.class},
+          origin)).isTrue();
+    } finally {
+      client.stop();
+    }
+  }
+
+  @Test
+  public void wasH2cUpgradeAttemptDetectsUpgradeHeader() throws Exception {
+    HTTP2JettyClient client = newClientForReflection();
+    Request withUpgrade = newProbeRequest("http://example.invalid/")
+        .headers(h -> h.put(HttpHeader.UPGRADE, "h2c"));
+    Request withoutUpgrade = newProbeRequest("http://example.invalid/");
+
+    assertThat((Boolean) invokePrivate(client, "wasH2cUpgradeAttempt",
+        new Class<?>[] {Request.class}, withUpgrade)).isTrue();
+    assertThat((Boolean) invokePrivate(client, "wasH2cUpgradeAttempt",
+        new Class<?>[] {Request.class}, withoutUpgrade)).isFalse();
+  }
+
+  @Test
+  public void buildHttp11FallbackRequestStripsH2cHeadersAndMarksAttempted() throws Exception {
+    HTTP2JettyClient client = newClientForReflection();
+    Request original = newProbeRequest("http://example.invalid/")
+        .headers(h -> h
+            .put(HttpHeader.UPGRADE, "h2c")
+            .put(HttpHeader.HTTP2_SETTINGS, "AAMAAABkAAQAoAAAAAIAAAAA")
+            .put(HttpHeader.CONNECTION, "Upgrade, HTTP2-Settings")
+            .put("X-Custom", "keep-me"));
+
+    Request fallback = (Request) invokePrivate(client, "buildHttp11FallbackRequest",
+        new Class<?>[] {Request.class}, original);
+
+    HttpFields fallbackHeaders = fallback.getHeaders();
+    assertThat(fallbackHeaders.get(HttpHeader.UPGRADE)).isNull();
+    assertThat(fallbackHeaders.get(HttpHeader.HTTP2_SETTINGS)).isNull();
+    assertThat(fallbackHeaders.get("X-Custom")).isEqualTo("keep-me");
+    String fallbackAttemptedAttribute = (String) readPrivateStaticField(
+        HTTP2JettyClient.class, "ATTR_H2C_FALLBACK_ATTEMPTED");
+    assertThat(fallback.getAttributes().get(fallbackAttemptedAttribute)).isEqualTo(Boolean.TRUE);
+  }
+
+  @Test
+  public void isClosedChannelFailureFindsItAnywhereInCauseChain() throws Exception {
+    HTTP2JettyClient client = newClientForReflection();
+    Exception wrapped = new ExecutionException(
+        new RuntimeException("network blip", new ClosedChannelException()));
+    Exception unrelated = new ExecutionException(new RuntimeException("unrelated failure"));
+
+    assertThat((Boolean) invokePrivate(client, "shouldFallbackToHttp11AfterTransportFailure",
+        new Class<?>[] {Throwable.class, Throwable.class}, wrapped.getCause(), wrapped))
+        .isTrue();
+    assertThat((Boolean) invokePrivate(client, "shouldFallbackToHttp11AfterTransportFailure",
+        new Class<?>[] {Throwable.class, Throwable.class}, unrelated.getCause(), unrelated))
+        .isFalse();
+  }
+
+  private int startHttp1OnlyServer() throws Exception {
+    server = new ServerBuilder().withHTTP1().buildServer();
+    server.start();
+    return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+  }
+
+  private static HTTPSampleResult sampleGet(HTTP2JettyClient client, int port) throws Exception {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod("GET");
+    sampler.setDomain("localhost");
+    sampler.setPort(port);
+    sampler.setPath(ServerBuilder.SERVER_PATH_200);
+    sampler.setProtocol("http");
+
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setSampleLabel("GET_H2C_FALLBACK");
+    result.setHTTPMethod("GET");
+    result.setURL(new URL("http", "localhost", port, ServerBuilder.SERVER_PATH_200));
+
+    return client.sample(sampler, result, false, 0);
+  }
+
+  private HTTP2JettyClient newClientForReflection() {
+    return new HTTP2JettyClient(false, "h2c-reflection-test");
+  }
+
+  private Request newProbeRequest(String uri) {
+    if (probeClient == null) {
+      probeClient = new HttpClient();
+    }
+    return probeClient.newRequest(URI.create(uri));
+  }
+
+  private static Object invokePrivate(Object target, String methodName, Class<?>[] paramTypes,
+      Object... args) throws Exception {
+    Method method = HTTP2JettyClient.class.getDeclaredMethod(methodName, paramTypes);
+    method.setAccessible(true);
+    return method.invoke(target, args);
+  }
+
+  private static Object readPrivateStaticField(Class<?> type, String fieldName) throws Exception {
+    java.lang.reflect.Field field = type.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.get(null);
+  }
+}


### PR DESCRIPTION
This pull request introduces significant improvements to the HTTP/2 to HTTP/1.1 fallback logic in the `HTTP2JettyClient` class, especially for cleartext (h2c) upgrade failures and transport errors. It unifies the handling of protocol errors and transport failures, improves detection and caching of HTTP/1.1-only origins, and ensures that fallback attempts are robust and avoid redundant retries. The changes also refactor the code for clarity and maintainability.

**Fallback and Retry Logic Enhancements:**

* Added unified logic to detect when to fallback to HTTP/1.1 after a failed h2c upgrade or transport failure (including `ClosedChannelException`), via the new `shouldFallbackToHttp11AfterTransportFailure` method. This ensures that both explicit protocol errors and abrupt connection drops trigger appropriate fallback behavior.
* Implemented `tryCleartextHttp11FallbackAfterH2cFailure` and `shouldRetryAfterFailedH2cUpgrade` to handle silent h2c upgrade failures, retrying the request as plain HTTP/1.1 when appropriate and avoiding redundant retries. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL1189-R1327) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR1934-R1944) [[3]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR1959-R1973)
* Updated error handling in `send`, `getContent`, and `sample` methods to use the new unified fallback logic, ensuring consistent and robust fallback behavior across different failure scenarios. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL1440-R1531) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR1674-R1681) [[3]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL1619-R1717) [[4]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL1884-R2006)

**Caching and Request Handling Improvements:**

* Enhanced the HTTP/1.1-only cache to record cleartext origins that fail h2c upgrades, so future requests skip futile upgrade attempts. Added `markHttp1OnlyOrigin` and improved `updateHttp1OnlyCache` logic to handle both HTTPS and cleartext HTTP cases. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL2382-L2396) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR2254-R2257)
* Refactored the HTTP/1.1 fallback request builder to correctly copy headers, avoid resending h2c upgrade headers, and ensure request attributes/state are preserved.

**Header and Protocol Handling:**

* Improved header handling to ensure upgrade headers are only added when both HTTP/2 is enabled and an upgrade is required, and only for non-HTTPS requests. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL3021-R3180) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL3193-R3352)
* Added a new request attribute (`ATTR_H2C_FALLBACK_ATTEMPTED`) to prevent multiple fallback attempts for the same request.

These changes make the HTTP/2 client more resilient to server-side protocol and transport issues, reduce unnecessary retries, and improve compatibility with servers that do not support h2c upgrades.