### PR TITLE
Fix User-Agent is the last request header

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -758,13 +758,15 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
       // see HTTPJavaImpl#getConnectionHeaders
       //': ' is used by JMeter to fill-in requestHeaders, see getConnectionHeaders
       final String userAgentPrefix = USER_AGENT + ": ";
-      String userAgentHdr = res.substring(
-          index + userAgentPrefix.length(),
-          res.indexOf(
-              '\n',
-              // '\n' is used by JMeter to fill-in requestHeaders, see getConnectionHeaders
-              index + userAgentPrefix.length() + 1));
-      return userAgentHdr.trim();
+      int valueStart = index + userAgentPrefix.length();
+      // '\n' is used by JMeter to fill-in requestHeaders, see getConnectionHeaders. When
+      // User-Agent is the last header, there's no trailing '\n' and indexOf returns -1; fall
+      // back to the end of the string instead of feeding -1 into substring().
+      int lineEnd = res.indexOf('\n', valueStart);
+      if (lineEnd < 0) {
+        lineEnd = res.length();
+      }
+      return res.substring(valueStart, lineEnd).trim();
     } else {
       if (LOG.isDebugEnabled()) {
         LOG.debug("No user agent extracted from requestHeaders:{}", res);

--- a/src/test/java/com/blazemeter/jmeter/http2/sampler/HTTP2SamplerUserAgentExtractionTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/sampler/HTTP2SamplerUserAgentExtractionTest.java
@@ -1,0 +1,50 @@
+package com.blazemeter.jmeter.http2.sampler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import java.lang.reflect.Method;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.junit.Test;
+
+/**
+ * {@link HTTP2Sampler#getUserAgent} reads the {@code User-Agent} value out of the serialized
+ * {@code requestHeaders} string to reuse it when parsing embedded resources. When User-Agent is
+ * the last header, there's no trailing {@code '\n'} to bound the substring.
+ */
+public class HTTP2SamplerUserAgentExtractionTest extends HTTP2TestBase {
+
+  @Test
+  public void extractsUserAgentWhenItIsTheLastHeader() throws Exception {
+    String requestHeaders = "Host: example.org\nUser-Agent: Mozilla/5.0 (test)";
+
+    String userAgent = getUserAgent(requestHeaders);
+
+    assertThat(userAgent).isEqualTo("Mozilla/5.0 (test)");
+  }
+
+  @Test
+  public void extractsUserAgentWhenFollowedByOtherHeaders() throws Exception {
+    String requestHeaders = "Host: example.org\nUser-Agent: Mozilla/5.0 (test)\nAccept: */*\n";
+
+    String userAgent = getUserAgent(requestHeaders);
+
+    assertThat(userAgent).isEqualTo("Mozilla/5.0 (test)");
+  }
+
+  @Test
+  public void returnsNullWhenNoUserAgentHeaderPresent() throws Exception {
+    String requestHeaders = "Host: example.org\nAccept: */*\n";
+
+    assertThat(getUserAgent(requestHeaders)).isNull();
+  }
+
+  private static String getUserAgent(String requestHeaders) throws Exception {
+    HTTPSampleResult sampleResult = new HTTPSampleResult();
+    sampleResult.setRequestHeaders(requestHeaders);
+
+    Method method = HTTP2Sampler.class.getDeclaredMethod("getUserAgent", HTTPSampleResult.class);
+    method.setAccessible(true);
+    return (String) method.invoke(new HTTP2Sampler(), sampleResult);
+  }
+}


### PR DESCRIPTION
This pull request improves the robustness of the `getUserAgent` method in `HTTP2Sampler` by fixing a bug that occurred when the `User-Agent` header was the last header in the request (i.e., with no trailing newline). It also adds comprehensive unit tests to verify the correct extraction of the `User-Agent` header in various scenarios.

**Bug fix:**

* Improved the implementation of `getUserAgent` in `HTTP2Sampler.java` to correctly extract the `User-Agent` header value even when it is the last header without a trailing newline, preventing a potential `StringIndexOutOfBoundsException`.

**Testing improvements:**

* Added a new test class, `HTTP2SamplerUserAgentExtractionTest`, to verify `getUserAgent` handles cases where the `User-Agent` header is the last header, is followed by other headers, or is missing entirely.