### PR TITLE
Fix exception handling for requests with only Cookie header

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -3630,6 +3630,11 @@ public class HTTP2JettyClient {
     } else {
       String ret = HttpFields.build(headers).remove(HTTPConstants.HEADER_COOKIE).toString()
           .replace("\r\n", "\n");
+      // When Cookie was the only header, removing it leaves an empty string; ret.length() - 1
+      // would then be -1, which substring() rejects.
+      if (ret.isEmpty()) {
+        return "";
+      }
       return ret.substring(0,
           ret.length() - 1); // removing final separator not included in jmeter headers
     }

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientHeaderStringTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientHeaderStringTest.java
@@ -1,0 +1,51 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import java.lang.reflect.Method;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.eclipse.jetty.http.HttpFields;
+import org.junit.Test;
+
+/**
+ * {@link HTTP2JettyClient#buildHeadersString} strips the {@code Cookie} header before serializing
+ * request headers into the sample result. When Cookie was the only header, the stripped result is
+ * empty, and trimming a trailing separator from an empty string used to crash.
+ */
+public class HTTP2JettyClientHeaderStringTest extends HTTP2TestBase {
+
+  @Test
+  public void returnsEmptyStringWhenCookieWasTheOnlyHeader() throws Exception {
+    HttpFields headers = HttpFields.build().add(HTTPConstants.HEADER_COOKIE, "session=abc");
+
+    String result = buildHeadersString(headers);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void returnsEmptyStringWhenHeadersIsNull() throws Exception {
+    assertThat(buildHeadersString(null)).isEmpty();
+  }
+
+  @Test
+  public void stripsCookieButKeepsOtherHeaders() throws Exception {
+    HttpFields headers = HttpFields.build()
+        .add(HTTPConstants.HEADER_COOKIE, "session=abc")
+        .add("Accept", "*/*");
+
+    String result = buildHeadersString(headers);
+
+    assertThat(result).contains("Accept");
+    assertThat(result).doesNotContain(HTTPConstants.HEADER_COOKIE);
+  }
+
+  private static String buildHeadersString(HttpFields headers) throws Exception {
+    HTTP2JettyClient client = new HTTP2JettyClient(false, "header-string-test");
+    Method method = HTTP2JettyClient.class.getDeclaredMethod("buildHeadersString",
+        HttpFields.class);
+    method.setAccessible(true);
+    return (String) method.invoke(client, headers);
+  }
+}


### PR DESCRIPTION
This pull request fixes a bug in the `buildHeadersString` method of `HTTP2JettyClient` that caused a crash when the only HTTP header was `Cookie`, and adds unit tests to ensure correct behavior. The main changes are:

Bug fix:

* Updated `buildHeadersString` in `HTTP2JettyClient.java` to safely handle cases where removing the `Cookie` header results in an empty string, preventing a `StringIndexOutOfBoundsException`.

Testing improvements:

* Added a new test class `HTTP2JettyClientHeaderStringTest.java` with tests to verify that:
  * An empty string is returned when `Cookie` was the only header.
  * An empty string is returned when headers are `null`.
  * The `Cookie` header is stripped but other headers are preserved.