### PR TITLE
Remove duplicate fallback and fix stale body reuse

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListener.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListener.java
@@ -3,7 +3,6 @@ package com.blazemeter.jmeter.http2.core;
 import static com.blazemeter.jmeter.http2.core.LowLevelDebugLog.lowLevelDebug;
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
@@ -16,12 +15,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.eclipse.jetty.client.BufferingResponseListener;
 import org.eclipse.jetty.client.ContentResponse;
-import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.client.Result;
-import org.eclipse.jetty.http.HttpFields;
-import org.eclipse.jetty.http.HttpHeader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +30,6 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
   private volatile boolean onCompleteCalled = false;
   private final CountDownLatch latch = new CountDownLatch(1);
   private Request request;
-  private HttpClient fallbackHttp1Client;
   private ContentResponse response;
   private Throwable failure;
   private volatile boolean cancelled;
@@ -62,10 +57,6 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
 
   public Request getRequest() {
     return request;
-  }
-
-  public void setFallbackHttp1Client(HttpClient fallbackHttp1Client) {
-    this.fallbackHttp1Client = fallbackHttp1Client;
   }
 
   protected void setStart() {
@@ -346,13 +337,9 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
     try {
       return getResult();
     } catch (ProtocolErrorException e) {
-      ContentResponse fallback = tryHttp11Fallback();
-      if (fallback != null) {
-        return fallback;
-      }
       LOG.error("ProtocolErrorException caught in get(), wrapping in ExecutionException");
-      // Wrap ProtocolErrorException in ExecutionException to maintain interface contract
-      // The calling code will unwrap it and handle the fallback
+      // Wrap ProtocolErrorException in ExecutionException so HTTP2JettyClient (the single,
+      // centralized place for HTTP/1.1 fallback decisions) can unwrap it and handle the fallback.
       throw new ExecutionException(e);
     }
   }
@@ -376,13 +363,9 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
     try {
       return getResult();
     } catch (ProtocolErrorException e) {
-      ContentResponse fallback = tryHttp11Fallback();
-      if (fallback != null) {
-        return fallback;
-      }
       LOG.error("ProtocolErrorException caught in get(timeout), wrapping in ExecutionException");
-      // Wrap ProtocolErrorException in ExecutionException to maintain interface contract
-      // The calling code will unwrap it and handle the fallback
+      // Wrap ProtocolErrorException in ExecutionException so HTTP2JettyClient (the single,
+      // centralized place for HTTP/1.1 fallback decisions) can unwrap it and handle the fallback.
       throw new ExecutionException(e);
     }
   }
@@ -472,48 +455,6 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
           response.getStatus(), response.getVersion());
     }
     return response;
-  }
-
-  private ContentResponse tryHttp11Fallback() {
-    if (fallbackHttp1Client == null || request == null) {
-      return null;
-    }
-    try {
-      Request http11Request = fallbackHttp1Client.newRequest(request.getURI())
-          .method(request.getMethod())
-          .followRedirects(request.isFollowRedirects());
-      if (request.getHeaders() != null) {
-        HttpFields originalHeaders = request.getHeaders();
-        HttpFields requestHeaders = http11Request.getHeaders();
-        if (requestHeaders instanceof HttpFields.Mutable) {
-          HttpFields.Mutable newHeaders = (HttpFields.Mutable) requestHeaders;
-          originalHeaders.forEach(field -> {
-            String name = field.getName();
-            if (!name.startsWith(":")) {
-              newHeaders.put(name, field.getValue());
-            }
-          });
-          if (!newHeaders.contains(HttpHeader.HOST)) {
-            URI uri = request.getURI();
-            String host = uri.getHost() != null ? uri.getHost() : uri.getAuthority();
-            int port = uri.getPort();
-            int defaultPort = "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
-            boolean includePort = port > 0 && port != defaultPort;
-            String hostValue = includePort ? host + ":" + port : host;
-            newHeaders.put(HttpHeader.HOST, hostValue);
-          }
-        }
-      }
-      if (request.getBody() != null) {
-        http11Request.body(request.getBody());
-      }
-      SslClientCertAliasSupport.copyFromRequest(request, http11Request);
-      lowLevelDebug("Retrying request with HTTP/1.1 in listener fallback: {}", request.getURI());
-      return http11Request.send();
-    } catch (Exception e) {
-      LOG.error("HTTP/1.1 fallback in listener failed", e);
-      return null;
-    }
   }
 
 }

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -1238,8 +1238,18 @@ public class HTTP2JettyClient {
       JmeterRequestHeadersSupport.prepareFromSampler(http11Request, (Boolean) useKeepAlive);
     }
     configureContentDecodersAndCapture(httpClientHttp1Only, http11Request);
-    if (originalRequest.getBody() != null) {
-      http11Request.body(originalRequest.getBody());
+    Request.Content body = originalRequest.getBody();
+    if (body != null) {
+      // The original attempt may already have read some or all of this content before
+      // failing; rewind it back to the start before reuse, exactly as Jetty's own retry
+      // paths do (see AuthenticationProtocolHandler/HttpRedirector). Skipping this can send
+      // a fallback request that declares the right Content-Length but no actual body bytes,
+      // hanging the server until its idle timeout instead of failing fast.
+      if (!body.rewind()) {
+        throw new IllegalStateException(
+            "Request body for " + uri + " is not reproducible for HTTP/1.1 fallback retry");
+      }
+      http11Request.body(body);
     }
     SslClientCertAliasSupport.copyFromRequest(originalRequest, http11Request);
     return http11Request;
@@ -1483,7 +1493,6 @@ public class HTTP2JettyClient {
     lowLevelDebug("Request built: URI={}, method={}", request.getURI(), request.getMethod());
     samplePrepareRequest(request, sampler, result, context.client);
     listener.setRequest(request);
-    listener.setFallbackHttp1Client(httpClientHttp1Only);
     lowLevelDebug("Request prepared, ready to send");
     return request;
 

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListenerDoubleFallbackInvestigationTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListenerDoubleFallbackInvestigationTest.java
@@ -1,0 +1,50 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import java.net.URI;
+import java.util.concurrent.ExecutionException;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.client.Result;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Item #14: {@link HTTP2FutureResponseListener} used to resolve a {@code protocol_error} on its
+ * own (via a {@code tryHttp11Fallback()}/{@code fallbackHttp1Client} pair), silently, before
+ * {@link HTTP2JettyClient} - the single place that should own the HTTP/1.1 fallback decision via
+ * {@code shouldFallbackToHttp11AfterTransportFailure}/{@code buildHttp11FallbackRequest} - ever
+ * saw the failure. That duplicate fallback path is gone; {@link #get} must now always propagate
+ * a {@code protocol_error} to the caller.
+ */
+public class HTTP2FutureResponseListenerDoubleFallbackInvestigationTest extends HTTP2TestBase {
+
+  private HttpClient probeClient;
+
+  @After
+  public void tearDown() throws Exception {
+    if (probeClient != null) {
+      probeClient.stop();
+    }
+  }
+
+  @Test
+  public void getPropagatesProtocolErrorInsteadOfResolvingItSilently() throws Exception {
+    probeClient = new HttpClient();
+    probeClient.start();
+
+    HTTP2FutureResponseListener listener = new HTTP2FutureResponseListener(2 * 1024 * 1024);
+    Request originalRequest = probeClient.newRequest(URI.create("http://localhost:1/unused"));
+    listener.setRequest(originalRequest);
+
+    ProtocolErrorException simulatedProtocolError =
+        new ProtocolErrorException("simulated for regression test");
+    listener.onComplete(new Result(originalRequest, simulatedProtocolError, null));
+
+    ExecutionException thrown = org.junit.Assert.assertThrows(ExecutionException.class,
+        listener::get);
+    assertThat(ProtocolErrorException.isProtocolError(thrown.getCause())).isTrue();
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientFallbackBodyReuseInvestigationTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientFallbackBodyReuseInvestigationTest.java
@@ -1,0 +1,121 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.client.StringRequestContent;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Item #14, phase 2: {@code HTTP2JettyClient#buildHttp11FallbackRequest} reuses the failed
+ * request's {@code Request.Content} instead of rebuilding the body from scratch (unlike
+ * {@code retryWithHTTP11Only}, the sampler-based last-resort fallback). Jetty's own retry paths
+ * ({@code AuthenticationProtocolHandler}, {@code HttpRedirector}) always call
+ * {@code Request.Content#rewind()} before reusing content on a retry, and abort the retry if it
+ * returns {@code false}. {@code buildHttp11FallbackRequest} used to skip that call: if the
+ * original content had already been (partially or fully) read before the transport failure was
+ * detected, the fallback request would declare the original {@code Content-Length} but send no
+ * body bytes, hanging the server until its idle timeout instead of failing fast or resending the
+ * body correctly.
+ */
+public class HTTP2JettyClientFallbackBodyReuseInvestigationTest extends HTTP2TestBase {
+
+  private TeardownableServer server;
+  private HTTP2JettyClient client;
+  private HttpClient probeClient;
+
+  @After
+  public void tearDown() throws Exception {
+    if (probeClient != null) {
+      probeClient.stop();
+    }
+    if (client != null) {
+      client.stop();
+    }
+    if (server != null) {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void reusingOriginalRequestBodyAfterAFailedSendStillDeliversFullContent()
+      throws Exception {
+    int port = startHttp1OnlyServer();
+    client = new HTTP2JettyClient(false, "fallback-body-reuse-test");
+    client.start();
+    probeClient = new HttpClient();
+    probeClient.start();
+
+    String bodyText = "hello=world&keep=this-data-intact";
+    Request originalRequest = probeClient.newRequest(
+            URI.create("http://localhost:" + port + ServerBuilder.SERVER_PATH_200_WITH_BODY))
+        .method("POST")
+        .body(new StringRequestContent(bodyText, StandardCharsets.UTF_8));
+
+    // Simulate "the original request already failed once" by sending it for real first -
+    // this drains its Request.Content exactly like a real send would, before the fallback
+    // reuses the same content object.
+    ContentResponse firstAttempt = originalRequest.send();
+    assertThat(firstAttempt.getContentAsString()).isEqualTo(bodyText);
+
+    Request fallbackRequest = buildFallback(originalRequest);
+    ContentResponse fallbackAttempt = fallbackRequest.send();
+
+    assertThat(fallbackAttempt.getContentAsString())
+        .as("the fallback request must resend the full original body, not an empty/stale one")
+        .isEqualTo(bodyText);
+  }
+
+  @Test
+  public void throwsInsteadOfSendingAnEmptyBodyWhenContentCannotBeRewound() throws Exception {
+    int port = startHttp1OnlyServer();
+    client = new HTTP2JettyClient(false, "fallback-body-reuse-test");
+    client.start();
+    probeClient = new HttpClient();
+    probeClient.start();
+
+    Request originalRequest = probeClient.newRequest(
+            URI.create("http://localhost:" + port + ServerBuilder.SERVER_PATH_200_WITH_BODY))
+        .method("POST")
+        .body(new NonRewindableStringContent("cannot-reuse-me"));
+
+    InvocationTargetException thrown = org.junit.Assert.assertThrows(
+        InvocationTargetException.class, () -> buildFallback(originalRequest));
+
+    assertThat(thrown.getCause()).isInstanceOf(IllegalStateException.class);
+  }
+
+  private Request buildFallback(Request originalRequest) throws Exception {
+    Method buildFallback = HTTP2JettyClient.class
+        .getDeclaredMethod("buildHttp11FallbackRequest", Request.class);
+    buildFallback.setAccessible(true);
+    return (Request) buildFallback.invoke(client, originalRequest);
+  }
+
+  private int startHttp1OnlyServer() throws Exception {
+    server = new ServerBuilder().withHTTP1().buildServer();
+    server.start();
+    return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+  }
+
+  private static final class NonRewindableStringContent extends StringRequestContent {
+    private NonRewindableStringContent(String content) {
+      super(content, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public boolean rewind() {
+      return false;
+    }
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
@@ -1509,13 +1509,13 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
 
     client = new HTTP2JettyClient(true, "Test");
     client.start();
-    Request httpRequest = client.sampleAsync(
-        sampler,
-        buildBaseResult(createURL(SERVER_PATH_200), HTTPConstants.GET),
-        sampler.getFutureResponseListener());
+    HTTPSampleResult result = buildBaseResult(createURL(SERVER_PATH_200), HTTPConstants.GET);
+    Request httpRequest = client.sampleAsync(sampler, result, sampler.getFutureResponseListener());
     httpRequest.send(listener);
-    ContentResponse contentResponse = listener.get();
-    assertThat(contentResponse.getContent()).isNotEmpty();
+    // Goes through sampleFromListener() -> getContent(), the single place that owns the
+    // HTTP/1.1 fallback decision (the listener no longer resolves protocol_error on its own).
+    HTTPSampleResult sampleResult = client.sampleFromListener(sampler, result, false, 0, listener);
+    assertThat(sampleResult.getResponseData()).isNotEmpty();
   }
 
   @Test


### PR DESCRIPTION
This pull request refactors the HTTP/1.1 fallback logic in the HTTP/2 client implementation to centralize decision-making and improve reliability, especially around request body reuse. The main changes remove duplicate fallback handling from `HTTP2FutureResponseListener`, ensuring that only `HTTP2JettyClient` manages fallback decisions, and add robust handling for request body rewinding when retrying failed requests. Comprehensive regression tests are also introduced to verify these behaviors.

**Centralization and Simplification of Fallback Logic:**

- Removed the duplicate HTTP/1.1 fallback mechanism from `HTTP2FutureResponseListener`, including the `fallbackHttp1Client` field, related setter, and the `tryHttp11Fallback()` method. Now, `get()` and `get(timeout)` always propagate `ProtocolErrorException` to the caller, so only `HTTP2JettyClient` decides when to fall back to HTTP/1.1. [[1]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aL6) [[2]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aL19-L24) [[3]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aL37) [[4]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aL67-L70) [[5]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aL349-R342) [[6]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aL379-R368) [[7]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aL477-L518) [[8]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL1486)

**Robust Request Body Reuse for Fallbacks:**

- Updated `HTTP2JettyClient#buildHttp11FallbackRequest` to call `rewind()` on the original request's body before reusing it for a fallback. If the body cannot be rewound, an exception is thrown to avoid sending a request with an incorrect body, preventing server hangs and ensuring data integrity.

**Testing and Verification:**

- Added `HTTP2FutureResponseListenerDoubleFallbackInvestigationTest` to verify that protocol errors are always propagated to the caller and not resolved silently by the listener.
- Added `HTTP2JettyClientFallbackBodyReuseInvestigationTest` to ensure fallback requests resend the correct body content and throw an exception if the body cannot be rewound.
- Updated `HTTP2JettyClientTest` to reflect the new fallback flow, ensuring tests go through the correct centralized fallback path.