### PR TITLE
Fix Content-Type check and gate request body attachment

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -149,6 +149,7 @@ public class HTTP2JettyClient {
   private static final String ALT_SVC_HEADER = "alt-svc";
   private static final String ATTR_HTTP3_ATTEMPTED = "bzm.http3.attempted";
   private static final String ATTR_H2C_FALLBACK_ATTEMPTED = "bzm.h2cFallbackAttempted";
+  private static final String ATTR_SKIP_H2C_UPGRADE = "bzm.skipH2cUpgrade";
   private static final String ATTR_ORIGIN_KEY = "bzm.http3.origin";
   private static final String ATTR_REQUEST_HEADERS_SERIALIZED = "bzm.request.headers.serialized";
   private static final String PROP_SKIP_REDUNDANT_MANUAL_DECODE =
@@ -1158,7 +1159,7 @@ public class HTTP2JettyClient {
     configureContentDecodersAndCapture(httpClientHttp1Only, http11Request);
 
     // Copy body if present
-    setBody(http11Request, sampler, result);
+    setBody(http11Request, sampler, result, false);
     JmeterRequestHeadersSupport.prepareFromSampler(http11Request, sampler.getUseKeepAlive());
 
     // Send request
@@ -1398,6 +1399,14 @@ public class HTTP2JettyClient {
                                     HTTP2Sampler sampler,
                                     HTTPSampleResult result,
                                     HttpClient client) throws IOException {
+    samplePrepareRequest(request, sampler, result, client, false);
+  }
+
+  private void samplePrepareRequest(Request request,
+                                    HTTP2Sampler sampler,
+                                    HTTPSampleResult result,
+                                    HttpClient client,
+                                    boolean areFollowingRedirect) throws IOException {
 
     URL url = result.getURL();
     lowLevelDebug("Preparing request: URL={}, method={}", url, result.getHTTPMethod());
@@ -1405,6 +1414,12 @@ public class HTTP2JettyClient {
     request.followRedirects(sampler.getAutoRedirects());
     String method = result.getHTTPMethod();
     request.method(method);
+    if (shouldAttachRequestBody(sampler, result, areFollowingRedirect)) {
+      // The h2c Upgrade dance sends this request as plain HTTP/1.1 first; attaching a body
+      // to it works but isn't well-supported across servers, so skip the upgrade attempt
+      // entirely for bodied cleartext requests (see resolveClientForRequest).
+      request.attribute(ATTR_SKIP_H2C_UPGRADE, Boolean.TRUE);
+    }
     setHeaders(request, url, sampler.getHeaderManager());
     ensureHostHeader(request, url);
     addPreemptiveAuthorizationHeader(request, url, sampler.getAuthManager());
@@ -1433,7 +1448,7 @@ public class HTTP2JettyClient {
     }
     result.sampleStart();
 
-    setBody(request, sampler, result);
+    setBody(request, sampler, result, areFollowingRedirect);
     JmeterRequestHeadersSupport.prepareFromSampler(request, sampler.getUseKeepAlive());
     initializeSentBytes(result, request);
 
@@ -1508,7 +1523,7 @@ public class HTTP2JettyClient {
     RequestContext context = buildRequestContext(result, resolveClientForRequest(sampler, result));
     Request request = context.request;
 
-    samplePrepareRequest(request, sampler, result, context.client);
+    samplePrepareRequest(request, sampler, result, context.client, areFollowingRedirect);
 
     JettyCacheManager cacheManager =
         JettyCacheManager.fromCacheManager(sampler.getCacheManager());
@@ -3101,7 +3116,13 @@ public class HTTP2JettyClient {
 
   private HttpClient resolveClientForRequest(HTTP2Sampler sampler, HTTPSampleResult result)
       throws URISyntaxException {
-    return selectHttpClient(result.getURL().toURI());
+    URI uri = result.getURL().toURI();
+    if ("http".equalsIgnoreCase(uri.getScheme())
+        && shouldAttachRequestBody(sampler, result, false)) {
+      lowLevelDebug("Cleartext request with body; using HTTP/1.1-only client for {}", uri);
+      return httpClientHttp1Only;
+    }
+    return selectHttpClient(uri);
   }
 
   private boolean requestAdvertisesEncoding(HTTP2Sampler sampler, String encoding) {
@@ -3188,7 +3209,8 @@ public class HTTP2JettyClient {
     // 2. Upgrade headers are for cleartext HTTP, not HTTPS
     // 3. It violates the HTTP/2 protocol (RFC 7540)
     if (http1UpgradeRequired && enableHttp2 && !"https".equalsIgnoreCase(url.getProtocol())
-        && !shouldUseH2cPriorKnowledge(request.getURI())) {
+        && !shouldUseH2cPriorKnowledge(request.getURI())
+        && !Boolean.TRUE.equals(request.getAttributes().get(ATTR_SKIP_H2C_UPGRADE))) {
       Mutable headers = ((Mutable) request.getHeaders());
       addHeaderIfMissing(HttpHeader.UPGRADE, "h2c", headers);
       addHeaderIfMissing(HttpHeader.HTTP2_SETTINGS, buildH2cSettingsHeaderValue(), headers);
@@ -3475,13 +3497,18 @@ public class HTTP2JettyClient {
     }
   }
 
-  private void setBody(Request request, HTTP2Sampler sampler, HTTPSampleResult result)
+  private void setBody(Request request, HTTP2Sampler sampler, HTTPSampleResult result,
+                       boolean areFollowingRedirect)
       throws IOException {
+    if (!shouldAttachRequestBody(sampler, result, areFollowingRedirect)) {
+      result.setQueryString("");
+      return;
+    }
     String contentEncoding = sampler.getContentEncoding();
     String contentTypeHeader =
         request.getHeaders() != null ? request.getHeaders().get(HTTPConstants.HEADER_CONTENT_TYPE)
             : null;
-    boolean hasContentTypeHeader = contentTypeHeader != null && contentTypeHeader.isEmpty();
+    boolean hasContentTypeHeader = StringUtils.isNotBlank(contentTypeHeader);
     StringBuilder postBody = new StringBuilder();
     if (sampler.getUseMultipart()) {
       // In Jetty 12, MultiPartRequestContent API has changed significantly
@@ -3554,44 +3581,56 @@ public class HTTP2JettyClient {
         request.body(requestContent);
         postBody.append("<actual file content, not shown here>");
       } else {
-        if (!hasContentTypeHeader && ADD_CONTENT_TYPE_TO_POST_IF_MISSING) {
-          HttpFields headers = request.getHeaders();
-          if (headers instanceof HttpFields.Mutable) {
-            ((HttpFields.Mutable) headers).put(HTTPConstants.HEADER_CONTENT_TYPE,
-                HTTPConstants.APPLICATION_X_WWW_FORM_URLENCODED);
-          }
-        }
         Charset contentCharset = buildCharsetOrDefault(contentEncoding, StandardCharsets.UTF_8);
         if (sampler.getSendParameterValuesAsPostBody()) {
+          if (!hasContentTypeHeader) {
+            HttpFields headers = request.getHeaders();
+            if (headers instanceof HttpFields.Mutable) {
+              ((HttpFields.Mutable) headers).put(HTTPConstants.HEADER_CONTENT_TYPE,
+                  "text/plain; charset=" + contentCharset.name());
+            }
+          }
           for (JMeterProperty jMeterProperty : sampler.getArguments()) {
             HTTPArgument arg = (HTTPArgument) jMeterProperty.getObjectValue();
             postBody.append(arg.getEncodedValue(contentCharset.name()));
           }
+          String bodyContentType = request.getHeaders() != null
+              ? request.getHeaders().get(HTTPConstants.HEADER_CONTENT_TYPE)
+              : null;
           // In Jetty 12, StringRequestContent implements Request.Content directly
           Request.Content requestContent =
-              new StringRequestContent(contentTypeHeader, postBody.toString(),
-                  contentCharset);
+              new StringRequestContent(bodyContentType, postBody.toString(), contentCharset);
           request.body(requestContent);
-        } else if (isMethodWithBody(sampler.getMethod())) {
-          Fields fields = new Fields();
-          for (JMeterProperty p : sampler.getArguments()) {
-            HTTPArgument arg = (HTTPArgument) p.getObjectValue();
-            String parameterName = arg.getName();
-            if (!arg.isSkippable(parameterName)) {
-              String parameterValue = arg.getValue();
-              if (!arg.isAlwaysEncoded()) {
-                // The FormRequestContent always urlencodes both name and value, in this case the
-                // value is already encoded by the user so is needed to decode the value now, so
-                // that when the httpclient encodes it, we end up with the same value as the user
-                // had entered.
-                parameterName = URLDecoder.decode(parameterName, contentCharset.name());
-                parameterValue = URLDecoder.decode(parameterValue, contentCharset.name());
-              }
-              fields.add(parameterName, parameterValue);
+        } else {
+          if (!hasContentTypeHeader && ADD_CONTENT_TYPE_TO_POST_IF_MISSING
+              && isMethodWithBody(sampler.getMethod())) {
+            HttpFields headers = request.getHeaders();
+            if (headers instanceof HttpFields.Mutable) {
+              ((HttpFields.Mutable) headers).put(HTTPConstants.HEADER_CONTENT_TYPE,
+                  HTTPConstants.APPLICATION_X_WWW_FORM_URLENCODED);
             }
           }
-          postBody.append(FormRequestContent.convert(fields));
-          request.body(new FormRequestContent(fields, contentCharset));
+          if (isMethodWithBody(sampler.getMethod())) {
+            Fields fields = new Fields();
+            for (JMeterProperty p : sampler.getArguments()) {
+              HTTPArgument arg = (HTTPArgument) p.getObjectValue();
+              String parameterName = arg.getName();
+              if (!arg.isSkippable(parameterName)) {
+                String parameterValue = arg.getValue();
+                if (!arg.isAlwaysEncoded()) {
+                  // The FormRequestContent always urlencodes both name and value, in this case
+                  // the value is already encoded by the user so is needed to decode the value
+                  // now, so that when the httpclient encodes it, we end up with the same value
+                  // as the user had entered.
+                  parameterName = URLDecoder.decode(parameterName, contentCharset.name());
+                  parameterValue = URLDecoder.decode(parameterValue, contentCharset.name());
+                }
+                fields.add(parameterName, parameterValue);
+              }
+            }
+            postBody.append(FormRequestContent.convert(fields));
+            request.body(new FormRequestContent(fields, contentCharset));
+          }
         }
       }
     }
@@ -3777,6 +3816,29 @@ public class HTTP2JettyClient {
 
   private boolean isMethodWithBody(String method) {
     return METHODS_WITH_BODY.contains(method);
+  }
+
+  /**
+   * Matches HttpClient4: entities are only attached for POST/PUT/PATCH, or GET/DELETE when
+   * {@code postBodyRaw} is enabled ({@code HttpGetWithEntity}).
+   */
+  private boolean shouldAttachRequestBody(HTTP2Sampler sampler, HTTPSampleResult result,
+                                          boolean areFollowingRedirect) {
+    String method = resolveRequestMethod(sampler, result);
+    if (areFollowingRedirect && !isMethodWithBody(method)) {
+      return false;
+    }
+    if (isMethodWithBody(method)) {
+      return true;
+    }
+    return sampler.getSendParameterValuesAsPostBody();
+  }
+
+  private String resolveRequestMethod(HTTP2Sampler sampler, HTTPSampleResult result) {
+    if (result != null && StringUtils.isNotBlank(result.getHTTPMethod())) {
+      return result.getHTTPMethod();
+    }
+    return sampler.getMethod();
   }
 
   private boolean isSupportedMethod(String method) {

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientBodyAttachAndContentTypeTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientBodyAttachAndContentTypeTest.java
@@ -1,0 +1,160 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import java.lang.reflect.Method;
+import java.net.URL;
+import org.apache.jmeter.protocol.http.control.Header;
+import org.apache.jmeter.protocol.http.control.HeaderManager;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * HttpClient4 only attaches an entity for POST/PUT/PATCH, or for GET/DELETE when
+ * {@code postBodyRaw} is enabled; and it never overwrites a {@code Content-Type} header the
+ * user already set. {@link HTTP2JettyClient#setBody} used to attach a body regardless of the
+ * request method, and its {@code hasContentTypeHeader} check was inverted
+ * ({@code contentTypeHeader != null && contentTypeHeader.isEmpty()}, true only when the header
+ * exists AND is blank), so it treated almost every real Content-Type header as absent and
+ * clobbered it. Fixing that also lets a bodied cleartext request skip the {@code Upgrade: h2c}
+ * dance entirely (see {@code ATTR_SKIP_H2C_UPGRADE}), since attaching a body to an in-flight h2c
+ * upgrade isn't well-supported.
+ */
+public class HTTP2JettyClientBodyAttachAndContentTypeTest extends HTTP2TestBase {
+
+  private TeardownableServer server;
+  private HTTP2JettyClient client;
+
+  @After
+  public void tearDown() throws Exception {
+    if (client != null) {
+      client.stop();
+    }
+    if (server != null) {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void preservesExplicitContentTypeHeaderForRawPostBody() throws Exception {
+    HTTPSampleResult result = sampleRawPostBody("application/json");
+
+    assertThat(result.getRequestHeaders()).contains("Content-Type: application/json");
+  }
+
+  @Test
+  public void defaultsRawPostBodyContentTypeToTextPlainWhenNotSet() throws Exception {
+    HTTPSampleResult result = sampleRawPostBody(null);
+
+    assertThat(result.getRequestHeaders()).contains("Content-Type: text/plain; charset=UTF-8");
+  }
+
+  @Test
+  public void skipsH2cUpgradeHeadersForCleartextRequestWithBody() throws Exception {
+    int port = startHttp1OnlyServer();
+    // http1UpgradeRequired=true: the client would normally attempt the Upgrade: h2c dance on
+    // this cleartext origin (see HTTP2JettyClientH2cFallbackTest for that base behavior with a
+    // bodyless GET); a bodied request must skip it instead.
+    client = new HTTP2JettyClient(true, "skip-h2c-upgrade-test");
+    client.start();
+
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.POST);
+    sampler.setDomain("localhost");
+    sampler.setPort(port);
+    sampler.setPath(ServerBuilder.SERVER_PATH_200_WITH_BODY);
+    sampler.setProtocol("http");
+    sampler.setPostBodyRaw(true);
+    sampler.addArgument("", "payload");
+
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setSampleLabel("POST_SKIP_H2C_UPGRADE");
+    result.setHTTPMethod(HTTPConstants.POST);
+    result.setURL(new URL("http", "localhost", port, ServerBuilder.SERVER_PATH_200_WITH_BODY));
+
+    HTTPSampleResult sampled = client.sample(sampler, result, false, 0);
+
+    assertThat(sampled.isSuccessful()).isTrue();
+    assertThat(sampled.getRequestHeaders()).doesNotContainIgnoringCase("upgrade");
+  }
+
+  @Test
+  public void attachesBodyForPostRegardlessOfPostBodyRawFlag() throws Exception {
+    assertThat(invokeShouldAttachRequestBody(HTTPConstants.POST, false, false)).isTrue();
+    assertThat(invokeShouldAttachRequestBody(HTTPConstants.PUT, false, false)).isTrue();
+    assertThat(invokeShouldAttachRequestBody(HTTPConstants.PATCH, false, false)).isTrue();
+  }
+
+  @Test
+  public void onlyAttachesBodyForGetOrDeleteWhenPostBodyRawEnabled() throws Exception {
+    assertThat(invokeShouldAttachRequestBody(HTTPConstants.GET, false, false)).isFalse();
+    assertThat(invokeShouldAttachRequestBody(HTTPConstants.GET, true, false)).isTrue();
+    assertThat(invokeShouldAttachRequestBody(HTTPConstants.DELETE, false, false)).isFalse();
+    assertThat(invokeShouldAttachRequestBody(HTTPConstants.DELETE, true, false)).isTrue();
+  }
+
+  @Test
+  public void neverAttachesBodyWhenFollowingARedirectToANonBodyMethod() throws Exception {
+    // A 302/303 redirect downgrades the follow-up request to GET, dropping any original body -
+    // matching HttpClient4, which never resends an entity after that kind of redirect.
+    assertThat(invokeShouldAttachRequestBody(HTTPConstants.GET, true, true)).isFalse();
+    assertThat(invokeShouldAttachRequestBody(HTTPConstants.POST, false, true)).isTrue();
+  }
+
+  private HTTPSampleResult sampleRawPostBody(String explicitContentType) throws Exception {
+    int port = startHttp1OnlyServer();
+    client = new HTTP2JettyClient(false, "raw-post-body-content-type-test");
+    client.start();
+
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.POST);
+    sampler.setDomain("localhost");
+    sampler.setPort(port);
+    sampler.setPath(ServerBuilder.SERVER_PATH_200_WITH_BODY);
+    sampler.setProtocol("http");
+    sampler.setPostBodyRaw(true);
+    sampler.addArgument("", "raw-body-content");
+    if (explicitContentType != null) {
+      HeaderManager headerManager = new HeaderManager();
+      headerManager.add(new Header(HttpHeader.CONTENT_TYPE.asString(), explicitContentType));
+      sampler.setHeaderManager(headerManager);
+    }
+
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setSampleLabel("POST_RAW_BODY_CONTENT_TYPE");
+    result.setHTTPMethod(HTTPConstants.POST);
+    result.setURL(new URL("http", "localhost", port, ServerBuilder.SERVER_PATH_200_WITH_BODY));
+
+    return client.sample(sampler, result, false, 0);
+  }
+
+  private int startHttp1OnlyServer() throws Exception {
+    server = new ServerBuilder().withHTTP1().buildServer();
+    server.start();
+    return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+  }
+
+  private boolean invokeShouldAttachRequestBody(String method, boolean postBodyRaw,
+                                                boolean areFollowingRedirect) throws Exception {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(method);
+    sampler.setPostBodyRaw(postBodyRaw);
+
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setHTTPMethod(method);
+
+    HTTP2JettyClient reflectionClient = new HTTP2JettyClient(false, "should-attach-body-test");
+    Method shouldAttachRequestBody = HTTP2JettyClient.class.getDeclaredMethod(
+        "shouldAttachRequestBody", HTTP2Sampler.class, HTTPSampleResult.class, boolean.class);
+    shouldAttachRequestBody.setAccessible(true);
+    return (boolean) shouldAttachRequestBody.invoke(
+        reflectionClient, sampler, result, areFollowingRedirect);
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
@@ -453,7 +453,7 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
     String requestBody = TEST_ARGUMENT_1 + TEST_ARGUMENT_2;
     HTTPSampleResult httpSampleResult = buildResult(true, Code.OK,
         hostHeader(),
-        requestBody.getBytes(StandardCharsets.UTF_8), "application/octet-stream",
+        requestBody.getBytes(StandardCharsets.UTF_8), "text/plain; charset=UTF-8",
         createURL(SERVER_PATH_200_WITH_BODY), HTTPConstants.POST);
 
     validateResponse(sample(SERVER_PATH_200_WITH_BODY, HTTPConstants.POST), httpSampleResult);
@@ -628,7 +628,7 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
         buildResult(true, HttpStatus.Code.OK, HttpFields.build().add(HttpHeader.HOST,
                 hostHeaderValue()),
             requestBody.getBytes(StandardCharsets.UTF_8),
-        "application/octet-stream", createURL(SERVER_PATH_200_WITH_BODY),
+        "text/plain; charset=UTF-8", createURL(SERVER_PATH_200_WITH_BODY),
         HTTPConstants.DELETE);
 
     validateResponse(sample(SERVER_PATH_200_WITH_BODY, HTTPConstants.DELETE), expected);


### PR DESCRIPTION
This pull request updates the HTTP/2 client implementation to more closely match Apache HttpClient4 behavior regarding when to attach request bodies and how to set the `Content-Type` header. It also improves compatibility with cleartext HTTP/1.1 servers by skipping the HTTP/2 upgrade attempt for bodied requests, and fixes a bug where user-specified `Content-Type` headers could be overwritten. Comprehensive tests are added to validate the new logic.

**Request body and Content-Type handling improvements:**

* Refactored the logic for attaching request bodies so that bodies are only sent for `POST`, `PUT`, `PATCH`, or for `GET`/`DELETE` when "Post Body Raw" is enabled, matching HttpClient4 behavior. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR3821-R3843) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL3478-R3511)
* Fixed the detection of user-specified `Content-Type` headers—these are now preserved and not overwritten by the client. The default for raw post bodies is now `text/plain; charset=UTF-8` instead of `application/octet-stream`. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL3557-R3624) [[2]](diffhunk://#diff-ecc5436f1e468983f5a6e6c8ccc9d551ff7052cd40f589248596fbde0406a407L456-R456) [[3]](diffhunk://#diff-ecc5436f1e468983f5a6e6c8ccc9d551ff7052cd40f589248596fbde0406a407L631-R631)

**HTTP/2 cleartext upgrade handling:**

* Added logic to skip the `Upgrade: h2c` HTTP/2 upgrade attempt for cleartext requests with bodies, improving compatibility with servers that do not support bodied upgrades. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR1402-R1422) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL3191-R3213) [[3]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL3104-R3125)

**Testing and validation:**

* Added a new test class `HTTP2JettyClientBodyAttachAndContentTypeTest` to cover all the new and fixed behaviors, including body attachment logic, content type preservation, and upgrade skipping.

These changes make the HTTP/2 client more robust, standards-compliant, and compatible with real-world servers and user expectations.