### PR TITLE
Fix multipart header casing and raw argument values

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -3656,6 +3656,11 @@ public class HTTP2JettyClient {
     return !contentEncoding.isEmpty() ? Charset.forName(contentEncoding) : defaultCharset;
   }
 
+  /** HttpClient4 writes raw argument values in multipart parts (not URL-encoded). */
+  private static String multipartArgumentValue(HTTPArgument arg) {
+    return arg.getValue();
+  }
+
   private String buildArgumentPartRequestBody(HTTPArgument arg, Charset contentCharset,
                                               String contentEncoding, String boundary)
       throws UnsupportedEncodingException {
@@ -3663,18 +3668,27 @@ public class HTTP2JettyClient {
     String contentType = arg.getContentType() + "; charset=" + contentCharset.name();
     String encoding = StringUtils.isNotBlank(contentEncoding) ? contentEncoding : "8bit";
     return buildPartBody(boundary, disposition, contentType, encoding,
-        arg.getEncodedValue(contentCharset.name()));
+        multipartArgumentValue(arg));
   }
 
   private String buildPartBody(String boundary, String disposition, String contentType,
                                String encoding, String value) {
-    return MULTI_PART_SEPARATOR + boundary + LINE_SEPARATOR +
-        HttpFields.build()
-            .add("Content-Disposition", "form-data; " + disposition)
-            .add(HttpHeader.CONTENT_TYPE.toString(), contentType)
-            .add("Content-Transfer-Encoding", encoding)
-            .toString()
+    return MULTI_PART_SEPARATOR + boundary + LINE_SEPARATOR
+        + formatMultipartPartHeaders("form-data; " + disposition, contentType, encoding)
         + value + LINE_SEPARATOR;
+  }
+
+  /** HC4 canonical header casing; Jetty {@link HttpFields#toString()} lowercases names. */
+  private String formatMultipartPartHeaders(String disposition, String contentType,
+                                            String transferEncoding) {
+    StringBuilder headers = new StringBuilder();
+    headers.append("Content-Disposition: ").append(disposition).append(LINE_SEPARATOR);
+    headers.append("Content-Type: ").append(contentType).append(LINE_SEPARATOR);
+    if (transferEncoding != null && !transferEncoding.isEmpty()) {
+      headers.append("Content-Transfer-Encoding: ").append(transferEncoding)
+          .append(LINE_SEPARATOR);
+    }
+    return headers.toString();
   }
 
   private String buildFilePartRequestBody(HTTPFileArg file, String fileName, String boundary) {
@@ -3725,14 +3739,12 @@ public class HTTP2JettyClient {
         argContentType = argContentType + "; charset="
             + contentCharset.name().toLowerCase(Locale.ROOT);
 
-        Mutable partHeaders = HttpFields.build()
-            .add("Content-Disposition", "form-data; name=\"" + arg.getEncodedName() + "\"")
-            .add(HttpHeader.CONTENT_TYPE, argContentType);
+        String partHeaders = formatMultipartPartHeaders(
+            "form-data; name=\"" + arg.getEncodedName() + "\"", argContentType, "8bit");
 
         output.write(boundaryLine.getBytes(StandardCharsets.US_ASCII));
-        output.write(partHeaders.toString().getBytes(StandardCharsets.US_ASCII));
-        output.write(newLine.getBytes(StandardCharsets.US_ASCII));
-        String argValue = arg.getEncodedValue(contentCharset.name());
+        output.write(partHeaders.getBytes(StandardCharsets.US_ASCII));
+        String argValue = multipartArgumentValue(arg);
         output.write(argValue.getBytes(contentCharset));
         output.write(newLine.getBytes(StandardCharsets.US_ASCII));
       }
@@ -3746,16 +3758,12 @@ public class HTTP2JettyClient {
       String fileName = Paths.get(file.getPath()).getFileName().toString();
       String mimeTypeFile = extractFileMimeType(hasContentTypeHeader, file);
 
-      // Build headers using HttpFields to match the format expected by tests
-      // The test uses HttpFields.build().toString() which has a specific format
-      Mutable partHeaders = HttpFields.build()
-          .add("Content-Disposition",
-              "form-data; name=\"" + file.getParamName() + "\"; filename=\"" + fileName + "\"")
-          .add(HttpHeader.CONTENT_TYPE, mimeTypeFile);
+      String partHeaders = formatMultipartPartHeaders(
+          "form-data; name=\"" + file.getParamName() + "\"; filename=\"" + fileName + "\"",
+          mimeTypeFile, "binary");
 
       output.write(boundaryLine.getBytes(StandardCharsets.US_ASCII));
-      output.write(partHeaders.toString().getBytes(StandardCharsets.US_ASCII));
-      output.write(newLine.getBytes(StandardCharsets.US_ASCII));
+      output.write(partHeaders.getBytes(StandardCharsets.US_ASCII));
 
       // Read and write file content
       try (InputStream fileStream = Files.newInputStream(Paths.get(file.getPath()))) {

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientMultipartHeaderCasingTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientMultipartHeaderCasingTest.java
@@ -1,0 +1,66 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import java.lang.reflect.Method;
+import org.apache.jmeter.protocol.http.util.HTTPArgument;
+import org.junit.Test;
+
+/**
+ * HttpClient4's multipart writer (Apache HttpMime) writes part headers with canonical casing
+ * ({@code Content-Disposition}, {@code Content-Type}, {@code Content-Transfer-Encoding}) and puts
+ * the raw argument value in the part body, never URL-encoded. {@link HTTP2JettyClient} used to
+ * build these part headers with Jetty's {@code HttpFields}, which lowercases header names and
+ * omitted {@code Content-Transfer-Encoding} entirely, and wrote {@code arg.getEncodedValue(...)}
+ * instead of the raw value.
+ */
+public class HTTP2JettyClientMultipartHeaderCasingTest extends HTTP2TestBase {
+
+  private static final HTTP2JettyClient CLIENT = new HTTP2JettyClient(false, "multipart-test");
+
+  @Test
+  public void formatsPartHeadersWithCanonicalCasingAndTransferEncoding() throws Exception {
+    String headers = invokeFormatMultipartPartHeaders(
+        "form-data; name=\"field\"", "text/plain; charset=utf-8", "8bit");
+
+    assertThat(headers).isEqualTo(
+        "Content-Disposition: form-data; name=\"field\"\r\n"
+            + "Content-Type: text/plain; charset=utf-8\r\n"
+            + "Content-Transfer-Encoding: 8bit\r\n");
+  }
+
+  @Test
+  public void omitsTransferEncodingLineWhenNotProvided() throws Exception {
+    String headers = invokeFormatMultipartPartHeaders(
+        "form-data; name=\"field\"", "text/plain", null);
+
+    assertThat(headers).isEqualTo(
+        "Content-Disposition: form-data; name=\"field\"\r\n"
+            + "Content-Type: text/plain\r\n");
+  }
+
+  @Test
+  public void multipartArgumentValueReturnsRawValueNotUrlEncoded() throws Exception {
+    HTTPArgument arg = new HTTPArgument("field", "a value & more = stuff");
+
+    String value = invokeMultipartArgumentValue(arg);
+
+    assertThat(value).isEqualTo("a value & more = stuff");
+  }
+
+  private String invokeFormatMultipartPartHeaders(String disposition, String contentType,
+                                                   String transferEncoding) throws Exception {
+    Method method = HTTP2JettyClient.class.getDeclaredMethod(
+        "formatMultipartPartHeaders", String.class, String.class, String.class);
+    method.setAccessible(true);
+    return (String) method.invoke(CLIENT, disposition, contentType, transferEncoding);
+  }
+
+  private String invokeMultipartArgumentValue(HTTPArgument arg) throws Exception {
+    Method method = HTTP2JettyClient.class.getDeclaredMethod(
+        "multipartArgumentValue", HTTPArgument.class);
+    method.setAccessible(true);
+    return (String) method.invoke(null, arg);
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
@@ -1140,14 +1140,16 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
     String dashDash = "--";
     // Set body response for Arguments
     args.forEach(httpArgument -> {
-      Mutable headerParam = HttpFields.build()
-          .add("Content-Disposition", "form-data; name=\"" + httpArgument.getEncodedName() + "\"")
-          .add(HttpHeader.CONTENT_TYPE, "text/plain; charset=utf-8");
+      // Canonical HC4 header casing (not Jetty's HttpFields, which lowercases names) and an
+      // explicit Content-Transfer-Encoding, matching HTTP2JettyClient#formatMultipartPartHeaders.
+      String headerParam = "Content-Disposition: form-data; name=\""
+          + httpArgument.getEncodedName() + "\"" + newLine
+          + "Content-Type: text/plain; charset=utf-8" + newLine
+          + "Content-Transfer-Encoding: 8bit" + newLine;
       try {
-        String headerParamWithBoundary = boundary + newLine + headerParam.toString();
+        String headerParamWithBoundary = boundary + newLine + headerParam;
         output.write(headerParamWithBoundary.getBytes(StandardCharsets.US_ASCII));
-        output.write(newLine.getBytes(StandardCharsets.US_ASCII));
-        output.write(httpArgument.getEncodedValue().getBytes(StandardCharsets.UTF_8));
+        output.write(httpArgument.getValue().getBytes(StandardCharsets.UTF_8));
         output.write(newLine.getBytes(StandardCharsets.US_ASCII));
       } catch (IOException e) {
         e.printStackTrace();
@@ -1157,17 +1159,16 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
     // Set body response for Files
     files.forEach(file -> {
       String fileName = Paths.get((file.getPath())).getFileName().toString();
-      Mutable headerFile = HttpFields.build()
-          .add("Content-Disposition", "form-data; name=\"" + file.getParamName()
-              + "\"; " + "filename=\"" + fileName + "\"")
-          .add(HttpHeader.CONTENT_TYPE, file.getMimeType());
+      String headerFile = "Content-Disposition: form-data; name=\"" + file.getParamName()
+          + "\"; filename=\"" + fileName + "\"" + newLine
+          + "Content-Type: " + file.getMimeType() + newLine
+          + "Content-Transfer-Encoding: binary" + newLine;
       try {
         String filePath = file.getPath();
         InputStream inputStream = Files.newInputStream(Paths.get(filePath));
         byte[] data = sampler.readResponse(expected, inputStream, 0);
-        String headerFileWithBoundary = boundary + newLine + headerFile.toString();
+        String headerFileWithBoundary = boundary + newLine + headerFile;
         output.write(headerFileWithBoundary.getBytes(StandardCharsets.US_ASCII));
-        output.write(newLine.getBytes(StandardCharsets.US_ASCII));
         output.write(data);
         output.write(newLine.getBytes(StandardCharsets.US_ASCII));
       } catch (IOException e) {


### PR DESCRIPTION
This pull request updates how HTTP multipart form data is constructed and tested to match the behavior of Apache HttpClient4 (HC4). The main changes ensure that multipart part headers use canonical casing (e.g., `Content-Disposition` instead of lowercase) and that argument values are not URL-encoded in the part body. Several refactorings and new tests were added to verify this behavior.

**Multipart header formatting and value handling:**

* Refactored `HTTP2JettyClient` to generate multipart part headers with canonical casing and always include the `Content-Transfer-Encoding` header when appropriate, replacing the previous use of Jetty's `HttpFields` which lowercased header names and sometimes omitted this header. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR3659-R3693) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL3728-R3747) [[3]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL3749-R3766)
* Updated multipart argument handling to write the raw value (not URL-encoded) in the part body, matching HC4 behavior. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR3659-R3693) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL3728-R3747)

**Testing improvements:**

* Added a dedicated test class `HTTP2JettyClientMultipartHeaderCasingTest` to verify correct header casing and argument value handling in multipart parts.
* Updated multipart test construction in `HTTP2JettyClientTest` to expect canonical header casing and the presence of `Content-Transfer-Encoding`, and to use the raw argument value instead of the encoded value. [[1]](diffhunk://#diff-ecc5436f1e468983f5a6e6c8ccc9d551ff7052cd40f589248596fbde0406a407L1143-R1152) [[2]](diffhunk://#diff-ecc5436f1e468983f5a6e6c8ccc9d551ff7052cd40f589248596fbde0406a407L1160-L1170)