### PR TITLE
Resolve HTTP file arguments in FileServer

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -11,6 +11,7 @@ import com.blazemeter.jmeter.http2.util.BzmHttpPluginProperties;
 import com.github.luben.zstd.ZstdInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -62,6 +63,7 @@ import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
 import org.apache.jmeter.protocol.http.util.HTTPArgument;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.protocol.http.util.HTTPFileArg;
+import org.apache.jmeter.services.FileServer;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.util.JMeterUtils;
 import org.brotli.dec.BrotliInputStream;
@@ -3546,7 +3548,7 @@ public class HTTP2JettyClient {
         if (StringUtils.isBlank(file.getParamName())) {
           throw new IllegalStateException("Param name is blank");
         }
-        String fileName = Paths.get((file.getPath())).getFileName().toString();
+        String fileName = resolveHttpFile(file.getPath()).getName();
         postBody.append(buildFilePartRequestBody(file, fileName, boundary));
       }
       postBody.append(MULTI_PART_SEPARATOR).append(boundary).append(MULTI_PART_SEPARATOR)
@@ -3571,7 +3573,7 @@ public class HTTP2JettyClient {
         }
         // In Jetty 12, PathRequestContent implements Request.Content directly
         Request.Content requestContent =
-            new PathRequestContent(mimeTypeFile, Path.of(file.getPath()));
+            new PathRequestContent(mimeTypeFile, resolveHttpFile(file.getPath()).toPath());
         request.body(requestContent);
         postBody.append("<actual file content, not shown here>");
       } else {
@@ -3731,6 +3733,26 @@ public class HTTP2JettyClient {
   }
 
   /**
+   * Resolves a sampler file path the same way HttpClient4 does: relative to the running test
+   * plan's directory via {@link FileServer}, falling back to JMeter's {@code bin} directory for
+   * files bundled alongside JMeter itself.
+   */
+  private File resolveHttpFile(String path) throws IOException {
+    if (StringUtils.isBlank(path)) {
+      throw new IOException("Empty HTTP file path");
+    }
+    File resolved = FileServer.getFileServer().getResolvedFile(path);
+    if (resolved.isFile()) {
+      return resolved;
+    }
+    Path inBin = Paths.get(JMeterUtils.getJMeterBinDir(), path);
+    if (Files.isRegularFile(inBin)) {
+      return inBin.toFile();
+    }
+    throw new IOException("HTTP file not found: " + path);
+  }
+
+  /**
    * Builds multipart/form-data body as bytes for Jetty 12.
    * In Jetty 12, MultiPartRequestContent API changed, so we build the body manually.
    *
@@ -3776,7 +3798,8 @@ public class HTTP2JettyClient {
       if (StringUtils.isBlank(file.getParamName())) {
         throw new IllegalStateException("Param name is blank");
       }
-      String fileName = Paths.get(file.getPath()).getFileName().toString();
+      File resolvedFile = resolveHttpFile(file.getPath());
+      String fileName = resolvedFile.getName();
       String mimeTypeFile = extractFileMimeType(hasContentTypeHeader, file);
 
       String partHeaders = formatMultipartPartHeaders(
@@ -3787,7 +3810,7 @@ public class HTTP2JettyClient {
       output.write(partHeaders.getBytes(StandardCharsets.US_ASCII));
 
       // Read and write file content
-      try (InputStream fileStream = Files.newInputStream(Paths.get(file.getPath()))) {
+      try (InputStream fileStream = Files.newInputStream(resolvedFile.toPath())) {
         byte[] buffer = new byte[8192];
         int bytesRead;
         while ((bytesRead = fileStream.read(buffer)) != -1) {

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientFileResolutionTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientFileResolutionTest.java
@@ -1,0 +1,112 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.protocol.http.util.HTTPFileArg;
+import org.apache.jmeter.services.FileServer;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * HttpClient4 resolves an HTTP request file argument via {@link FileServer}, relative to the
+ * running test plan's directory (falling back to JMeter's {@code bin} dir) - not relative to the
+ * JVM's working directory. {@link HTTP2JettyClient} used to call {@code Paths.get(file.getPath())}
+ * directly, so a relative path that resolves fine for a real JMeter test plan would fail here.
+ */
+public class HTTP2JettyClientFileResolutionTest extends HTTP2TestBase {
+
+  private TeardownableServer server;
+  private HTTP2JettyClient client;
+  private Path tempDir;
+
+  @After
+  public void tearDown() throws Exception {
+    FileServer.getFileServer().resetBase();
+    if (client != null) {
+      client.stop();
+    }
+    if (server != null) {
+      server.stop();
+    }
+    if (tempDir != null) {
+      Files.walk(tempDir)
+          .sorted(java.util.Comparator.reverseOrder())
+          .forEach(path -> path.toFile().delete());
+    }
+  }
+
+  @Test
+  public void resolvesSingleFilePostBodyRelativeToFileServerBaseDir() throws Exception {
+    String fileContent = "resolved-via-fileserver-base-dir";
+    tempDir = Files.createTempDirectory("http2-file-resolution-test");
+    Files.write(tempDir.resolve("upload.txt"), fileContent.getBytes(StandardCharsets.UTF_8));
+    FileServer.getFileServer().setBase(tempDir.toFile());
+
+    int port = startHttp1OnlyServer();
+    client = new HTTP2JettyClient(false, "file-resolution-test");
+    client.start();
+
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.POST);
+    sampler.setDomain("localhost");
+    sampler.setPort(port);
+    sampler.setPath(ServerBuilder.SERVER_PATH_200_FILE_SENT);
+    sampler.setProtocol("http");
+    // Bare filename, no directory: can only resolve via FileServer's configured base dir, never
+    // via a plain Paths.get(...) relative to the JVM's working directory.
+    sampler.setHTTPFiles(new HTTPFileArg[] {new HTTPFileArg("upload.txt", "", "text/plain")});
+
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setSampleLabel("POST_FILE_RESOLUTION");
+    result.setHTTPMethod(HTTPConstants.POST);
+    result.setURL(new URL("http", "localhost", port, ServerBuilder.SERVER_PATH_200_FILE_SENT));
+
+    HTTPSampleResult sampled = client.sample(sampler, result, false, 0);
+
+    assertThat(sampled.isSuccessful()).isTrue();
+    assertThat(sampled.getResponseDataAsString()).isEqualTo(fileContent);
+  }
+
+  @Test
+  public void throwsAClearErrorWhenFileCannotBeResolvedAnywhere() throws Exception {
+    tempDir = Files.createTempDirectory("http2-file-resolution-test-missing");
+    FileServer.getFileServer().setBase(tempDir.toFile());
+
+    int port = startHttp1OnlyServer();
+    client = new HTTP2JettyClient(false, "file-resolution-missing-test");
+    client.start();
+
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.POST);
+    sampler.setDomain("localhost");
+    sampler.setPort(port);
+    sampler.setPath(ServerBuilder.SERVER_PATH_200_FILE_SENT);
+    sampler.setProtocol("http");
+    sampler.setHTTPFiles(
+        new HTTPFileArg[] {new HTTPFileArg("does-not-exist.txt", "", "text/plain")});
+
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setSampleLabel("POST_FILE_RESOLUTION_MISSING");
+    result.setHTTPMethod(HTTPConstants.POST);
+    result.setURL(new URL("http", "localhost", port, ServerBuilder.SERVER_PATH_200_FILE_SENT));
+
+    org.junit.Assert.assertThrows(java.io.IOException.class,
+        () -> client.sample(sampler, result, false, 0));
+  }
+
+  private int startHttp1OnlyServer() throws Exception {
+    server = new ServerBuilder().withHTTP1().buildServer();
+    server.start();
+    return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+  }
+}


### PR DESCRIPTION
This pull request improves how HTTP file arguments are resolved in `HTTP2JettyClient`, ensuring compatibility with JMeter's `FileServer` logic. Previously, file paths were resolved relative to the JVM working directory, which could cause failures when running test plans that rely on JMeter's file resolution behavior. The changes introduce a dedicated method to resolve file paths in the same way as HttpClient4, and add comprehensive tests to verify the new behavior.

**File resolution improvements:**

* Added a `resolveHttpFile` method to `HTTP2JettyClient` that resolves file paths relative to the running test plan's directory using `FileServer`, and falls back to JMeter's `bin` directory if necessary. This ensures file arguments are located consistently with HttpClient4's behavior.
* Updated all usages of file path resolution in multipart request building and file uploads to use the new `resolveHttpFile` method instead of directly calling `Paths.get(...)`. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL3549-R3551) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL3574-R3576) [[3]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL3779-R3802) [[4]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL3790-R3813)

**Testing enhancements:**

* Added a new test class, `HTTP2JettyClientFileResolutionTest`, which verifies that file arguments are resolved relative to the test plan's directory and that clear errors are thrown when files cannot be found.

**Dependency updates:**

* Added imports for `File` and `FileServer` to support the new file resolution logic. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR14) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR66)