### PR TITLE
Support file:// URLs in sampler

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -19,6 +19,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.net.URLDecoder;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
@@ -142,6 +143,11 @@ public class HTTP2JettyClient {
   private static final Path ALPN_DEBUG_LOG_PATH = resolveAlpnLogPath();
   private static final boolean ADD_CONTENT_TYPE_TO_POST_IF_MISSING = JMeterUtils.getPropDefault(
       "http.post_add_content_type_if_missing", false);
+  // Matches HTTPFileImpl: caps stored response data for file:// samples, while sampleEnd's
+  // bodySize still reflects the true total bytes read.
+  private static final int MAX_FILE_SAMPLE_BYTES_TO_STORE = JMeterUtils.getPropDefault(
+      "httpsampler.max_bytes_to_store_per_request", 10 * 1024 * 1024);
+  private static final int FILE_SAMPLE_BUFFER_SIZE = 4096;
   private static final Pattern PORT_PATTERN = Pattern.compile("\\d+");
   private static final String MULTI_PART_SEPARATOR = "--";
   private static final String LINE_SEPARATOR = "\r\n";
@@ -1524,6 +1530,11 @@ public class HTTP2JettyClient {
     lowLevelDebug("=== HTTP2JettyClient.sample() called ===");
     lowLevelDebug("Method: {}, URL: {}", result.getHTTPMethod(), result.getURL());
 
+    URL sampleUrl = result.getURL();
+    if (sampleUrl != null && "file".equalsIgnoreCase(sampleUrl.getProtocol())) {
+      return sampleLocalFile(sampler, result, sampleUrl, areFollowingRedirect, depth);
+    }
+
     errorWhenNotSupportedMethod(result.getHTTPMethod());
     setAuthManager(sampler);
     RequestContext context = buildRequestContext(result, resolveClientForRequest(sampler, result));
@@ -1563,6 +1574,55 @@ public class HTTP2JettyClient {
 
     postContentResponse(sampler, request, result, contentResponse, cacheManager);
     result.setEndTime(listener.getResponseEnd());
+
+    resetSamplerDataBeforeResultProcessing(result);
+    return sampler.resultProcessing(areFollowingRedirect, depth, result);
+  }
+
+  /**
+   * Matches HttpClient4's {@code HTTPFileImpl}: {@code file://} samples always use GET, open the
+   * URL directly (Java's built-in {@code file} URL handler - relative paths resolve against the
+   * JVM's working directory, not via {@link org.apache.jmeter.services.FileServer}), and always
+   * report {@code text/html} as the content type regardless of the file's actual type, since this
+   * exists to test the HTML embedded-resource parser against local fixtures, not to serve
+   * arbitrary static files.
+   */
+  private HTTPSampleResult sampleLocalFile(HTTP2Sampler sampler, HTTPSampleResult result, URL url,
+                                           boolean areFollowingRedirect, int depth)
+      throws Exception {
+    result.setHTTPMethod(HTTPConstants.GET);
+    result.setURL(url);
+    result.setSampleLabel(url.toString());
+    result.sampleStart();
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream(FILE_SAMPLE_BUFFER_SIZE);
+    long totalBytes = 0;
+    URLConnection connection = url.openConnection();
+    try (InputStream inputStream = connection.getInputStream()) {
+      byte[] buffer = new byte[FILE_SAMPLE_BUFFER_SIZE];
+      int bytesRead;
+      while ((bytesRead = inputStream.read(buffer)) != -1) {
+        if (totalBytes < MAX_FILE_SAMPLE_BYTES_TO_STORE) {
+          int toStore = (int) Math.min(bytesRead, MAX_FILE_SAMPLE_BYTES_TO_STORE - totalBytes);
+          output.write(buffer, 0, toStore);
+        }
+        totalBytes += bytesRead;
+      }
+    }
+
+    result.sampleEnd();
+    result.setResponseData(output.toByteArray());
+    result.setBodySize(totalBytes);
+    result.setResponseCodeOK();
+    result.setResponseMessageOK();
+    result.setSuccessful(true);
+    String contentType = "text/html";
+    String contentEncoding = sampler.getContentEncoding();
+    if (StringUtils.isNotBlank(contentEncoding)) {
+      contentType = contentType + "; charset=" + contentEncoding;
+    }
+    result.setContentType(contentType);
+    result.setEncodingAndType(contentType);
 
     resetSamplerDataBeforeResultProcessing(result);
     return sampler.resultProcessing(areFollowingRedirect, depth, result);

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -658,6 +658,58 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
     embedded.setHttp1UpgradeEnabled(isHttp1UpgradeEnabled());
   }
 
+  /**
+   * Builds an embedded-resource child sampler for a {@code file://} URL discovered by the HTML
+   * parser (e.g. a relative {@code href}/{@code src} resolved against a {@code file://} parent).
+   * {@code setImageParser} is enabled for {@code .html}/{@code .htm} targets so nested embedded
+   * resources (e.g. an iframe pointing at another local HTML file) are themselves parsed and
+   * downloaded, matching how a real HTTP-embedded HTML resource would recurse.
+   */
+  private HTTP2Sampler newFileEmbeddedSampler(URL url) {
+    HTTP2Sampler fileSampler = new HTTP2Sampler();
+    copyJettyProtocolSettingsToEmbeddedSampler(fileSampler);
+    String path = url.getPath();
+    boolean htmlResource = path != null
+        && (path.endsWith(".html") || path.endsWith(".htm"));
+    fileSampler.setImageParser(htmlResource);
+    fileSampler.setMethod(HTTPConstants.GET);
+    fileSampler.setProtocol(url.getProtocol());
+    fileSampler.setDomain(url.getHost());
+    fileSampler.setPort(url.getPort());
+    if (url.getQuery() == null) {
+      fileSampler.setPath(url.getPath());
+    } else {
+      fileSampler.setPath(url.getPath() + url.getQuery());
+    }
+    fileSampler.setHeaderManager(getHeaderManager());
+    fileSampler.setCookieManager(getCookieManager());
+    return fileSampler;
+  }
+
+  /** {@code file://} URLs have no HTTP-style path to label sub-results with; build one instead. */
+  private static String formatFileEmbeddedLabel(URL url, int index) {
+    String path = url.getPath();
+    if (path != null && path.startsWith("/")) {
+      path = path.substring(1);
+    }
+    return url.getProtocol() + ":" + path + "-" + index;
+  }
+
+  private static void relabelFileEmbeddedChildren(HTTPSampleResult parent) {
+    int childIndex = 0;
+    for (SampleResult child : parent.getSubResults()) {
+      if (child instanceof HTTPSampleResult) {
+        HTTPSampleResult httpChild = (HTTPSampleResult) child;
+        if (httpChild.getURL() != null
+            && "file".equalsIgnoreCase(httpChild.getURL().getProtocol())) {
+          httpChild.setSampleLabel(
+              formatFileEmbeddedLabel(httpChild.getURL(), childIndex++));
+          relabelFileEmbeddedChildren(httpChild);
+        }
+      }
+    }
+  }
+
   private HTTP2JettyClient buildClient() throws Exception {
     HTTP2ClientKey connectionKey = buildConnectionKey();
     HTTP2JettyClient client = new HTTP2JettyClient(isHttp1UpgradeEnabled(),
@@ -933,6 +985,7 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
 
       setSyncRequest(!isConcurrentDwn); // Change default from main request based on sub request
 
+      int fileEmbeddedIndex = 0;
       while (urls.hasNext()) {
         Object binURL = urls.next(); // See catch clause below
         try {
@@ -962,6 +1015,20 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
                   errorResult(new Exception(url.toString() + " URI can not be normalized", e),
                       new HTTPSampleResult(subres)));
               setParentSampleSuccess(subres, false);
+              continue;
+            }
+
+            if ("file".equalsIgnoreCase(url.getProtocol())) {
+              HTTP2Sampler fileSampler = newFileEmbeddedSampler(url);
+              HTTPSampleResult binRes =
+                  fileSampler.sample(url, HTTPConstants.GET, false, frameDepth + 1);
+              if (binRes != null) {
+                binRes.setSampleLabel(formatFileEmbeddedLabel(url, fileEmbeddedIndex++));
+                relabelFileEmbeddedChildren(binRes);
+              }
+              subres.addSubResult(binRes);
+              setParentSampleSuccess(subres,
+                  subres.isSuccessful() && (binRes == null || binRes.isSuccessful()));
               continue;
             }
 

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientFileProtocolSamplingTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientFileProtocolSamplingTest.java
@@ -1,0 +1,95 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * HttpClient4's {@code HTTPFileImpl} handles {@code file://} sampler URLs (used by JMeter's own
+ * HTML-parser regression fixtures to test the embedded-resource parser against local files
+ * without a live server): it always uses GET, opens the URL directly via Java's built-in
+ * {@code file} handler, and always reports {@code text/html} as the content type regardless of
+ * the file's real type - not a guess based on the file extension.
+ */
+public class HTTP2JettyClientFileProtocolSamplingTest extends HTTP2TestBase {
+
+  private HTTP2JettyClient client;
+  private Path tempFile;
+
+  @After
+  public void tearDown() throws Exception {
+    if (client != null) {
+      client.stop();
+    }
+    if (tempFile != null) {
+      Files.deleteIfExists(tempFile);
+    }
+  }
+
+  @Test
+  public void samplesLocalFileWithHardcodedGetMethodAndTextHtmlContentType() throws Exception {
+    String fileContent = "not-actually-html-content";
+    // .txt on purpose: content type must be hardcoded to text/html, not guessed from extension.
+    tempFile = Files.createTempFile("http2-file-protocol-test", ".txt");
+    Files.write(tempFile, fileContent.getBytes(StandardCharsets.UTF_8));
+    URL fileUrl = tempFile.toUri().toURL();
+
+    HTTPSampleResult sampled = sampleFileUrl(fileUrl, null);
+
+    assertThat(sampled.isSuccessful()).isTrue();
+    assertThat(sampled.getResponseCode()).isEqualTo("200");
+    assertThat(sampled.getHTTPMethod()).isEqualTo(HTTPConstants.GET);
+    assertThat(sampled.getContentType()).isEqualTo("text/html");
+    assertThat(sampled.getResponseDataAsString()).isEqualTo(fileContent);
+  }
+
+  @Test
+  public void appendsSamplerContentEncodingAsCharsetOnTheContentType() throws Exception {
+    tempFile = Files.createTempFile("http2-file-protocol-test", ".txt");
+    Files.write(tempFile, "content".getBytes(StandardCharsets.UTF_8));
+    URL fileUrl = tempFile.toUri().toURL();
+
+    HTTPSampleResult sampled = sampleFileUrl(fileUrl, "UTF-8");
+
+    assertThat(sampled.getContentType()).isEqualTo("text/html; charset=UTF-8");
+  }
+
+  @Test
+  public void propagatesAnErrorWhenTheFileDoesNotExist() throws Exception {
+    tempFile = Files.createTempFile("http2-file-protocol-test", ".txt");
+    Files.delete(tempFile);
+    URL fileUrl = tempFile.toUri().toURL();
+    tempFile = null;
+
+    org.junit.Assert.assertThrows(IOException.class, () -> sampleFileUrl(fileUrl, null));
+  }
+
+  private HTTPSampleResult sampleFileUrl(URL fileUrl, String contentEncoding) throws Exception {
+    client = new HTTP2JettyClient(false, "file-protocol-sampling-test");
+    client.start();
+
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.GET);
+    sampler.setProtocol("file");
+    if (contentEncoding != null) {
+      sampler.setContentEncoding(contentEncoding);
+    }
+
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setSampleLabel("GET_FILE_PROTOCOL");
+    result.setHTTPMethod(HTTPConstants.GET);
+    result.setURL(fileUrl);
+
+    return client.sample(sampler, result, false, 0);
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2SamplerNestedFileEmbeddedResourceTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2SamplerNestedFileEmbeddedResourceTest.java
@@ -1,0 +1,89 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.samplers.SampleResult;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * A {@code file://} page with an embedded resource that is itself HTML (e.g. an iframe) must
+ * have ITS OWN embedded resources downloaded too, exactly like a real HTTP-embedded HTML resource
+ * would recurse. {@link HTTP2Sampler}'s generic embedded-resource child sampler never enabled
+ * {@code setImageParser} on the child, so this second level of embedded {@code file://} resources
+ * was silently never downloaded.
+ */
+public class HTTP2SamplerNestedFileEmbeddedResourceTest extends HTTP2TestBase {
+
+  private Path tempDir;
+
+  @After
+  public void tearDown() throws Exception {
+    if (tempDir != null) {
+      try (var stream = Files.walk(tempDir)) {
+        stream.sorted(Comparator.reverseOrder()).forEach(path -> path.toFile().delete());
+      }
+    }
+  }
+
+  @Test
+  public void downloadsEmbeddedResourcesOfANestedFileEmbeddedHtmlResource() throws Exception {
+    tempDir = Files.createTempDirectory("http2-nested-file-embedded-test");
+    Files.writeString(tempDir.resolve("parent.html"),
+        "<html><body><iframe src=\"child.html\"></iframe></body></html>",
+        StandardCharsets.UTF_8);
+    Files.writeString(tempDir.resolve("child.html"),
+        "<html><body><img src=\"pixel.png\"></body></html>",
+        StandardCharsets.UTF_8);
+    Files.write(tempDir.resolve("pixel.png"), "pixel-bytes".getBytes(StandardCharsets.UTF_8));
+
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.GET);
+    sampler.setProtocol("file");
+    sampler.setImageParser(true);
+    sampler.setConcurrentDwn(false);
+
+    URL parentUrl = tempDir.resolve("parent.html").toUri().toURL();
+    HTTPSampleResult pageResult = invokeSample(sampler, parentUrl);
+
+    SampleResult childHtmlResult = findSubResultByUrlContains(pageResult, "child.html");
+    assertThat(childHtmlResult).as("nested file:// HTML sub-result (iframe)").isNotNull();
+
+    SampleResult pixelResult = findSubResultByUrlContains(pageResult, "pixel.png");
+    assertThat(pixelResult)
+        .as("the nested HTML resource's own embedded image must have been downloaded too")
+        .isNotNull();
+    assertThat(((HTTPSampleResult) pixelResult).getResponseDataAsString())
+        .isEqualTo("pixel-bytes");
+  }
+
+  private static HTTPSampleResult invokeSample(HTTP2Sampler sampler, URL url) throws Exception {
+    Method sample = HTTP2Sampler.class.getDeclaredMethod(
+        "sample", URL.class, String.class, boolean.class, int.class);
+    sample.setAccessible(true);
+    return (HTTPSampleResult) sample.invoke(sampler, url, HTTPConstants.GET, false, 0);
+  }
+
+  private static SampleResult findSubResultByUrlContains(SampleResult root, String substring) {
+    if (root.getUrlAsString() != null && root.getUrlAsString().contains(substring)) {
+      return root;
+    }
+    for (SampleResult sr : root.getSubResults()) {
+      SampleResult found = findSubResultByUrlContains(sr, substring);
+      if (found != null) {
+        return found;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
This pull request adds support for `file://` protocol sampling in the HTTP2 implementation, ensuring compatibility with JMeter's existing behavior for local file resources and enabling proper handling of embedded and nested embedded resources in local HTML files. It introduces logic to sample local files, label embedded resources, and recurse into nested HTML resources, along with comprehensive tests to verify the new behavior.

**Support for `file://` protocol sampling:**

* [`HTTP2JettyClient.java`](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR22): Implements a new code path to handle `file://` URLs by directly opening the file, always using the GET method, and hardcoding the content type to `text/html`, matching JMeter's `HTTPFileImpl` behavior. It also limits the maximum number of bytes stored per request. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR22) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR146-R150) [[3]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR1533-R1537)
* [`HTTP2Sampler.java`](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R661-R712): Adds logic to create embedded resource samplers for `file://` URLs, ensures HTML subresources are parsed recursively, and provides deterministic labeling for file-based embedded resources. [[1]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R661-R712) [[2]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R988) [[3]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R1021-R1034)

**Testing and validation:**

* [`HTTP2JettyClientFileProtocolSamplingTest.java`](diffhunk://#diff-21a739a12f08206998e6007833b579b5bf593a5e5c67fa0402aaa13727f671cbR1-R95): Adds unit tests to verify correct sampling of local files, including method, content type, content encoding, and error handling when files are missing.
* [`HTTP2SamplerNestedFileEmbeddedResourceTest.java`](diffhunk://#diff-7597f65c9e7d157c325f6525eea1126701ca734eb3b61257eb0911b64c2d346aR1-R89): Adds tests to ensure that nested embedded HTML resources in local files are also downloaded and parsed recursively, matching expected behavior for HTML resource trees.This pull request adds support for sampling `file://` URLs in the `HTTP2JettyClient`, matching the behavior of JMeter's `HTTPFileImpl` used by the HttpClient4 sampler. It ensures that local file resources can be sampled for embedded-resource parsing tests, always using the GET method and returning a hardcoded `text/html` content type. The implementation also includes a dedicated test class to verify this behavior.

**Support for `file://` protocol in HTTP2JettyClient:**

* Added logic in `HTTP2JettyClient.sample` to detect `file://` URLs and delegate to a new `sampleLocalFile` method, which opens the file using Java's built-in handler, always uses GET, and returns `text/html` as the content type regardless of file extension. The response data is capped at a configurable maximum size. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR1533-R1537) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR146-R150)
* Introduced constants for maximum bytes to store per file sample and buffer size, controlled by a JMeter property.

**Testing and validation:**

* Added a new test class `HTTP2JettyClientFileProtocolSamplingTest` that verifies:
  - Successful sampling of a local file returns the file contents, uses GET, and reports `text/html` as the content type.
  - The sampler's content encoding is appended as a charset parameter.
  - An error is propagated if the file does not exist.

**Other improvements:**

* Imported `URLConnection` to support opening file URLs.