### PR TITLE
Load HTTP response parsers lazily

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -116,33 +116,6 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
   private static final String USER_AGENT = "User-Agent"; // $NON-NLS-1$
   private static final boolean USE_JAVA_REGEX = !getPropDefault(
       "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
-  private static final String RESPONSE_PARSERS = // list of parsers
-      JMeterUtils.getProperty("HTTPResponse.parsers"); //$NON-NLS-1$
-
-  static {
-    String[] parsers =
-        JOrphanUtils.split(RESPONSE_PARSERS, " ", true); // returns empty array for null
-    for (final String parser : parsers) {
-      String classname = JMeterUtils.getProperty(parser + ".className"); //$NON-NLS-1$
-      if (classname == null) {
-        LOG.error("Cannot find .className property for {}, ensure you set property: '{}.className'",
-            parser, parser);
-        continue;
-      }
-      String typeList = JMeterUtils.getProperty(parser + ".types"); //$NON-NLS-1$
-      if (typeList != null) {
-        String[] types = JOrphanUtils.split(typeList, " ", true);
-        for (final String type : types) {
-          registerParser(type, classname);
-        }
-      } else {
-        LOG.warn(
-            "Cannot find .types property for {}, as a consequence parser " +
-                "will not be used, to make it usable, define property:'{}.types'",
-            parser, parser);
-      }
-    }
-  }
 
   private final transient Callable<HTTP2JettyClient> clientFactory;
   private final boolean dumpAtThreadEnd =
@@ -739,8 +712,50 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
     PARSERS_FOR_CONTENT_TYPE.put(contentType, className);
   }
 
+  /**
+   * JMeter batch runs configure HTML parsers via {@code -q jmeter-batch.properties}, loaded after
+   * this class may already have been initialized - so register parsers lazily on first use
+   * instead of in a static block, to read whatever properties are actually in effect by then.
+   */
+  private static void ensureResponseParsersLoaded() {
+    if (!PARSERS_FOR_CONTENT_TYPE.isEmpty()) {
+      return;
+    }
+    synchronized (PARSERS_FOR_CONTENT_TYPE) {
+      if (PARSERS_FOR_CONTENT_TYPE.isEmpty()) {
+        loadResponseParsersFromProperties();
+      }
+    }
+  }
+
+  private static void loadResponseParsersFromProperties() {
+    String responseParsers = JMeterUtils.getProperty("HTTPResponse.parsers"); //$NON-NLS-1$
+    String[] parsers = JOrphanUtils.split(responseParsers, " ", true); // empty array for null
+    for (final String parser : parsers) {
+      String classname = JMeterUtils.getProperty(parser + ".className"); //$NON-NLS-1$
+      if (classname == null) {
+        LOG.error("Cannot find .className property for {}, ensure you set property: '{}.className'",
+            parser, parser);
+        continue;
+      }
+      String typeList = JMeterUtils.getProperty(parser + ".types"); //$NON-NLS-1$
+      if (typeList != null) {
+        String[] types = JOrphanUtils.split(typeList, " ", true);
+        for (final String type : types) {
+          registerParser(type, classname);
+        }
+      } else {
+        LOG.warn(
+            "Cannot find .types property for {}, as a consequence parser "
+                + "will not be used, to make it usable, define property:'{}.types'",
+            parser, parser);
+      }
+    }
+  }
+
   private LinkExtractorParser getParser(HTTPSampleResult res)
       throws LinkExtractorParseException {
+    ensureResponseParsersLoaded();
     String parserClassName =
         PARSERS_FOR_CONTENT_TYPE.get(res.getMediaType());
     if (!StringUtils.isEmpty(parserClassName)) {

--- a/src/test/java/com/blazemeter/jmeter/http2/sampler/HTTP2SamplerLazyResponseParserLoadingTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/sampler/HTTP2SamplerLazyResponseParserLoadingTest.java
@@ -1,0 +1,101 @@
+package com.blazemeter.jmeter.http2.sampler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.jmeter.util.JMeterUtils;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * {@link HTTP2Sampler} used to register response parsers ({@code HTTPResponse.parsers} and
+ * friends) in a static initializer, which runs once at class-load time. JMeter batch runs
+ * configure these via {@code -q jmeter-batch.properties}, loaded after this class may already
+ * have been initialized, so the static block would read stale/default properties forever. Parsers
+ * must instead load lazily, on first use, so whatever properties are actually in effect by then
+ * get picked up.
+ */
+public class HTTP2SamplerLazyResponseParserLoadingTest extends HTTP2TestBase {
+
+  private static final String TEST_CONTENT_TYPE = "text/test-lazy-parser";
+  private static final String TEST_PARSER_KEY = "testLazyParser";
+
+  private Map<String, String> originalParsers;
+  private String originalResponseParsersProperty;
+  private String originalClassNameProperty;
+  private String originalTypesProperty;
+
+  @After
+  public void tearDown() throws Exception {
+    restoreProperty("HTTPResponse.parsers", originalResponseParsersProperty);
+    restoreProperty(TEST_PARSER_KEY + ".className", originalClassNameProperty);
+    restoreProperty(TEST_PARSER_KEY + ".types", originalTypesProperty);
+    if (originalParsers != null) {
+      Map<String, String> parsers = parsersField();
+      parsers.clear();
+      parsers.putAll(originalParsers);
+    }
+  }
+
+  @Test
+  public void loadsParsersOnFirstUseFromPropertiesSetAfterClassInitialization() throws Exception {
+    Map<String, String> parsers = parsersField();
+    originalParsers = new HashMap<>(parsers);
+    parsers.clear();
+
+    originalResponseParsersProperty = JMeterUtils.getProperty("HTTPResponse.parsers");
+    originalClassNameProperty = JMeterUtils.getProperty(TEST_PARSER_KEY + ".className");
+    originalTypesProperty = JMeterUtils.getProperty(TEST_PARSER_KEY + ".types");
+
+    // Set AFTER the class (and its old static block, if it still existed) would already have
+    // run - simulating a JMeter batch run applying -q jmeter-batch.properties post-class-load.
+    JMeterUtils.setProperty("HTTPResponse.parsers", TEST_PARSER_KEY);
+    JMeterUtils.setProperty(TEST_PARSER_KEY + ".className",
+        "org.apache.jmeter.protocol.http.parser.RegexpHTMLParser");
+    JMeterUtils.setProperty(TEST_PARSER_KEY + ".types", TEST_CONTENT_TYPE);
+
+    invokeEnsureResponseParsersLoaded();
+
+    assertThat(parsersField())
+        .as("parser registered from properties set after class initialization")
+        .containsEntry(TEST_CONTENT_TYPE, "org.apache.jmeter.protocol.http.parser.RegexpHTMLParser");
+  }
+
+  @Test
+  public void doesNotReloadOnceParsersAreAlreadyRegistered() throws Exception {
+    Map<String, String> parsers = parsersField();
+    originalParsers = new HashMap<>(parsers);
+    parsers.put("text/already-loaded-marker", "some.Marker");
+
+    // HTTPResponse.parsers left unset/whatever it currently is: if this reloaded, it would not
+    // add our marker back after a clear, but it also must not wipe it out just by being called.
+    invokeEnsureResponseParsersLoaded();
+
+    assertThat(parsersField()).containsKey("text/already-loaded-marker");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, String> parsersField() throws Exception {
+    Field field = HTTP2Sampler.class.getDeclaredField("PARSERS_FOR_CONTENT_TYPE");
+    field.setAccessible(true);
+    return (Map<String, String>) field.get(null);
+  }
+
+  private static void invokeEnsureResponseParsersLoaded() throws Exception {
+    Method method = HTTP2Sampler.class.getDeclaredMethod("ensureResponseParsersLoaded");
+    method.setAccessible(true);
+    method.invoke(null);
+  }
+
+  private static void restoreProperty(String key, String originalValue) {
+    if (originalValue == null) {
+      JMeterUtils.getJMeterProperties().remove(key);
+    } else {
+      JMeterUtils.setProperty(key, originalValue);
+    }
+  }
+}


### PR DESCRIPTION
This pull request improves how HTTP response parsers are loaded in the `HTTP2Sampler` class to ensure they respect properties set at runtime, especially in JMeter batch runs. Previously, parsers were registered in a static block at class load time, which could miss properties loaded later. Now, parser registration is deferred until first use, and a new test ensures this behavior works as intended.

**Lazy loading of response parsers:**

* Refactored `HTTP2Sampler` to remove the static block that registered response parsers at class initialization, replacing it with a lazy-loading mechanism via the new `ensureResponseParsersLoaded()` method. This ensures that parser configuration properties set after class load (e.g., via `-q` in batch mode) are picked up correctly. [[1]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30L119-L145) [[2]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R715-R758)

**Testing improvements:**

* Added `HTTP2SamplerLazyResponseParserLoadingTest` to verify that response parsers are loaded from properties set after class initialization and that they are not reloaded unnecessarily. This test ensures the new lazy-loading logic works as expected.