### PR TITLE
Map Jetty client failures to HttpClient4 exception types

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/JmeterHttpClientExceptionMapper.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/JmeterHttpClientExceptionMapper.java
@@ -1,0 +1,104 @@
+package com.blazemeter.jmeter.http2.core;
+
+import java.net.ConnectException;
+import java.net.InetAddress;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.Locale;
+import java.util.concurrent.ExecutionException;
+import org.apache.http.HttpHost;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.conn.HttpHostConnectException;
+
+/**
+ * Maps Jetty client failures to the exception types JMeter {@code HTTPHC4Impl} reports in
+ * {@code HTTPSampleResult} for semantic parity.
+ */
+public final class JmeterHttpClientExceptionMapper {
+
+  private JmeterHttpClientExceptionMapper() {
+  }
+
+  public static Throwable forSampleResult(Throwable thrown, boolean autoRedirects) {
+    return forSampleResult(thrown, autoRedirects, null);
+  }
+
+  public static Throwable forSampleResult(Throwable thrown, boolean autoRedirects, URL url) {
+    if (thrown == null) {
+      return null;
+    }
+    Throwable root = unwrap(thrown);
+    if (autoRedirects && isAutoRedirectProtocolFailure(root)) {
+      return new ClientProtocolException();
+    }
+    Throwable connectMapped = mapConnectFailure(root, url);
+    if (connectMapped != null) {
+      return connectMapped;
+    }
+    return thrown;
+  }
+
+  private static Throwable unwrap(Throwable throwable) {
+    Throwable current = throwable;
+    while (current instanceof ExecutionException && current.getCause() != null) {
+      current = current.getCause();
+    }
+    return current;
+  }
+
+  private static boolean isAutoRedirectProtocolFailure(Throwable throwable) {
+    if (throwable == null) {
+      return false;
+    }
+    if (!"HttpResponseException".equals(throwable.getClass().getSimpleName())) {
+      return false;
+    }
+    String message = throwable.getMessage();
+    return message != null && message.contains("Max redirects exceeded");
+  }
+
+  private static Throwable mapConnectFailure(Throwable root, URL url) {
+    if (root instanceof HttpHostConnectException) {
+      return root;
+    }
+    if (root instanceof ConnectException) {
+      HttpHost host = toHttpHost(url);
+      ConnectException cause = normalizeConnectCause((ConnectException) root);
+      if (host != null) {
+        try {
+          return new HttpHostConnectException(cause, host,
+              InetAddress.getAllByName(host.getHostName()));
+        } catch (UnknownHostException ignored) {
+          // Fall back to host-only message formatting.
+        }
+      }
+      return new HttpHostConnectException(cause, host);
+    }
+    return null;
+  }
+
+  private static ConnectException normalizeConnectCause(ConnectException root) {
+    String message = root.getMessage();
+    if (message != null && message.toLowerCase(Locale.ROOT).contains("getsockopt")) {
+      ConnectException normalized = new ConnectException("Connection refused: connect");
+      normalized.initCause(root);
+      return normalized;
+    }
+    return root;
+  }
+
+  private static HttpHost toHttpHost(URL url) {
+    if (url == null || url.getHost() == null || url.getHost().isEmpty()) {
+      return null;
+    }
+    int port = url.getPort();
+    if (port < 0) {
+      port = url.getDefaultPort();
+    }
+    String scheme = url.getProtocol();
+    if (scheme == null || scheme.isEmpty()) {
+      return new HttpHost(url.getHost(), port);
+    }
+    return new HttpHost(url.getHost(), port, scheme);
+  }
+}

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -7,6 +7,7 @@ import com.blazemeter.jmeter.http2.core.HTTP2ClientProfileConfig;
 import com.blazemeter.jmeter.http2.core.HTTP2FutureResponseListener;
 import com.blazemeter.jmeter.http2.core.HTTP2JettyClient;
 import com.blazemeter.jmeter.http2.core.HpackFailureDetector;
+import com.blazemeter.jmeter.http2.core.JmeterHttpClientExceptionMapper;
 import com.blazemeter.jmeter.http2.core.ProtocolErrorException;
 import com.blazemeter.jmeter.http2.util.BzmHttpPluginProperties;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -602,7 +603,9 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
         result.sampleEnd();
       }
     }
-    return errorResult(e, result);
+    return errorResult(
+        JmeterHttpClientExceptionMapper.forSampleResult(e, getAutoRedirects(), result.getURL()),
+        result);
   }
 
   /**

--- a/src/test/java/com/blazemeter/jmeter/http2/core/JmeterHttpClientExceptionMapperTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/JmeterHttpClientExceptionMapperTest.java
@@ -1,0 +1,48 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.ConnectException;
+import java.net.URL;
+import java.util.concurrent.ExecutionException;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.conn.HttpHostConnectException;
+import org.eclipse.jetty.client.HttpResponseException;
+import org.junit.Test;
+
+public class JmeterHttpClientExceptionMapperTest {
+
+  @Test
+  public void shouldMapJettyMaxRedirectsToClientProtocolExceptionWhenAutoRedirectsEnabled() {
+    Throwable jetty = new ExecutionException(
+        new HttpResponseException("Max redirects exceeded 8", null));
+
+    Throwable mapped = JmeterHttpClientExceptionMapper.forSampleResult(jetty, true);
+
+    assertThat(mapped).isInstanceOf(ClientProtocolException.class);
+    assertThat(mapped.getMessage()).isNull();
+  }
+
+  @Test
+  public void shouldKeepExecutionExceptionWhenAutoRedirectsDisabled() {
+    Throwable failure = new ExecutionException(
+        new HttpResponseException("Max redirects exceeded 8", null));
+
+    Throwable mapped = JmeterHttpClientExceptionMapper.forSampleResult(failure, false);
+
+    assertThat(mapped).isInstanceOf(ExecutionException.class);
+  }
+
+  @Test
+  public void shouldMapConnectExceptionToHttpHostConnectException() throws Exception {
+    Throwable failure = new ExecutionException(
+        new ConnectException("Connection refused: getsockopt"));
+    URL url = new URL("https://localhost:8082/");
+
+    Throwable mapped = JmeterHttpClientExceptionMapper.forSampleResult(failure, false, url);
+
+    assertThat(mapped).isInstanceOf(HttpHostConnectException.class);
+    assertThat(mapped.getCause()).isInstanceOf(ConnectException.class);
+    assertThat(mapped.getMessage()).contains("localhost:8082");
+  }
+}


### PR DESCRIPTION
This pull request introduces a new exception mapping utility to ensure that HTTP/2 client errors are reported in a way that matches JMeter's expectations, improving semantic parity and error handling in the `HTTP2Sampler`. It also adds comprehensive unit tests for the new mapper.

**Exception mapping improvements:**

* Added a new utility class `JmeterHttpClientExceptionMapper` to map Jetty client exceptions to the types expected by JMeter's `HTTPSampleResult`, including handling redirect and connection errors for better semantic parity.
* Updated `HTTP2Sampler` to use the new exception mapper when building error results, ensuring consistent error reporting. [[1]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R10) [[2]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30L605-R608)

**Testing:**

* Added unit tests in `JmeterHttpClientExceptionMapperTest` to verify correct mapping of Jetty exceptions to JMeter-compatible exceptions, including cases for max redirects and connection failures.