### PR TITLE
Add headless CLI tool to migrate stock JMeter HTTP samplers to BlazeMeter HTTP

### DIFF
--- a/scripts/jmx-migrate.cmd
+++ b/scripts/jmx-migrate.cmd
@@ -1,0 +1,14 @@
+@echo off
+rem Migrates stock JMeter HTTP Request samplers to the BlazeMeter HTTP sampler in a .jmx file
+rem or directory. Run from a real JMeter installation with jmeter-bzm-http2-*.jar installed
+rem under lib\ext\ (this script assumes it lives at <jmeter.home>\bin\jmx-migrate.cmd).
+rem
+rem Usage: see `jmx-migrate.cmd --help`
+
+setlocal
+set SCRIPT_DIR=%~dp0
+set JMETER_HOME_DIR=%SCRIPT_DIR%..
+
+java -Djava.awt.headless=true ^
+  -cp "%JMETER_HOME_DIR%\lib\*;%JMETER_HOME_DIR%\lib\ext\*" ^
+  com.blazemeter.jmeter.http2.sampler.JmxBlazeMeterHttpMigratorCli %*

--- a/scripts/jmx-migrate.sh
+++ b/scripts/jmx-migrate.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Migrates stock JMeter HTTP Request samplers to the BlazeMeter HTTP sampler in a .jmx file
+# or directory. Run from a real JMeter installation with jmeter-bzm-http2-*.jar installed
+# under lib/ext/ (this script assumes it lives at <jmeter.home>/bin/jmx-migrate.sh).
+#
+# Usage: see `jmx-migrate.sh --help`
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+JMETER_HOME_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+
+exec java -Djava.awt.headless=true \
+  -cp "$JMETER_HOME_DIR/lib/*:$JMETER_HOME_DIR/lib/ext/*" \
+  com.blazemeter.jmeter.http2.sampler.JmxBlazeMeterHttpMigratorCli "$@"

--- a/src/main/java/com/blazemeter/jmeter/http2/cli/JMeterCliEnvironment.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/cli/JMeterCliEnvironment.java
@@ -1,0 +1,96 @@
+package com.blazemeter.jmeter.http2.cli;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.security.CodeSource;
+import org.apache.jmeter.util.JMeterUtils;
+
+/**
+ * Bootstraps a headless JMeter environment for command-line tools shipped inside this plugin's
+ * jar, without requiring the JMeter GUI or the lightweight test emulator used by unit tests.
+ *
+ * <p>Resolves {@code JMETER_HOME} by locating this jar under {@code <jmeter.home>/lib/ext/},
+ * matching how JMeter loads plugins; falls back to the {@code JMETER_HOME} environment variable
+ * or the {@code jmeter.home} system property when the jar isn't installed there.
+ */
+public final class JMeterCliEnvironment {
+
+  private static volatile boolean initialized;
+
+  private JMeterCliEnvironment() {
+  }
+
+  public static synchronized void ensureInitialized() {
+    if (initialized) {
+      return;
+    }
+    System.setProperty("java.awt.headless", "true");
+    if (isNotBlank(JMeterUtils.getJMeterHome())) {
+      // Some other bootstrap (JMeter GUI/engine, or the in-process test emulator) already
+      // configured JMeterUtils; reloading properties here would discard that configuration.
+      initialized = true;
+      return;
+    }
+    String home = resolveJMeterHome();
+    JMeterUtils.setJMeterHome(home);
+    File propertiesFile = new File(new File(home, "bin"), "jmeter.properties");
+    JMeterUtils.loadJMeterProperties(propertiesFile.getAbsolutePath());
+    JMeterUtils.initLocale();
+    JMeterUtils.initLogging();
+    initialized = true;
+  }
+
+  static String resolveJMeterHome() {
+    String fromProperty = System.getProperty("jmeter.home");
+    if (isNotBlank(fromProperty)) {
+      return fromProperty.trim();
+    }
+    String fromEnv = System.getenv("JMETER_HOME");
+    if (isNotBlank(fromEnv)) {
+      return fromEnv.trim();
+    }
+    String fromJarLocation = homeFromExtDirJar(locateOwnJarFile());
+    if (fromJarLocation != null) {
+      return fromJarLocation;
+    }
+    throw new IllegalStateException(
+        "Could not determine JMeter home. This tool expects to run from <jmeter.home>/lib/ext/, "
+            + "or with -Djmeter.home=<path> / the JMETER_HOME environment variable set.");
+  }
+
+  /**
+   * @return {@code <home>} when {@code jarFile} looks like {@code <home>/lib/ext/some.jar},
+   *     {@code null} otherwise (e.g. when running from a build output directory).
+   */
+  static String homeFromExtDirJar(File jarFile) {
+    if (jarFile == null) {
+      return null;
+    }
+    File extDir = jarFile.getParentFile();
+    if (extDir == null || !"ext".equalsIgnoreCase(extDir.getName())) {
+      return null;
+    }
+    File libDir = extDir.getParentFile();
+    if (libDir == null || !"lib".equalsIgnoreCase(libDir.getName())) {
+      return null;
+    }
+    File home = libDir.getParentFile();
+    return home == null ? null : home.getAbsolutePath();
+  }
+
+  private static File locateOwnJarFile() {
+    try {
+      CodeSource codeSource = JMeterCliEnvironment.class.getProtectionDomain().getCodeSource();
+      if (codeSource == null) {
+        return null;
+      }
+      return new File(codeSource.getLocation().toURI());
+    } catch (URISyntaxException | IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  private static boolean isNotBlank(String value) {
+    return value != null && !value.trim().isEmpty();
+  }
+}

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/JmxBlazeMeterHttpMigrator.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/JmxBlazeMeterHttpMigrator.java
@@ -1,0 +1,151 @@
+package com.blazemeter.jmeter.http2.sampler;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase;
+import org.apache.jmeter.save.SaveService;
+import org.apache.jmeter.testelement.TestElement;
+import org.apache.jorphan.collections.HashTree;
+import org.apache.jorphan.collections.ListedHashTree;
+
+/**
+ * Headless migration of JMeter test plans: replaces stock HTTP Request samplers with
+ * {@link HTTP2Sampler} while preserving child elements (assertions, timers, etc.).
+ */
+public final class JmxBlazeMeterHttpMigrator {
+
+  private JmxBlazeMeterHttpMigrator() {
+  }
+
+  public static HashTree loadTree(File jmxFile) throws IOException {
+    return SaveService.loadTree(jmxFile);
+  }
+
+  public static void saveTree(HashTree tree, File jmxFile) throws IOException {
+    try (OutputStream out = java.nio.file.Files.newOutputStream(jmxFile.toPath())) {
+      SaveService.saveTree(tree, out);
+    }
+  }
+
+  /**
+   * @return number of HTTP Request samplers replaced
+   */
+  public static int migrateTree(HashTree tree) {
+    return migrateTreeWithDetails(tree).getReplacedCount();
+  }
+
+  public static MigrationResult migrateTreeWithDetails(HashTree tree) {
+    MigrationResult result = new MigrationResult();
+    migrateInPlace(tree, result);
+    return result;
+  }
+
+  public static HashTree migrateCopy(HashTree source) {
+    return migrateCopy(source, new MigrationResult());
+  }
+
+  public static HashTree migrateCopy(HashTree source, MigrationResult result) {
+    ListedHashTree copy = new ListedHashTree();
+    for (Object key : source.list()) {
+      Object newKey = maybeReplaceSampler(key, result);
+      HashTree sub = source.getTree(key);
+      if (sub != null && !sub.isEmpty()) {
+        copy.add(newKey, migrateCopy(sub, result));
+      } else {
+        copy.add(newKey);
+      }
+    }
+    return copy;
+  }
+
+  public static File migrateFile(File sourceJmx, File targetJmx) throws IOException {
+    HashTree tree = loadTree(sourceJmx);
+    migrateTree(tree);
+    saveTree(tree, targetJmx);
+    return targetJmx;
+  }
+
+  public static int countMigratableSamplers(HashTree tree) {
+    int count = 0;
+    for (Object key : tree.list()) {
+      if (key instanceof TestElement
+          && HttpSamplerToBlazeMeterHttpMigrator.isMigratableApacheHttpSampler(
+              (TestElement) key)) {
+        count++;
+      }
+      HashTree sub = tree.getTree(key);
+      if (sub != null && !sub.isEmpty()) {
+        count += countMigratableSamplers(sub);
+      }
+    }
+    return count;
+  }
+
+  public static int countHttp2Samplers(HashTree tree) {
+    int count = 0;
+    for (Object key : tree.list()) {
+      if (key instanceof HTTP2Sampler) {
+        count++;
+      }
+      HashTree sub = tree.getTree(key);
+      if (sub != null && !sub.isEmpty()) {
+        count += countHttp2Samplers(sub);
+      }
+    }
+    return count;
+  }
+
+  private static void migrateInPlace(HashTree tree, MigrationResult result) {
+    List<Object> keys = new ArrayList<>(tree.list());
+    for (Object key : keys) {
+      HashTree sub = tree.getTree(key);
+      if (sub != null && !sub.isEmpty()) {
+        migrateInPlace(sub, result);
+      }
+      if (key instanceof TestElement
+          && HttpSamplerToBlazeMeterHttpMigrator.isMigratableApacheHttpSampler(
+              (TestElement) key)) {
+        HTTPSamplerBase source = (HTTPSamplerBase) key;
+        HTTP2Sampler replacement =
+            HttpSamplerToBlazeMeterHttpMigrator.migrateFromApacheHttpSampler(source);
+        result.recordReplacement(source, replacement);
+        tree.replaceKey(key, replacement);
+      }
+    }
+  }
+
+  private static Object maybeReplaceSampler(Object key, MigrationResult result) {
+    if (key instanceof TestElement
+        && HttpSamplerToBlazeMeterHttpMigrator.isMigratableApacheHttpSampler(
+            (TestElement) key)) {
+      HTTPSamplerBase source = (HTTPSamplerBase) key;
+      HTTP2Sampler replacement =
+          HttpSamplerToBlazeMeterHttpMigrator.migrateFromApacheHttpSampler(source);
+      result.recordReplacement(source, replacement);
+      return replacement;
+    }
+    return key;
+  }
+
+  public static final class MigrationResult {
+    private int replacedCount;
+    private final List<String> replacedLabels = new ArrayList<>();
+
+    private void recordReplacement(HTTPSamplerBase source, HTTP2Sampler replacement) {
+      replacedCount++;
+      replacedLabels.add(source.getName());
+      replacement.setName(source.getName());
+    }
+
+    public int getReplacedCount() {
+      return replacedCount;
+    }
+
+    public List<String> getReplacedLabels() {
+      return replacedLabels;
+    }
+  }
+}

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/JmxBlazeMeterHttpMigrator.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/JmxBlazeMeterHttpMigrator.java
@@ -48,7 +48,11 @@ public final class JmxBlazeMeterHttpMigrator {
   }
 
   public static HashTree migrateCopy(HashTree source, MigrationResult result) {
-    ListedHashTree copy = new ListedHashTree();
+    // Declared as HashTree (not ListedHashTree) so add(Object) binds to the stable base-class
+    // method: JMeter 5.6.3's ListedHashTree added a covariant add(Object) override that older
+    // jorphan releases (e.g. 5.5) don't have, which would throw NoSuchMethodError at runtime
+    // if this class were compiled against a jar with the override and loaded into an older one.
+    HashTree copy = new ListedHashTree();
     for (Object key : source.list()) {
       Object newKey = maybeReplaceSampler(key, result);
       HashTree sub = source.getTree(key);

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/JmxBlazeMeterHttpMigratorCli.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/JmxBlazeMeterHttpMigratorCli.java
@@ -1,0 +1,211 @@
+package com.blazemeter.jmeter.http2.sampler;
+
+import com.blazemeter.jmeter.http2.cli.JMeterCliEnvironment;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+import org.apache.jorphan.collections.HashTree;
+
+/**
+ * Command-line entry point for {@link JmxBlazeMeterHttpMigrator}: migrates stock JMeter HTTP
+ * Request samplers to {@link HTTP2Sampler} in one {@code .jmx} file, or in every {@code .jmx}
+ * file under a directory.
+ *
+ * <p>Run from {@code <jmeter.home>/lib/ext/} (where this plugin's jar is installed) with
+ * {@code <jmeter.home>/lib/*} and {@code <jmeter.home>/lib/ext/*} on the classpath; see
+ * {@code scripts/jmx-migrate.sh} / {@code scripts/jmx-migrate.cmd}.
+ */
+public final class JmxBlazeMeterHttpMigratorCli {
+
+  static final int EXIT_OK = 0;
+  static final int EXIT_USAGE_ERROR = 1;
+  static final int EXIT_RUNTIME_ERROR = 2;
+
+  private JmxBlazeMeterHttpMigratorCli() {
+  }
+
+  public static void main(String[] args) {
+    System.exit(run(args, System.out, System.err));
+  }
+
+  public static int run(String[] args, PrintStream out, PrintStream err) {
+    CliOptions options;
+    try {
+      options = CliOptions.parse(args);
+    } catch (IllegalArgumentException e) {
+      err.println("Error: " + e.getMessage());
+      printUsage(err);
+      return EXIT_USAGE_ERROR;
+    }
+    if (options.help) {
+      printUsage(out);
+      return EXIT_OK;
+    }
+    try {
+      JMeterCliEnvironment.ensureInitialized();
+      if (options.source.isDirectory()) {
+        return runBatch(options, out);
+      }
+      return runSingleFile(options, out, err);
+    } catch (IOException e) {
+      err.println("Error: " + e.getMessage());
+      return EXIT_RUNTIME_ERROR;
+    }
+  }
+
+  private static int runSingleFile(CliOptions options, PrintStream out, PrintStream err)
+      throws IOException {
+    File source = options.source;
+    if (!source.isFile()) {
+      err.println("Error: source file not found: " + source);
+      return EXIT_RUNTIME_ERROR;
+    }
+    HashTree tree = JmxBlazeMeterHttpMigrator.loadTree(source);
+    if (options.dryRun) {
+      int count = JmxBlazeMeterHttpMigrator.countMigratableSamplers(tree);
+      out.println(count + " sampler(s) would be migrated in " + source);
+      return EXIT_OK;
+    }
+    JmxBlazeMeterHttpMigrator.MigrationResult result =
+        JmxBlazeMeterHttpMigrator.migrateTreeWithDetails(tree);
+    File destination = options.inPlace ? source : options.target;
+    JmxBlazeMeterHttpMigrator.saveTree(tree, destination);
+    out.println(result.getReplacedCount() + " sampler(s) migrated: " + source + " -> "
+        + destination);
+    return EXIT_OK;
+  }
+
+  private static int runBatch(CliOptions options, PrintStream out) throws IOException {
+    List<Path> jmxFiles = findJmxFiles(options.source.toPath());
+    if (jmxFiles.isEmpty()) {
+      out.println("No .jmx files found under " + options.source);
+      return EXIT_OK;
+    }
+    int totalReplaced = 0;
+    for (Path jmxFile : jmxFiles) {
+      HashTree tree = JmxBlazeMeterHttpMigrator.loadTree(jmxFile.toFile());
+      if (options.dryRun) {
+        int count = JmxBlazeMeterHttpMigrator.countMigratableSamplers(tree);
+        totalReplaced += count;
+        out.println(count + " sampler(s) would be migrated in " + jmxFile);
+        continue;
+      }
+      JmxBlazeMeterHttpMigrator.MigrationResult result =
+          JmxBlazeMeterHttpMigrator.migrateTreeWithDetails(tree);
+      File destination = options.inPlace
+          ? jmxFile.toFile()
+          : resolveBatchDestination(options.source.toPath(), jmxFile, options.target.toPath());
+      Files.createDirectories(destination.getAbsoluteFile().getParentFile().toPath());
+      JmxBlazeMeterHttpMigrator.saveTree(tree, destination);
+      totalReplaced += result.getReplacedCount();
+      out.println(result.getReplacedCount() + " sampler(s) migrated: " + jmxFile + " -> "
+          + destination);
+    }
+    out.println((options.dryRun ? "Total would migrate: " : "Total migrated: ") + totalReplaced
+        + " sampler(s) across " + jmxFiles.size() + " file(s)");
+    return EXIT_OK;
+  }
+
+  private static File resolveBatchDestination(Path sourceDir, Path jmxFile, Path targetDir) {
+    Path relative = sourceDir.toAbsolutePath().relativize(jmxFile.toAbsolutePath());
+    return targetDir.resolve(relative).toFile();
+  }
+
+  private static List<Path> findJmxFiles(Path dir) throws IOException {
+    List<Path> result = new ArrayList<>();
+    try (Stream<Path> stream = Files.walk(dir)) {
+      stream.filter(Files::isRegularFile)
+          .filter(p -> p.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".jmx"))
+          .sorted()
+          .forEach(result::add);
+    }
+    return result;
+  }
+
+  private static void printUsage(PrintStream out) {
+    out.println("Usage:");
+    out.println("  migrator <source.jmx> <target.jmx> [--dry-run]");
+    out.println("  migrator <source.jmx> --in-place [--dry-run]");
+    out.println("  migrator <source-dir> --out <target-dir> [--dry-run]");
+    out.println("  migrator <source-dir> --in-place [--dry-run]");
+    out.println("  migrator --help");
+    out.println();
+    out.println("Replaces stock JMeter HTTP Request samplers with the BlazeMeter HTTP");
+    out.println("sampler, in a single .jmx file or recursively across a directory.");
+    out.println();
+    out.println("Options:");
+    out.println("  --in-place      overwrite the source file(s) instead of writing elsewhere");
+    out.println("  --out <dir>     write migrated files to <dir>, mirroring the source layout");
+    out.println("  --dry-run       report how many samplers would migrate, without writing");
+    out.println("  --help          show this message");
+  }
+
+  private static final class CliOptions {
+    private File source;
+    private File target;
+    private boolean inPlace;
+    private boolean dryRun;
+    private boolean help;
+
+    static CliOptions parse(String[] args) {
+      CliOptions options = new CliOptions();
+      List<String> positional = new ArrayList<>();
+      int i = 0;
+      while (i < args.length) {
+        String arg = args[i];
+        i++;
+        switch (arg) {
+          case "--help":
+          case "-h":
+            options.help = true;
+            break;
+          case "--in-place":
+            options.inPlace = true;
+            break;
+          case "--dry-run":
+            options.dryRun = true;
+            break;
+          case "--out":
+            if (i >= args.length) {
+              throw new IllegalArgumentException("--out requires a directory argument");
+            }
+            options.target = new File(args[i]);
+            i++;
+            break;
+          default:
+            positional.add(arg);
+        }
+      }
+      if (options.help) {
+        return options;
+      }
+      if (positional.isEmpty()) {
+        throw new IllegalArgumentException("Missing <source> argument");
+      }
+      options.source = new File(positional.get(0));
+      if (positional.size() > 1) {
+        if (options.target != null) {
+          throw new IllegalArgumentException("Specify either a positional target or --out, "
+              + "not both");
+        }
+        options.target = new File(positional.get(1));
+      }
+      if (positional.size() > 2) {
+        throw new IllegalArgumentException("Unexpected extra argument: " + positional.get(2));
+      }
+      if (options.inPlace && options.target != null) {
+        throw new IllegalArgumentException("--in-place cannot be combined with a target");
+      }
+      if (!options.dryRun && !options.inPlace && options.target == null) {
+        throw new IllegalArgumentException("Specify a target, --in-place, or --dry-run");
+      }
+      return options;
+    }
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/cli/JMeterCliEnvironmentTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/cli/JMeterCliEnvironmentTest.java
@@ -1,0 +1,42 @@
+package com.blazemeter.jmeter.http2.cli;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.nio.file.Path;
+import org.junit.Test;
+
+public class JMeterCliEnvironmentTest {
+
+  @Test
+  public void resolvesHomeWhenJarIsUnderLibExt() {
+    Path home = Path.of("jmeter-home", "apache-jmeter-5.6.3");
+    File jar = home.resolve("lib").resolve("ext").resolve("jmeter-bzm-http2.jar").toFile();
+    assertEquals(home.toFile().getAbsolutePath(), JMeterCliEnvironment.homeFromExtDirJar(jar));
+  }
+
+  @Test
+  public void resolvesHomeWhenExtDirCasingDiffers() {
+    Path home = Path.of("jmeter-home", "jmeter");
+    File jar = home.resolve("LIB").resolve("EXT").resolve("plugin.jar").toFile();
+    assertEquals(home.toFile().getAbsolutePath(), JMeterCliEnvironment.homeFromExtDirJar(jar));
+  }
+
+  @Test
+  public void returnsNullWhenNotUnderLibExt() {
+    File jar = Path.of("some-build-dir", "target", "classes").toFile();
+    assertNull(JMeterCliEnvironment.homeFromExtDirJar(jar));
+  }
+
+  @Test
+  public void returnsNullForNullJarFile() {
+    assertNull(JMeterCliEnvironment.homeFromExtDirJar(null));
+  }
+
+  @Test
+  public void returnsNullWhenParentChainIsTooShort() {
+    File jar = Path.of("ext", "plugin.jar").toFile();
+    assertNull(JMeterCliEnvironment.homeFromExtDirJar(jar));
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/sampler/JmxBlazeMeterHttpMigratorCliTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/sampler/JmxBlazeMeterHttpMigratorCliTest.java
@@ -1,0 +1,194 @@
+package com.blazemeter.jmeter.http2.sampler;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import org.apache.jmeter.config.Arguments;
+import org.apache.jmeter.protocol.http.sampler.HTTPSamplerProxy;
+import org.apache.jorphan.collections.HashTree;
+import org.apache.jorphan.collections.ListedHashTree;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class JmxBlazeMeterHttpMigratorCliTest extends HTTP2TestBase {
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private File sampleJmx;
+  private File otherSampleJmx;
+
+  private ByteArrayOutputStream outBuffer;
+  private ByteArrayOutputStream errBuffer;
+  private PrintStream out;
+  private PrintStream err;
+
+  @Before
+  public void setUpStreams() {
+    outBuffer = new ByteArrayOutputStream();
+    errBuffer = new ByteArrayOutputStream();
+    out = new PrintStream(outBuffer, true, StandardCharsets.UTF_8);
+    err = new PrintStream(errBuffer, true, StandardCharsets.UTF_8);
+  }
+
+  @Before
+  public void writeSampleFixtures() throws Exception {
+    sampleJmx = tempFolder.newFile("sample.jmx");
+    JmxBlazeMeterHttpMigrator.saveTree(buildSamplePlan("first-call", "/a"), sampleJmx);
+    otherSampleJmx = tempFolder.newFile("other-sample.jmx");
+    JmxBlazeMeterHttpMigrator.saveTree(buildSamplePlan("second-call", "/b"), otherSampleJmx);
+  }
+
+  @Test
+  public void printsUsageAndSucceedsOnHelp() {
+    int exitCode = JmxBlazeMeterHttpMigratorCli.run(new String[] {"--help"}, out, err);
+    assertEquals(JmxBlazeMeterHttpMigratorCli.EXIT_OK, exitCode);
+    assertTrue(outBuffer.toString(StandardCharsets.UTF_8).contains("Usage:"));
+  }
+
+  @Test
+  public void failsWithUsageErrorWhenNoArguments() {
+    int exitCode = JmxBlazeMeterHttpMigratorCli.run(new String[0], out, err);
+    assertEquals(JmxBlazeMeterHttpMigratorCli.EXIT_USAGE_ERROR, exitCode);
+    assertTrue(errBuffer.toString(StandardCharsets.UTF_8).contains("Missing"));
+  }
+
+  @Test
+  public void failsWithUsageErrorWhenTargetAndInPlaceConflict() {
+    int exitCode = JmxBlazeMeterHttpMigratorCli.run(
+        new String[] {sampleJmx.getPath(), "out.jmx", "--in-place"}, out, err);
+    assertEquals(JmxBlazeMeterHttpMigratorCli.EXIT_USAGE_ERROR, exitCode);
+  }
+
+  @Test
+  public void failsWithUsageErrorWhenNeitherTargetNorInPlaceNorDryRun() {
+    int exitCode =
+        JmxBlazeMeterHttpMigratorCli.run(new String[] {sampleJmx.getPath()}, out, err);
+    assertEquals(JmxBlazeMeterHttpMigratorCli.EXIT_USAGE_ERROR, exitCode);
+  }
+
+  @Test
+  public void failsWithRuntimeErrorWhenSourceFileMissing() {
+    File missing = new File(tempFolder.getRoot(), "missing.jmx");
+    int exitCode =
+        JmxBlazeMeterHttpMigratorCli.run(
+            new String[] {missing.getPath(), "--in-place"}, out, err);
+    assertEquals(JmxBlazeMeterHttpMigratorCli.EXIT_RUNTIME_ERROR, exitCode);
+  }
+
+  @Test
+  public void migratesSingleFileToTarget() throws Exception {
+    File target = new File(tempFolder.getRoot(), "migrated.jmx");
+    int exitCode = JmxBlazeMeterHttpMigratorCli.run(
+        new String[] {sampleJmx.getPath(), target.getPath()}, out, err);
+    assertEquals(JmxBlazeMeterHttpMigratorCli.EXIT_OK, exitCode);
+    assertTrue(target.isFile());
+
+    HashTree migrated = JmxBlazeMeterHttpMigrator.loadTree(target);
+    assertEquals(0, JmxBlazeMeterHttpMigrator.countMigratableSamplers(migrated));
+    assertTrue(JmxBlazeMeterHttpMigrator.countHttp2Samplers(migrated) > 0);
+
+    HashTree original = JmxBlazeMeterHttpMigrator.loadTree(sampleJmx);
+    assertTrue("source file must stay untouched",
+        JmxBlazeMeterHttpMigrator.countMigratableSamplers(original) > 0);
+  }
+
+  @Test
+  public void migratesSingleFileInPlace() throws Exception {
+    File source = tempFolder.newFile("in-place.jmx");
+    Files.copy(sampleJmx.toPath(), source.toPath(),
+        java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+
+    int exitCode = JmxBlazeMeterHttpMigratorCli.run(
+        new String[] {source.getPath(), "--in-place"}, out, err);
+    assertEquals(JmxBlazeMeterHttpMigratorCli.EXIT_OK, exitCode);
+
+    HashTree migrated = JmxBlazeMeterHttpMigrator.loadTree(source);
+    assertEquals(0, JmxBlazeMeterHttpMigrator.countMigratableSamplers(migrated));
+    assertTrue(JmxBlazeMeterHttpMigrator.countHttp2Samplers(migrated) > 0);
+  }
+
+  @Test
+  public void dryRunReportsCountWithoutWriting() throws Exception {
+    File source = tempFolder.newFile("dry-run.jmx");
+    Files.copy(sampleJmx.toPath(), source.toPath(),
+        java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+    long beforeModified = source.lastModified();
+    long beforeLength = source.length();
+
+    int exitCode = JmxBlazeMeterHttpMigratorCli.run(
+        new String[] {source.getPath(), "--dry-run"}, out, err);
+    assertEquals(JmxBlazeMeterHttpMigratorCli.EXIT_OK, exitCode);
+    assertTrue(outBuffer.toString(StandardCharsets.UTF_8).contains("would be migrated"));
+    assertEquals(beforeLength, source.length());
+    assertEquals(beforeModified, source.lastModified());
+  }
+
+  @Test
+  public void migratesDirectoryRecursivelyToOutputDirectory() throws Exception {
+    File sourceDir = tempFolder.newFolder("source");
+    File nested = new File(sourceDir, "nested");
+    assertTrue(nested.mkdirs());
+    Files.copy(sampleJmx.toPath(), new File(sourceDir, "sample.jmx").toPath());
+    Files.copy(otherSampleJmx.toPath(), new File(nested, "other-sample.jmx").toPath());
+
+    File targetDir = new File(tempFolder.getRoot(), "target");
+    int exitCode = JmxBlazeMeterHttpMigratorCli.run(
+        new String[] {sourceDir.getPath(), "--out", targetDir.getPath()}, out, err);
+    assertEquals(JmxBlazeMeterHttpMigratorCli.EXIT_OK, exitCode);
+
+    File migratedSample = new File(targetDir, "sample.jmx");
+    File migratedOther = new File(new File(targetDir, "nested"), "other-sample.jmx");
+    assertTrue(migratedSample.isFile());
+    assertTrue(migratedOther.isFile());
+    assertTrue(JmxBlazeMeterHttpMigrator.countHttp2Samplers(
+        JmxBlazeMeterHttpMigrator.loadTree(migratedSample)) > 0);
+    assertTrue(outBuffer.toString(StandardCharsets.UTF_8).contains("Total migrated:"));
+  }
+
+  @Test
+  public void dryRunOverDirectoryReportsTotalsWithoutWriting() throws Exception {
+    File sourceDir = tempFolder.newFolder("source-dry");
+    Files.copy(sampleJmx.toPath(), new File(sourceDir, "sample.jmx").toPath());
+
+    int exitCode = JmxBlazeMeterHttpMigratorCli.run(
+        new String[] {sourceDir.getPath(), "--dry-run"}, out, err);
+    assertEquals(JmxBlazeMeterHttpMigratorCli.EXIT_OK, exitCode);
+    assertTrue(outBuffer.toString(StandardCharsets.UTF_8).contains("Total would migrate:"));
+    assertFalse(new File(sourceDir, "sample.jmx.bak").exists());
+  }
+
+  @Test
+  public void reportsWhenDirectoryHasNoJmxFiles() throws Exception {
+    File emptyDir = tempFolder.newFolder("empty");
+    int exitCode = JmxBlazeMeterHttpMigratorCli.run(
+        new String[] {emptyDir.getPath(), "--in-place"}, out, err);
+    assertEquals(JmxBlazeMeterHttpMigratorCli.EXIT_OK, exitCode);
+    assertTrue(outBuffer.toString(StandardCharsets.UTF_8).contains("No .jmx files found"));
+  }
+
+  private static HashTree buildSamplePlan(String samplerName, String path) {
+    HashTree tree = new ListedHashTree();
+    HTTPSamplerProxy sampler = new HTTPSamplerProxy();
+    sampler.setName(samplerName);
+    sampler.setDomain("example.org");
+    sampler.setPath(path);
+    sampler.setMethod("GET");
+    sampler.setArguments(new Arguments());
+    // A real .jmx always has guiclass set (by the GUI when the element is created);
+    // SaveService.loadTree NPEs reading it back otherwise.
+    sampler.setProperty(org.apache.jmeter.testelement.TestElement.GUI_CLASS,
+        "org.apache.jmeter.protocol.http.control.gui.HttpTestSampleGui");
+    tree.add(sampler);
+    return tree;
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/sampler/JmxBlazeMeterHttpMigratorTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/sampler/JmxBlazeMeterHttpMigratorTest.java
@@ -1,0 +1,135 @@
+package com.blazemeter.jmeter.http2.sampler;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import java.io.File;
+import org.apache.jmeter.config.Arguments;
+import org.apache.jmeter.protocol.http.sampler.HTTPSamplerProxy;
+import org.apache.jmeter.testelement.TestElement;
+import org.apache.jorphan.collections.HashTree;
+import org.apache.jorphan.collections.ListedHashTree;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class JmxBlazeMeterHttpMigratorTest extends HTTP2TestBase {
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private File samplePlanJmx;
+
+  @Before
+  public void writeSamplePlan() throws Exception {
+    samplePlanJmx = tempFolder.newFile("sample-plan.jmx");
+    JmxBlazeMeterHttpMigrator.saveTree(buildSamplePlanWithTwoSamplers(), samplePlanJmx);
+  }
+
+  @Test
+  public void migratesAllApacheHttpSamplersInSamplePlan() throws Exception {
+    HashTree tree = JmxBlazeMeterHttpMigrator.loadTree(samplePlanJmx);
+    int before = JmxBlazeMeterHttpMigrator.countMigratableSamplers(tree);
+    assertTrue(before > 0);
+
+    JmxBlazeMeterHttpMigrator.MigrationResult result =
+        JmxBlazeMeterHttpMigrator.migrateTreeWithDetails(tree);
+    assertEquals(before, result.getReplacedCount());
+    assertEquals(0, JmxBlazeMeterHttpMigrator.countMigratableSamplers(tree));
+    assertEquals(before, JmxBlazeMeterHttpMigrator.countHttp2Samplers(tree));
+  }
+
+  @Test
+  public void preservesSamplerPropertiesDuringMigration() throws Exception {
+    HTTPSamplerProxy src = new HTTPSamplerProxy();
+    src.setName("api-call");
+    src.setDomain("example.org");
+    src.setPort(443);
+    src.setPath("/v1/items");
+    src.setMethod("POST");
+    src.setFollowRedirects(true);
+
+    HashTree tree = new ListedHashTree();
+    tree.add(src);
+
+    JmxBlazeMeterHttpMigrator.migrateTree(tree);
+    Object migrated = tree.list().iterator().next();
+    assertTrue(migrated instanceof HTTP2Sampler);
+    HTTP2Sampler dest = (HTTP2Sampler) migrated;
+    assertEquals("example.org", dest.getDomain());
+    assertEquals(443, dest.getPort());
+    assertEquals("/v1/items", dest.getPath());
+    assertEquals("POST", dest.getMethod());
+    assertTrue(dest.getFollowRedirects());
+    assertEquals(HTTP2Sampler.class.getName(), dest.getPropertyAsString(TestElement.TEST_CLASS));
+    assertFalse(dest.getPropertyAsString(TestElement.GUI_CLASS).contains("HTTPSampler"));
+  }
+
+  @Test
+  public void migrateCopyPreservesChildElements() throws Exception {
+    HTTPSamplerProxy parent = new HTTPSamplerProxy();
+    parent.setName("parent");
+    org.apache.jmeter.assertions.ResponseAssertion assertion =
+        new org.apache.jmeter.assertions.ResponseAssertion();
+    assertion.setName("assert-ok");
+    HashTree tree = new ListedHashTree();
+    HashTree sub = tree.add(parent);
+    sub.add(assertion);
+
+    HashTree migrated = JmxBlazeMeterHttpMigrator.migrateCopy(tree);
+    Object key = migrated.list().iterator().next();
+    assertTrue(key instanceof HTTP2Sampler);
+    HashTree childTree = migrated.getTree(key);
+    assertEquals(1, childTree.list().size());
+    assertTrue(childTree.list().iterator().next()
+        instanceof org.apache.jmeter.assertions.ResponseAssertion);
+  }
+
+  @Test
+  public void migrateFileWritesNewJmx() throws Exception {
+    File target = tempFolder.newFile("migrated.jmx");
+    JmxBlazeMeterHttpMigrator.migrateFile(samplePlanJmx, target);
+
+    HashTree loaded = JmxBlazeMeterHttpMigrator.loadTree(target);
+    assertEquals(0, JmxBlazeMeterHttpMigrator.countMigratableSamplers(loaded));
+    assertTrue(JmxBlazeMeterHttpMigrator.countHttp2Samplers(loaded) > 0);
+  }
+
+  private static HashTree buildSamplePlanWithTwoSamplers() {
+    HashTree tree = new ListedHashTree();
+
+    HTTPSamplerProxy first = new HTTPSamplerProxy();
+    first.setName("first-call");
+    first.setDomain("example.org");
+    first.setPath("/a");
+    first.setMethod("GET");
+    first.setArguments(new Arguments());
+    setGuiClass(first);
+    tree.add(first);
+
+    HTTPSamplerProxy second = new HTTPSamplerProxy();
+    second.setName("second-call");
+    second.setDomain("example.org");
+    second.setPath("/b");
+    second.setMethod("POST");
+    second.setArguments(new Arguments());
+    setGuiClass(second);
+    tree.add(second);
+
+    return tree;
+  }
+
+  /**
+   * A real .jmx always has {@code guiclass} on each element (set by the GUI when the element is
+   * created); {@code SaveService.loadTree} NPEs reading it back otherwise, since
+   * {@code TestElementConverter} passes the (then-null) {@code guiclass} XML attribute straight
+   * into a {@code Properties} lookup.
+   */
+  private static void setGuiClass(TestElement element) {
+    element.setProperty(TestElement.GUI_CLASS,
+        "org.apache.jmeter.protocol.http.control.gui.HttpTestSampleGui");
+  }
+}


### PR DESCRIPTION
This pull request introduces a new headless command-line migration tool for JMeter test plans, enabling users to convert stock HTTP Request samplers to the BlazeMeter HTTP2 sampler in `.jmx` files or directories. The tool is cross-platform, with both shell and Windows batch scripts for easy invocation, and includes robust environment detection to work seamlessly from a standard JMeter installation. The main features and changes are as follows:

**New Command-Line Migration Tool:**

* Added `JmxBlazeMeterHttpMigratorCli` as a command-line interface for batch or single-file migration of HTTP samplers, supporting in-place migration, dry runs, and directory mirroring.
* Added `jmx-migrate.sh` and `jmx-migrate.cmd` scripts for Unix and Windows, respectively, to simplify tool invocation from a JMeter installation. [[1]](diffhunk://#diff-f31ae61e97eae3bcacf5dd306bb5ce0c511c4e7bddc996f75d617ba95f188c6bR1-R13) [[2]](diffhunk://#diff-41a68f536a768fb9717cc93cc5ab0ae8fd0c822fd32a6a152561886a54f421baR1-R14)

**Migration Logic and Environment Setup:**

* Implemented `JmxBlazeMeterHttpMigrator` to perform the actual migration, with methods for in-place and copy migration, detailed reporting, and helper methods for counting and replacing samplers.
* Introduced `JMeterCliEnvironment` to bootstrap a headless JMeter environment, automatically resolving `JMETER_HOME` based on the plugin jar location or environment variables.

**Testing and Reliability:**

* Added `JMeterCliEnvironmentTest` to verify correct detection of the JMeter home directory in various installation scenarios, ensuring robust environment setup.