### PR TITLE
Set default minimum JMeter version to 5.5 for compatibility tests

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -10,6 +10,13 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 5.5 is the minimum supported JMeter version, 5.6.3 the latest; both are exercised
+        # end-to-end (unit + HTTP parity regression tests) since ApacheJMeter_* are provided-scope
+        # and the same compiled plugin must behave correctly against either at runtime.
+        jmeter_version: ["5.5", "5.6.3"]
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -21,14 +28,17 @@ jobs:
           java-version: "17"
           cache: maven
 
-      - name: Build and test
-        run: xvfb-run -a mvn -U --batch-mode clean install
+      - name: Build and test (JMeter ${{ matrix.jmeter_version }})
+        run: >-
+          xvfb-run -a mvn -U --batch-mode
+          -Djmeter.version=${{ matrix.jmeter_version }}
+          clean install
 
       - name: Upload build artifacts
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: ci-build-artifacts-${{ github.run_id }}
+          name: ci-build-artifacts-${{ matrix.jmeter_version }}-${{ github.run_id }}
           path: |
             target/jmeter-bzm-http2-*.jar
             target/jmeter-test

--- a/.github/workflows/ci-jmeter-compatibility.yaml
+++ b/.github/workflows/ci-jmeter-compatibility.yaml
@@ -55,7 +55,13 @@ jobs:
         env:
           JMETER_PATH_BASE: ${{ github.workspace }}/.jmeter
         run: |
-          JMETER_VERSION=5.6.3 JMETER_PATH=$JMETER_PATH_BASE/5.6.3 sh testJMeter.sh
+          # Verify the built plugin jar loads and runs against every JMeter version we claim
+          # to support: 5.5 (minimum) through 5.6.3 (latest), regardless of which version the
+          # jar itself was compiled against (jmeter.version in pom.xml is provided-scope).
+          for JMETER_VERSION in 5.5 5.6.3; do
+            echo "=== Compatibility check against JMeter $JMETER_VERSION ==="
+            JMETER_VERSION=$JMETER_VERSION JMETER_PATH=$JMETER_PATH_BASE/$JMETER_VERSION sh testJMeter.sh
+          done
 
       - name: Upload compatibility artifacts on failure
         if: failure()

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <jmeter.version>5.4.1</jmeter.version>
+    <jmeter.version>5.5</jmeter.version>
     <jetty.version>12.1.11</jetty.version>
     <!-- Matches jetty-project ${brotli4j.version} for Jetty 12.1.11 -->
     <brotli4j.version>1.23.0</brotli4j.version>
@@ -50,11 +50,11 @@
       <scope>provided</scope>
     </dependency>
     <!-- Apache HttpClient for compilation (classes used in JettyCacheManager) -->
-    <!-- Using same version as JMeter 5.4.1 -->
+    <!-- Using same version as JMeter 5.5 (our minimum supported version) -->
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
-      <version>4.4.14</version>
+      <version>4.4.15</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientFileProtocolSamplingTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientFileProtocolSamplingTest.java
@@ -9,6 +9,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.junit.After;
@@ -49,7 +50,15 @@ public class HTTP2JettyClientFileProtocolSamplingTest extends HTTP2TestBase {
     assertThat(sampled.isSuccessful()).isTrue();
     assertThat(sampled.getResponseCode()).isEqualTo("200");
     assertThat(sampled.getHTTPMethod()).isEqualTo(HTTPConstants.GET);
-    assertThat(sampled.getContentType()).isEqualTo("text/html");
+    // HTTP2Sampler.getContentEncoding()'s default is JMeter-version-dependent: 5.6.3 added a
+    // hardcoded UTF-8 schema default (HTTPSamplerBaseSchema), while 5.5 (our minimum supported
+    // version) leaves it blank until explicitly set. Read the sampler's actual runtime default
+    // instead of hardcoding the literal so this test passes on both supported versions.
+    String defaultContentEncoding = new HTTP2Sampler().getContentEncoding();
+    String expectedContentType = StringUtils.isBlank(defaultContentEncoding)
+        ? "text/html"
+        : "text/html; charset=" + defaultContentEncoding;
+    assertThat(sampled.getContentType()).isEqualTo(expectedContentType);
     assertThat(sampled.getResponseDataAsString()).isEqualTo(fileContent);
   }
 


### PR DESCRIPTION
This pull request updates the project's JMeter compatibility and build process to ensure support for both JMeter 5.5 (minimum) and 5.6.3 (latest). The CI pipeline is enhanced to build and test against both versions, and the code and tests are adjusted to handle version-specific differences.

**CI/CD workflow improvements:**

* [`.github/workflows/ci-build.yaml`](diffhunk://#diff-b8790dc873e80c2f7f63bf198b4da0147787ad8954767b839967d29f65155e2cR13-R19): The build matrix now runs tests for both JMeter 5.5 and 5.6.3, ensuring the plugin is compatible with both versions. Artifacts are named by JMeter version for clarity. [[1]](diffhunk://#diff-b8790dc873e80c2f7f63bf198b4da0147787ad8954767b839967d29f65155e2cR13-R19) [[2]](diffhunk://#diff-b8790dc873e80c2f7f63bf198b4da0147787ad8954767b839967d29f65155e2cL24-R41)
* [`.github/workflows/ci-jmeter-compatibility.yaml`](diffhunk://#diff-d8d3cde603e8c9fa803a96096ac598d9c481d3152c73060c2a4ec2d3a0d3c834L58-R64): The compatibility check now loops over both supported JMeter versions, running tests for each to verify runtime compatibility.

**Dependency and configuration updates:**

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L33-R33): The default `jmeter.version` is updated to 5.5, and the `httpcore` dependency is aligned with the version used by JMeter 5.5. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L33-R33) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L53-R57)

**Test improvements for JMeter version differences:**

* [`src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientFileProtocolSamplingTest.java`](diffhunk://#diff-21a739a12f08206998e6007833b579b5bf593a5e5c67fa0402aaa13727f671cbR12): The test for content type now dynamically determines the expected value based on the JMeter version's default encoding, ensuring the test passes on both 5.5 and 5.6.3. [[1]](diffhunk://#diff-21a739a12f08206998e6007833b579b5bf593a5e5c67fa0402aaa13727f671cbR12) [[2]](diffhunk://#diff-21a739a12f08206998e6007833b579b5bf593a5e5c67fa0402aaa13727f671cbL52-R61)