### PR TITLE
Restore original settings on exception

### DIFF
--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
@@ -1003,11 +1003,13 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
     sampler.setImageParser(true);
     String message = "message";
     String responseCode = "300";
+    String previousCacheMode = JMeterUtils.getProperty("cache_manager.cached_resource_mode");
     JMeterUtils.setProperty("cache_manager.cached_resource_mode", "RETURN_CUSTOM_STATUS");
     JMeterUtils.setProperty("RETURN_CUSTOM_STATUS.message", message);
     JMeterUtils.setProperty("RETURN_CUSTOM_STATUS.code", responseCode);
     JmeterCachedResourceModeSupport.refreshSnapshotFromProperties();
     configureCacheManagerToSampler(true, false);
+    try {
     HTTPSampleResult firstRequestExpected = buildResult(true, Code.OK,
       hostHeader(), null, null, createURL(SERVER_PATH_200_EMBEDDED), HTTPConstants.GET);
     firstRequestExpected.setResponseData(BASIC_HTML_TEMPLATE, StandardCharsets.UTF_8.name());
@@ -1020,6 +1022,9 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
     firstRequestExpected.setSentBytes(0);
     firstRequestExpected.setResponseData("", StandardCharsets.UTF_8.name());
     validateEmbeddedResultCached(sampleWithGet(SERVER_PATH_200_EMBEDDED), firstRequestExpected);
+    } finally {
+      restoreCacheResourceMode(previousCacheMode);
+    }
   }
 
   /**
@@ -1035,10 +1040,12 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
     buildStartedServer();
     sampler.setImageParser(true);
     String message = "message";
+    String previousCacheMode = JMeterUtils.getProperty("cache_manager.cached_resource_mode");
     JMeterUtils.setProperty("cache_manager.cached_resource_mode", "RETURN_200_CACHE");
     JMeterUtils.setProperty("RETURN_200_CACHE.message", message);
     JmeterCachedResourceModeSupport.refreshSnapshotFromProperties();
     configureCacheManagerToSampler(true, false);
+    try {
     // First request must connect to the server
     HTTPSampleResult expected = buildResult(true, Code.OK,
       hostHeader(), null, null, createURL(SERVER_PATH_200_EMBEDDED), HTTPConstants.GET);
@@ -1050,6 +1057,17 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
     expected.setResponseData("", StandardCharsets.UTF_8.name());
     expected.setResponseMessage(message);
     validateEmbeddedResultCached(sampleWithGet(SERVER_PATH_200_EMBEDDED), expected);
+    } finally {
+      restoreCacheResourceMode(previousCacheMode);
+    }
+  }
+
+  private void restoreCacheResourceMode(String previousCacheMode) {
+    if (previousCacheMode == null) {
+      JMeterUtils.getJMeterProperties().remove("cache_manager.cached_resource_mode");
+    } else {
+      JMeterUtils.setProperty("cache_manager.cached_resource_mode", previousCacheMode);
+    }
   }
 
   @Test


### PR DESCRIPTION
This pull request improves the reliability of tests in `HTTP2JettyClientTest.java` by ensuring that changes to the `cache_manager.cached_resource_mode` property are properly restored after each test. This prevents side effects between tests that could lead to inconsistent results.

Test isolation improvements:

* Wrapped the modification of the `cache_manager.cached_resource_mode` property in `shouldNotGetSubResultWhenResourceIsCachedWithCode()` and `shouldNotGetSubResultWhenResourceIsCachedWithoutCode()` in a try/finally block, saving and restoring the previous value to avoid side effects between tests. [[1]](diffhunk://#diff-ecc5436f1e468983f5a6e6c8ccc9d551ff7052cd40f589248596fbde0406a407R1006-R1012) [[2]](diffhunk://#diff-ecc5436f1e468983f5a6e6c8ccc9d551ff7052cd40f589248596fbde0406a407R1025-R1027) [[3]](diffhunk://#diff-ecc5436f1e468983f5a6e6c8ccc9d551ff7052cd40f589248596fbde0406a407R1043-R1048) [[4]](diffhunk://#diff-ecc5436f1e468983f5a6e6c8ccc9d551ff7052cd40f589248596fbde0406a407R1060-R1070)
* Added a new helper method `restoreCacheResourceMode` to encapsulate the logic for restoring or removing the property as appropriate.