### PR TITLE
Set default maxBufferSize to unlimited with warning and truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,9 +309,23 @@ Common configurations:
 
 
 <a id="readme-buffer-capacity"></a>
-### Buffer capacity
+### Buffer capacity / response store truncation
 
-By default there is no buffering cap (`blazemeter.http.maxBufferSize=-1`, same idea as JMeter’s unlimited response store). Set `blazemeter.http.maxBufferSize` in `jmeter.properties` or `user.properties` to a positive size in bytes if you want Jetty to reject larger bodies (Jetty’s own `BufferingResponseListener` default is 2 MiB if you construct it without a size).
+By default there is no store cap (`blazemeter.http.maxBufferSize` unset → effective **`-1`**): Jetty buffers without a hard fail (unlike Jetty’s own `BufferingResponseListener` 2 MiB default), and the full decoded body is kept in the sample.
+
+When a positive limit applies, behaviour matches Apache JMeter’s
+`httpsampler.max_bytes_to_store_per_request`: the sample stays **successful**, only the first N
+bytes are stored in response data, `bodySize` reflects the full decoded length, and JMeter logs
+`Big response, truncating it to {} bytes` at **DEBUG**. Truncation is skipped while recording.
+
+**Precedence** (first match wins):
+
+1. Plugin `blazemeter.http.maxBufferSize` (aliases `HTTP2Sampler.maxBufferSize` /
+   `httpJettyClient.maxBufferSize`) if set
+2. Else JMeter `httpsampler.max_bytes_to_store_per_request` if set
+3. Else `-1` (no truncation)
+
+`<= 0` means do not truncate.
 
 
 <a id="readme-alpn"></a>
@@ -375,7 +389,7 @@ Restart JMeter after changing JMeter properties that are applied when affected c
 | **Attribute** | **Description** | **Default** |
 |---|---|---:|
 | **blazemeter.http.proxy_enabled** | When **`true`**, the HTTP(S) Test Script Recorder creates **`bzm - HTTP Sampler`** instead of stock **HTTP Request** (legacy `HTTP2Sampler.proxy_enabled` accepted) | true |
-| **blazemeter.http.maxBufferSize** | Maximum size of buffered response bodies in bytes (`-1` = unlimited) | -1 |
+| **blazemeter.http.maxBufferSize** | Max bytes stored in sample response data (`<=0` / unset default path = no truncation). Overrides JMeter store limit when set | -1 |
 | **blazemeter.http.minThreads** | Minimum number of threads per HTTP client | 1 |
 | **blazemeter.http.maxThreads** | Maximum number of threads per HTTP client | 5 |
 | **blazemeter.http.maxRequestsQueuedPerDestination** | Maximum number of requests that may be queued to a destination | 32767 |

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Common configurations:
 <a id="readme-buffer-capacity"></a>
 ### Buffer capacity
 
-By default, the size of downloaded resources is limited to 2 MB (2,097,152 bytes); you can raise the limit by setting `blazemeter.http.maxBufferSize` in `jmeter.properties` or `user.properties` (value in bytes).
+By default there is no buffering cap (`blazemeter.http.maxBufferSize=-1`, same idea as JMeter’s unlimited response store). Set `blazemeter.http.maxBufferSize` in `jmeter.properties` or `user.properties` to a positive size in bytes if you want Jetty to reject larger bodies (Jetty’s own `BufferingResponseListener` default is 2 MiB if you construct it without a size).
 
 
 <a id="readme-alpn"></a>
@@ -375,7 +375,7 @@ Restart JMeter after changing JMeter properties that are applied when affected c
 | **Attribute** | **Description** | **Default** |
 |---|---|---:|
 | **blazemeter.http.proxy_enabled** | When **`true`**, the HTTP(S) Test Script Recorder creates **`bzm - HTTP Sampler`** instead of stock **HTTP Request** (legacy `HTTP2Sampler.proxy_enabled` accepted) | true |
-| **blazemeter.http.maxBufferSize** | Maximum size of the downloaded resources in bytes | 2097152 |
+| **blazemeter.http.maxBufferSize** | Maximum size of buffered response bodies in bytes (`-1` = unlimited) | -1 |
 | **blazemeter.http.minThreads** | Minimum number of threads per HTTP client | 1 |
 | **blazemeter.http.maxThreads** | Maximum number of threads per HTTP client | 5 |
 | **blazemeter.http.maxRequestsQueuedPerDestination** | Maximum number of requests that may be queued to a destination | 32767 |

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListener.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListener.java
@@ -37,7 +37,7 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
   private long responseEnd;
 
   public HTTP2FutureResponseListener() {
-    this(2 * 1024 * 1024);
+    this(-1);
   }
 
   public HTTP2FutureResponseListener(int maxLength) {

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -38,6 +38,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -67,6 +68,7 @@ import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.protocol.http.util.HTTPFileArg;
 import org.apache.jmeter.services.FileServer;
 import org.apache.jmeter.testelement.property.JMeterProperty;
+import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.util.JMeterUtils;
 import org.brotli.dec.BrotliInputStream;
 import org.eclipse.jetty.client.AbstractAuthentication;
@@ -147,10 +149,17 @@ public class HTTP2JettyClient {
   private static final boolean ADD_CONTENT_TYPE_TO_POST_IF_MISSING = JMeterUtils.getPropDefault(
       "http.post_add_content_type_if_missing", false);
   // Matches HTTPFileImpl: caps stored response data for file:// samples, while sampleEnd's
-  // bodySize still reflects the true total bytes read.
+  // bodySize still reflects the true total bytes read. Separate from HTTP store truncation
+  // ({@link #maxBufferSize}): JMeter also keeps HTTPFileImpl's 10 MiB default distinct from
+  // HTTPSamplerBase's default of 0 for the same property name.
   private static final int MAX_FILE_SAMPLE_BYTES_TO_STORE = JMeterUtils.getPropDefault(
-      "httpsampler.max_bytes_to_store_per_request", 10 * 1024 * 1024);
+      BzmHttpPluginProperties.JMETER_MAX_BYTES_TO_STORE_PER_REQUEST, 10 * 1024 * 1024);
   private static final int FILE_SAMPLE_BUFFER_SIZE = 4096;
+  /**
+   * Jetty {@code BufferingResponseListener} hard cap. Always unlimited so large bodies are not
+   * aborted; SampleResult store truncation uses {@link #maxBufferSize} instead (JMeter parity).
+   */
+  private static final int JETTY_BUFFERING_UNLIMITED = -1;
   private static final Pattern PORT_PATTERN = Pattern.compile("\\d+");
   private static final String MULTI_PART_SEPARATOR = "--";
   private static final String LINE_SEPARATOR = "\r\n";
@@ -190,7 +199,11 @@ public class HTTP2JettyClient {
   private static final Map<String, Http1OnlyEntry> HTTP1_ONLY_CACHE = new ConcurrentHashMap<>();
   private static final Map<String, H2cEntry> H2C_CACHE = new ConcurrentHashMap<>();
   private int requestTimeout = 0;
-  /** {@code -1} means unlimited (Jetty {@code DynamicCapacity} treats negative as no cap). */
+  /**
+   * Max bytes stored in {@link HTTPSampleResult} response data ({@code <= 0} = no truncation).
+   * Resolved from plugin {@code maxBufferSize} if set, else JMeter
+   * {@code httpsampler.max_bytes_to_store_per_request} if set, else {@code -1}.
+   */
   private int maxBufferSize = -1;
   private int maxThreads = 5;
   private boolean maxThreadsConfigured = false;
@@ -718,8 +731,17 @@ public class HTTP2JettyClient {
     return httpClient;
   }
 
+  /**
+   * Max bytes kept in the sample response data (JMeter-style store truncation). {@code <= 0} means
+   * do not truncate.
+   */
   public int getMaxBufferSize() {
     return maxBufferSize;
+  }
+
+  /** Length passed to Jetty buffering listeners; always unlimited so truncation is store-only. */
+  public static int getJettyBufferingMaxLength() {
+    return JETTY_BUFFERING_UNLIMITED;
   }
 
   public int getRequestTimeout() {
@@ -736,9 +758,7 @@ public class HTTP2JettyClient {
     byteBufferPoolFactor =
         Integer.parseInt(BzmHttpPluginProperties.getPropDefault(
             "httpJettyClient.byteBufferPoolFactor", String.valueOf(byteBufferPoolFactor)));
-    maxBufferSize =
-        Integer.parseInt(BzmHttpPluginProperties.getPropDefault("httpJettyClient.maxBufferSize",
-            "-1"));
+    maxBufferSize = resolveMaxBytesToStorePerRequest();
     minThreads = Integer
         .parseInt(BzmHttpPluginProperties.getPropDefault("httpJettyClient.minThreads",
             String.valueOf(minThreads)));
@@ -868,6 +888,25 @@ public class HTTP2JettyClient {
     if (!enableHttp1) {
       protocolErrorFallbackEnabled = false;
     }
+  }
+
+  /**
+   * Plugin {@code maxBufferSize} wins when set; otherwise JMeter
+   * {@code httpsampler.max_bytes_to_store_per_request} when set; otherwise {@code -1} (no
+   * truncation). {@code <= 0} means do not truncate, matching JMeter's store semantics.
+   */
+  private static int resolveMaxBytesToStorePerRequest() {
+    if (BzmHttpPluginProperties.isDefined(BzmHttpPluginProperties.MAX_BUFFER_SIZE_PROP)) {
+      return Integer.parseInt(BzmHttpPluginProperties.getPropDefault(
+          BzmHttpPluginProperties.MAX_BUFFER_SIZE_PROP, "-1").trim());
+    }
+    Properties props = JMeterUtils.getJMeterProperties();
+    if (props != null
+        && props.containsKey(BzmHttpPluginProperties.JMETER_MAX_BYTES_TO_STORE_PER_REQUEST)) {
+      return Integer.parseInt(JMeterUtils.getPropDefault(
+          BzmHttpPluginProperties.JMETER_MAX_BYTES_TO_STORE_PER_REQUEST, "0").trim());
+    }
+    return -1;
   }
 
   private boolean getBooleanProp(String key, Boolean overrideValue, boolean defaultValue) {
@@ -1576,8 +1615,9 @@ public class HTTP2JettyClient {
       return cacheManager.buildCachedSampleResult(result);
     }
     lowLevelDebug("=== Creating HTTP2FutureResponseListener ===");
-    lowLevelDebug("maxBufferSize: {}", maxBufferSize);
-    HTTP2FutureResponseListener listener = new HTTP2FutureResponseListener(maxBufferSize);
+    lowLevelDebug("maxBytesToStorePerRequest: {}", maxBufferSize);
+    HTTP2FutureResponseListener listener =
+        new HTTP2FutureResponseListener(JETTY_BUFFERING_UNLIMITED);
     lowLevelDebug("=== HTTP2FutureResponseListener created successfully ===");
     listener.setRequest(request);
     lowLevelDebug("=== About to call send() ===");
@@ -1882,7 +1922,8 @@ public class HTTP2JettyClient {
     java.util.concurrent.atomic.AtomicBoolean h2Started =
         new java.util.concurrent.atomic.AtomicBoolean(false);
 
-    HTTP2FutureResponseListener h2Listener = new HTTP2FutureResponseListener(maxBufferSize);
+    HTTP2FutureResponseListener h2Listener =
+        new HTTP2FutureResponseListener(JETTY_BUFFERING_UNLIMITED);
     Request h2Request = cloneRequest(h3Request, httpClientNoH3);
     h2Listener.setRequest(h2Request);
 
@@ -4008,7 +4049,8 @@ public class HTTP2JettyClient {
     // Decode compressed payloads when possible even if the request did not advertise
     // Accept-Encoding (some servers still compress, and JMeter should show decoded body).
     byte[] responseContent = maybeDecodeCompressedContent(contentResponse);
-    // Avoid an extra stream->byte[] copy; content is already fully buffered.
+    // JMeter parity: optionally truncate stored response data while keeping full bodySize.
+    responseContent = maybeTruncateStoredResponseData(result, responseContent);
     result.setResponseData(responseContent);
 
     if (result.getEndTime() == 0) {
@@ -4120,6 +4162,33 @@ public class HTTP2JettyClient {
           StandardOpenOption.CREATE, StandardOpenOption.APPEND);
     } catch (IOException ignored) {
       // Intentional: best-effort diagnostic logging.
+    }
+  }
+
+  /**
+   * Matches {@code HTTPSamplerBase#readResponse}: keep at most {@link #maxBufferSize} bytes in the
+   * sample store, log the same debug line JMeter uses, set {@code bodySize} to the full decoded
+   * length, and leave the sample successful. Skipped while recording.
+   */
+  private byte[] maybeTruncateStoredResponseData(HTTPSampleResult result, byte[] content) {
+    if (content == null) {
+      return new byte[0];
+    }
+    int fullLength = content.length;
+    if (maxBufferSize <= 0 || fullLength <= maxBufferSize || isJMeterRecording()) {
+      return content;
+    }
+    // Same message as Apache JMeter HTTPSamplerBase.readResponse (debug level).
+    LOG.debug("Big response, truncating it to {} bytes", maxBufferSize);
+    result.setBodySize(fullLength);
+    return Arrays.copyOf(content, maxBufferSize);
+  }
+
+  private static boolean isJMeterRecording() {
+    try {
+      return JMeterContextService.getContext().isRecording();
+    } catch (RuntimeException e) {
+      return false;
     }
   }
 

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -190,7 +190,8 @@ public class HTTP2JettyClient {
   private static final Map<String, Http1OnlyEntry> HTTP1_ONLY_CACHE = new ConcurrentHashMap<>();
   private static final Map<String, H2cEntry> H2C_CACHE = new ConcurrentHashMap<>();
   private int requestTimeout = 0;
-  private int maxBufferSize = 21 * 1024 * 1024;
+  /** {@code -1} means unlimited (Jetty {@code DynamicCapacity} treats negative as no cap). */
+  private int maxBufferSize = -1;
   private int maxThreads = 5;
   private boolean maxThreadsConfigured = false;
   private int minThreads = 1;
@@ -737,7 +738,7 @@ public class HTTP2JettyClient {
             "httpJettyClient.byteBufferPoolFactor", String.valueOf(byteBufferPoolFactor)));
     maxBufferSize =
         Integer.parseInt(BzmHttpPluginProperties.getPropDefault("httpJettyClient.maxBufferSize",
-            String.valueOf(2 * 1024 * 1024)));
+            "-1"));
     minThreads = Integer
         .parseInt(BzmHttpPluginProperties.getPropDefault("httpJettyClient.minThreads",
             String.valueOf(minThreads)));

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -402,7 +402,7 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
             this.result.setIgnore();
           }
           HTTP2FutureResponseListener listener =
-              new HTTP2FutureResponseListener(client.getMaxBufferSize());
+              new HTTP2FutureResponseListener(HTTP2JettyClient.getJettyBufferingMaxLength());
           this.asyncListener = listener;
           Request req = client.sampleAsync(this, this.result, listener);
           req.send(listener); // Fire the Async

--- a/src/main/java/com/blazemeter/jmeter/http2/util/BzmHttpPluginProperties.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/util/BzmHttpPluginProperties.java
@@ -29,6 +29,20 @@ public final class BzmHttpPluginProperties {
   /** Legacy prefix for async-controller-related JMeter properties (backward compatibility). */
   public static final String CONTROLLER_LEGACY_PREFIX = "http2AsyncController.";
 
+  /**
+   * Plugin property for max bytes stored in HTTP sample response data (any accepted prefix form).
+   * Aliases: {@code blazemeter.http.maxBufferSize}, {@code HTTP2Sampler.maxBufferSize},
+   * {@code httpJettyClient.maxBufferSize}.
+   */
+  public static final String MAX_BUFFER_SIZE_PROP = "httpJettyClient.maxBufferSize";
+
+  /**
+   * Stock JMeter property for max response bytes stored per request (HTTPSamplerBase /
+   * HTTPFileImpl).
+   */
+  public static final String JMETER_MAX_BYTES_TO_STORE_PER_REQUEST =
+      "httpsampler.max_bytes_to_store_per_request";
+
   private static final String PREFERRED_PREFIX = "blazemeter.http.";
   private static final String LEGACY_SAMPLER_PREFIX = "HTTP2Sampler.";
   private static final String LEGACY_JETTY_PREFIX = "httpJettyClient.";
@@ -68,6 +82,14 @@ public final class BzmHttpPluginProperties {
         samplerKeyForSuffix(suffix),
         jettyKeyForSuffix(suffix)
     };
+  }
+
+  /**
+   * All accepted JMeter property keys for a plugin setting (preferred + legacy aliases), for
+   * tests or cleanup that must remove every form.
+   */
+  public static String[] keysInResolveOrder(String propertyName) {
+    return allKeysInResolveOrder(propertyName);
   }
 
   /** Suffix after {@link #CONTROLLER_PREFERRED_PREFIX} or {@link #CONTROLLER_LEGACY_PREFIX}. */

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListenerTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListenerTest.java
@@ -31,6 +31,13 @@ public class HTTP2FutureResponseListenerTest extends HTTP2TestBase {
     }
 
     @Test
+    public void defaultConstructorUsesUnlimitedBufferingCapacity() {
+        // Jetty BufferingResponseListener's no-arg default is 2 MiB; plugin default must stay -1
+        // (DynamicCapacity maps that to Long.MAX_VALUE) so large responses are not rejected.
+        assertEquals(Long.MAX_VALUE, listener.getMaxLength());
+    }
+
+    @Test
     public void getRequestReturnsSetRequest() {
         assertEquals(mockRequest, listener.getRequest());
     }

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
@@ -1629,24 +1629,65 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
   public void shouldGetResponseWhenBufferSizeIsSmallerOrTheSameAsMaxBufferSize() throws Exception {
     buildStartedServer();
     JMeterUtils.setProperty("httpJettyClient.maxBufferSize", String.valueOf(BIG_BUFFER_SIZE));
-    HTTPSampleResult result = sampleWithGet(SERVER_PATH_BIG_RESPONSE);
-    //Since no text response was set, we validate the size of the response body instead.
-    assertThat(result.getBodySizeAsLong()).isEqualTo(BIG_BUFFER_SIZE);
+    try {
+      HTTPSampleResult result = sampleWithGet(SERVER_PATH_BIG_RESPONSE);
+      //Since no text response was set, we validate the size of the response body instead.
+      assertThat(result.getBodySizeAsLong()).isEqualTo(BIG_BUFFER_SIZE);
+    } finally {
+      clearMaxBufferSizeProperties();
+    }
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void shouldThrowAnExceptionWhenBufferSizeIsBiggerThanMaxBufferSize() throws Throwable {
     buildStartedServer();
     JMeterUtils.setProperty("httpJettyClient.maxBufferSize", String.valueOf(BIG_BUFFER_SIZE - 1));
-    sampleWithGet(SERVER_PATH_BIG_RESPONSE);
+    try {
+      sampleWithGet(SERVER_PATH_BIG_RESPONSE);
+    } finally {
+      clearMaxBufferSizeProperties();
+    }
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void shouldNotGetAResponseWhenBufferSizeIsBiggerThanMaxBufferSize() throws Exception {
     buildStartedServer();
     JMeterUtils.setProperty("httpJettyClient.maxBufferSize", String.valueOf(BIG_BUFFER_SIZE - 1));
-    //There is no response, since an exception is thrown in this case
-    sampleWithGet(SERVER_PATH_BIG_RESPONSE);
+    try {
+      //There is no response, since an exception is thrown in this case
+      sampleWithGet(SERVER_PATH_BIG_RESPONSE);
+    } finally {
+      clearMaxBufferSizeProperties();
+    }
+  }
+
+  /**
+   * Regression guard: plugin default {@code maxBufferSize=-1} must accept bodies larger than
+   * Jetty {@link org.eclipse.jetty.client.BufferingResponseListener}'s built-in 2 MiB default.
+   * {@link ServerBuilder#BIG_BUFFER_SIZE} is 4 MiB; if the unlimited default is lost, Jetty aborts
+   * with {@code Buffering capacity 2097152 exceeded}.
+   */
+  @Test
+  public void shouldGetBigResponseWhenMaxBufferSizeUsesUnlimitedPluginDefault() throws Exception {
+    clearMaxBufferSizeProperties();
+    buildStartedServer();
+    client.loadProperties();
+    assertThat(client.getMaxBufferSize())
+        .as("plugin default must stay unlimited (-1), not Jetty's 2 MiB BufferingResponseListener "
+            + "default")
+        .isEqualTo(-1);
+
+    HTTPSampleResult result = sampleWithGet(SERVER_PATH_BIG_RESPONSE);
+
+    assertThat(result.isSuccessful()).isTrue();
+    assertThat(result.getBodySizeAsLong()).isEqualTo(BIG_BUFFER_SIZE);
+  }
+
+  private static void clearMaxBufferSizeProperties() {
+    java.util.Properties props = JMeterUtils.getJMeterProperties();
+    props.remove("blazemeter.http.maxBufferSize");
+    props.remove("HTTP2Sampler.maxBufferSize");
+    props.remove("httpJettyClient.maxBufferSize");
   }
 
   @Test

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
@@ -38,6 +38,7 @@ import com.blazemeter.jmeter.http2.HTTP2TestBase;
 import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
 import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
 import com.blazemeter.jmeter.http2.sampler.JMeterTestUtils;
+import com.blazemeter.jmeter.http2.util.BzmHttpPluginProperties;
 import com.google.common.io.Resources;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -1626,50 +1627,95 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
   }
 
   @Test
-  public void shouldGetResponseWhenBufferSizeIsSmallerOrTheSameAsMaxBufferSize() throws Exception {
+  public void shouldStoreFullBodyWhenWithinMaxBytesToStore() throws Exception {
     buildStartedServer();
-    JMeterUtils.setProperty("httpJettyClient.maxBufferSize", String.valueOf(BIG_BUFFER_SIZE));
+    JMeterUtils.setProperty(BzmHttpPluginProperties.MAX_BUFFER_SIZE_PROP,
+        String.valueOf(BIG_BUFFER_SIZE));
     try {
       HTTPSampleResult result = sampleWithGet(SERVER_PATH_BIG_RESPONSE);
-      //Since no text response was set, we validate the size of the response body instead.
+      assertThat(result.isSuccessful()).isTrue();
+      assertThat(result.getResponseData().length).isEqualTo(BIG_BUFFER_SIZE);
       assertThat(result.getBodySizeAsLong()).isEqualTo(BIG_BUFFER_SIZE);
     } finally {
-      clearMaxBufferSizeProperties();
+      clearMaxBytesToStoreProperties();
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldThrowAnExceptionWhenBufferSizeIsBiggerThanMaxBufferSize() throws Throwable {
+  @Test
+  public void shouldTruncateStoredResponseLikeJMeterWhenPluginMaxBufferSizeExceeded()
+      throws Exception {
     buildStartedServer();
-    JMeterUtils.setProperty("httpJettyClient.maxBufferSize", String.valueOf(BIG_BUFFER_SIZE - 1));
+    int storeLimit = BIG_BUFFER_SIZE - 1;
+    JMeterUtils.setProperty(BzmHttpPluginProperties.MAX_BUFFER_SIZE_PROP,
+        String.valueOf(storeLimit));
     try {
-      sampleWithGet(SERVER_PATH_BIG_RESPONSE);
+      HTTPSampleResult result = sampleWithGet(SERVER_PATH_BIG_RESPONSE);
+      assertThat(result.isSuccessful()).isTrue();
+      assertThat(result.getResponseCode()).isEqualTo("200");
+      assertThat(result.getResponseData().length).isEqualTo(storeLimit);
+      // Full decoded length retained for throughput/size (JMeter file:// / store semantics).
+      assertThat(result.getBodySizeAsLong()).isEqualTo(BIG_BUFFER_SIZE);
+      assertThat(result.getResponseMessage()).doesNotContain("Buffering capacity");
+      // ServerBuilder marks the big body as image/jpg → binary data type like stock JMeter.
+      assertThat(result.getDataType()).isEqualTo(SampleResult.BINARY);
+      assertThat(result.getContentType()).startsWith("image/jpg");
     } finally {
-      clearMaxBufferSizeProperties();
+      clearMaxBytesToStoreProperties();
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldNotGetAResponseWhenBufferSizeIsBiggerThanMaxBufferSize() throws Exception {
+  @Test
+  public void shouldUseJMeterMaxBytesToStoreWhenPluginMaxBufferSizeUnset() throws Exception {
+    clearMaxBytesToStoreProperties();
     buildStartedServer();
-    JMeterUtils.setProperty("httpJettyClient.maxBufferSize", String.valueOf(BIG_BUFFER_SIZE - 1));
+    int storeLimit = BIG_BUFFER_SIZE - 1;
+    JMeterUtils.setProperty(BzmHttpPluginProperties.JMETER_MAX_BYTES_TO_STORE_PER_REQUEST,
+        String.valueOf(storeLimit));
     try {
-      //There is no response, since an exception is thrown in this case
-      sampleWithGet(SERVER_PATH_BIG_RESPONSE);
+      client.loadProperties();
+      assertThat(client.getMaxBufferSize()).isEqualTo(storeLimit);
+
+      HTTPSampleResult result = sampleWithGet(SERVER_PATH_BIG_RESPONSE);
+      assertThat(result.isSuccessful()).isTrue();
+      assertThat(result.getResponseData().length).isEqualTo(storeLimit);
+      assertThat(result.getBodySizeAsLong()).isEqualTo(BIG_BUFFER_SIZE);
     } finally {
-      clearMaxBufferSizeProperties();
+      clearMaxBytesToStoreProperties();
+    }
+  }
+
+  @Test
+  public void shouldPreferPluginMaxBufferSizeOverJMeterMaxBytesToStore() throws Exception {
+    clearMaxBytesToStoreProperties();
+    buildStartedServer();
+    int jmeterLimit = 1024;
+    int pluginLimit = BIG_BUFFER_SIZE - 1;
+    JMeterUtils.setProperty(BzmHttpPluginProperties.JMETER_MAX_BYTES_TO_STORE_PER_REQUEST,
+        String.valueOf(jmeterLimit));
+    JMeterUtils.setProperty(BzmHttpPluginProperties.MAX_BUFFER_SIZE_PROP,
+        String.valueOf(pluginLimit));
+    try {
+      client.loadProperties();
+      assertThat(client.getMaxBufferSize()).isEqualTo(pluginLimit);
+
+      HTTPSampleResult result = sampleWithGet(SERVER_PATH_BIG_RESPONSE);
+      assertThat(result.isSuccessful()).isTrue();
+      assertThat(result.getResponseData().length).isEqualTo(pluginLimit);
+      assertThat(result.getBodySizeAsLong()).isEqualTo(BIG_BUFFER_SIZE);
+    } finally {
+      clearMaxBytesToStoreProperties();
     }
   }
 
   /**
-   * Regression guard: plugin default {@code maxBufferSize=-1} must accept bodies larger than
+   * Regression guard: plugin default store limit {@code -1} must accept bodies larger than
    * Jetty {@link org.eclipse.jetty.client.BufferingResponseListener}'s built-in 2 MiB default.
-   * {@link ServerBuilder#BIG_BUFFER_SIZE} is 4 MiB; if the unlimited default is lost, Jetty aborts
-   * with {@code Buffering capacity 2097152 exceeded}.
+   * {@link ServerBuilder#BIG_BUFFER_SIZE} is 4 MiB; if Jetty buffering were left at 2 MiB, the
+   * sample would fail with {@code Buffering capacity 2097152 exceeded}.
    */
   @Test
   public void shouldGetBigResponseWhenMaxBufferSizeUsesUnlimitedPluginDefault() throws Exception {
-    clearMaxBufferSizeProperties();
+    clearMaxBytesToStoreProperties();
     buildStartedServer();
     client.loadProperties();
     assertThat(client.getMaxBufferSize())
@@ -1680,14 +1726,17 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
     HTTPSampleResult result = sampleWithGet(SERVER_PATH_BIG_RESPONSE);
 
     assertThat(result.isSuccessful()).isTrue();
+    assertThat(result.getResponseData().length).isEqualTo(BIG_BUFFER_SIZE);
     assertThat(result.getBodySizeAsLong()).isEqualTo(BIG_BUFFER_SIZE);
   }
 
-  private static void clearMaxBufferSizeProperties() {
+  private static void clearMaxBytesToStoreProperties() {
     java.util.Properties props = JMeterUtils.getJMeterProperties();
-    props.remove("blazemeter.http.maxBufferSize");
-    props.remove("HTTP2Sampler.maxBufferSize");
-    props.remove("httpJettyClient.maxBufferSize");
+    for (String key : BzmHttpPluginProperties.keysInResolveOrder(
+        BzmHttpPluginProperties.MAX_BUFFER_SIZE_PROP)) {
+      props.remove(key);
+    }
+    props.remove(BzmHttpPluginProperties.JMETER_MAX_BYTES_TO_STORE_PER_REQUEST);
   }
 
   @Test

--- a/src/test/java/com/blazemeter/jmeter/http2/core/ServerBuilder.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/ServerBuilder.java
@@ -451,8 +451,8 @@ public class ServerBuilder {
             resp.setStatus(HttpStatus.OK_200);
             break;
           case SERVER_PATH_BIG_RESPONSE:
-            resp.getOutputStream().write(new byte[(int) BIG_BUFFER_SIZE]);
             resp.setContentType("image/jpg");
+            resp.getOutputStream().write(new byte[(int) BIG_BUFFER_SIZE]);
             break;
         }
       }

--- a/src/test/java/com/blazemeter/jmeter/http2/parity/Http401WithoutWwwAuthenticateParityTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/parity/Http401WithoutWwwAuthenticateParityTest.java
@@ -43,6 +43,9 @@ public class Http401WithoutWwwAuthenticateParityTest extends HTTP2TestBase {
   private HTTP2JettyClient pluginClient;
   private HTTP2Sampler sampler;
   private String originalSharedThreadPoolProperty;
+  private String originalEnableHttp1Property;
+  private String originalEnableHttp2Property;
+  private String originalEnableHttp3Property;
 
   @BeforeClass
   public static void setupClass() {
@@ -52,6 +55,9 @@ public class Http401WithoutWwwAuthenticateParityTest extends HTTP2TestBase {
   @Before
   public void setUp() throws Exception {
     originalSharedThreadPoolProperty = JMeterUtils.getProperty("httpJettyClient.sharedThreadPool");
+    originalEnableHttp1Property = JMeterUtils.getProperty("httpJettyClient.enableHttp1");
+    originalEnableHttp2Property = JMeterUtils.getProperty("httpJettyClient.enableHttp2");
+    originalEnableHttp3Property = JMeterUtils.getProperty("httpJettyClient.enableHttp3");
     JMeterUtils.setProperty("httpJettyClient.sharedThreadPool", "false");
     JMeterUtils.setProperty("httpJettyClient.enableHttp1", "true");
     JMeterUtils.setProperty("httpJettyClient.enableHttp2", "false");
@@ -90,11 +96,17 @@ public class Http401WithoutWwwAuthenticateParityTest extends HTTP2TestBase {
     if (server != null) {
       server.stop();
     }
-    if (originalSharedThreadPoolProperty == null) {
-      JMeterUtils.getJMeterProperties().remove("httpJettyClient.sharedThreadPool");
+    restoreProperty("httpJettyClient.sharedThreadPool", originalSharedThreadPoolProperty);
+    restoreProperty("httpJettyClient.enableHttp1", originalEnableHttp1Property);
+    restoreProperty("httpJettyClient.enableHttp2", originalEnableHttp2Property);
+    restoreProperty("httpJettyClient.enableHttp3", originalEnableHttp3Property);
+  }
+
+  private static void restoreProperty(String key, String originalValue) {
+    if (originalValue == null) {
+      JMeterUtils.getJMeterProperties().remove(key);
     } else {
-      JMeterUtils.setProperty("httpJettyClient.sharedThreadPool",
-          originalSharedThreadPoolProperty);
+      JMeterUtils.setProperty(key, originalValue);
     }
   }
 

--- a/src/test/java/com/blazemeter/jmeter/http2/sampler/HTTP2SamplerLazyResponseParserLoadingTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/sampler/HTTP2SamplerLazyResponseParserLoadingTest.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.jmeter.util.JMeterUtils;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 
 /**
@@ -28,17 +29,32 @@ public class HTTP2SamplerLazyResponseParserLoadingTest extends HTTP2TestBase {
   private String originalResponseParsersProperty;
   private String originalClassNameProperty;
   private String originalTypesProperty;
+  /** Only {@link #loadsParsersOnFirstUseFromPropertiesSetAfterClassInitialization} mutates these. */
+  private boolean restoredResponseParserProperties;
 
   @After
   public void tearDown() throws Exception {
-    restoreProperty("HTTPResponse.parsers", originalResponseParsersProperty);
-    restoreProperty(TEST_PARSER_KEY + ".className", originalClassNameProperty);
-    restoreProperty(TEST_PARSER_KEY + ".types", originalTypesProperty);
+    if (restoredResponseParserProperties) {
+      restoreProperty("HTTPResponse.parsers", originalResponseParsersProperty);
+      restoreProperty(TEST_PARSER_KEY + ".className", originalClassNameProperty);
+      restoreProperty(TEST_PARSER_KEY + ".types", originalTypesProperty);
+    }
     if (originalParsers != null) {
       Map<String, String> parsers = parsersField();
       parsers.clear();
       parsers.putAll(originalParsers);
     }
+  }
+
+  /**
+   * {@link #doesNotReloadOnceParsersAreAlreadyRegistered} must not wipe {@code HTTPResponse.parsers}
+   * for later test classes (JUnit creates a fresh instance per method; that test never captures the
+   * original property, and a naive {@code restore(null)} would {@code remove} the suite default).
+   */
+  @AfterClass
+  public static void restoreSuiteResponseParserProperties() throws Exception {
+    JMeterTestUtils.ensureResponseParserProperties();
+    parsersField().clear();
   }
 
   @Test
@@ -50,6 +66,7 @@ public class HTTP2SamplerLazyResponseParserLoadingTest extends HTTP2TestBase {
     originalResponseParsersProperty = JMeterUtils.getProperty("HTTPResponse.parsers");
     originalClassNameProperty = JMeterUtils.getProperty(TEST_PARSER_KEY + ".className");
     originalTypesProperty = JMeterUtils.getProperty(TEST_PARSER_KEY + ".types");
+    restoredResponseParserProperties = true;
 
     // Set AFTER the class (and its old static block, if it still existed) would already have
     // run - simulating a JMeter batch run applying -q jmeter-batch.properties post-class-load.

--- a/src/test/java/com/blazemeter/jmeter/http2/sampler/JMeterTestUtils.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/sampler/JMeterTestUtils.java
@@ -17,17 +17,24 @@ public class JMeterTestUtils {
       TestJMeterUtils.createJmeterEnv();
       // Use a real locale to avoid ignoreresources warnings in test logs.
       JMeterUtils.setLocale(Locale.ENGLISH);
-      JMeterUtils.setProperty("HTTPResponse.parsers", "htmlParser wmlParser cssParser");
-      JMeterUtils.setProperty("htmlParser.className",
-          "org.apache.jmeter.protocol.http.parser.LagartoBasedHtmlParser");
-      JMeterUtils.setProperty("htmlParser.types",
-          "text/html application/xhtml+xml application/xml text/xml");
-      JMeterUtils.setProperty("wmlParser.className",
-          "org.apache.jmeter.protocol.http.parser.RegexpHTMLParser");
-      JMeterUtils.setProperty("wmlParser.types", "text/vnd.wap.wml");
-      JMeterUtils
-          .setProperty("cssParser.className", "org.apache.jmeter.protocol.http.parser.CssParser");
-      JMeterUtils.setProperty("cssParser.types", "text/css");
     }
+    // Always (re)apply: individual tests may mutate or remove these properties, and
+    // HTTP2Sampler loads parsers lazily from whatever is set when first needed.
+    ensureResponseParserProperties();
+  }
+
+  /** Suite defaults for HTML/CSS/WML link extractors used by embedded-resource downloads. */
+  public static void ensureResponseParserProperties() {
+    JMeterUtils.setProperty("HTTPResponse.parsers", "htmlParser wmlParser cssParser");
+    JMeterUtils.setProperty("htmlParser.className",
+        "org.apache.jmeter.protocol.http.parser.LagartoBasedHtmlParser");
+    JMeterUtils.setProperty("htmlParser.types",
+        "text/html application/xhtml+xml application/xml text/xml");
+    JMeterUtils.setProperty("wmlParser.className",
+        "org.apache.jmeter.protocol.http.parser.RegexpHTMLParser");
+    JMeterUtils.setProperty("wmlParser.types", "text/vnd.wap.wml");
+    JMeterUtils.setProperty("cssParser.className",
+        "org.apache.jmeter.protocol.http.parser.CssParser");
+    JMeterUtils.setProperty("cssParser.types", "text/css");
   }
 }


### PR DESCRIPTION
This pull request refactors how HTTP response data truncation (buffer capacity) is handled in the BlazeMeter HTTP plugin, aligning its behavior more closely with Apache JMeter. The changes clarify configuration precedence, ensure that large HTTP responses are not aborted but are optionally truncated only when storing sample data, and update documentation and tests accordingly.

**Configuration and Documentation Updates:**
- Updated the documentation in `README.md` to clarify that by default, there is no truncation of stored response data, and to explain the new precedence order for buffer size configuration. The default is now unlimited unless explicitly set. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L312-R328) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L378-R392)

**Core Logic and Behavior Changes:**
- Changed the default buffer size in `HTTP2FutureResponseListener` and `HTTP2JettyClient` to unlimited (`-1`), ensuring that large responses are not rejected or truncated unless configured. [[1]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aL40-R40) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL193-R207)
- Refactored buffer size configuration resolution in `HTTP2JettyClient` to use plugin properties first, then JMeter’s property, then unlimited. Truncation now only affects how much data is stored in the sample, not what is downloaded. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL738-R761) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR893-R911)
- Implemented `maybeTruncateStoredResponseData`, which truncates stored response data (not the downloaded data) to the configured limit, logs a debug message, and keeps the sample successful. Truncation is skipped during recording. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL4010-R4053) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR4168-R4194)

**Test and Utility Enhancements:**
- Added tests to verify that the default constructor uses unlimited buffering capacity.
- Added utility methods and constants for property key resolution and documentation of configuration aliases. [[1]](diffhunk://#diff-f9e093337b2baba3bbe0ee659750ab7594c491d7653e1ea1ce44586110301e4cR32-R45) [[2]](diffhunk://#diff-f9e093337b2baba3bbe0ee659750ab7594c491d7653e1ea1ce44586110301e4cR87-R94)

**Code Consistency and Clean-up:**
- Updated all usages to pass the correct buffer size to listeners and clarified documentation/comments throughout the codebase. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL1578-R1620) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL1884-R1926) [[3]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30L405-R405)

These changes ensure that the plugin’s handling of large HTTP responses is more robust, configurable, and consistent with JMeter’s expectations.