### PR TITLE
Improve negotiation logic and embed hanging functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jmeter.version>5.5</jmeter.version>
     <jetty.version>12.1.11</jetty.version>
+    <!-- Matches the log4j that JMeter 5.6.x ships in lib/, which provides the API at runtime. -->
+    <log4j.version>2.22.1</log4j.version>
     <!-- Matches jetty-project ${brotli4j.version} for Jetty 12.1.11 -->
     <brotli4j.version>1.23.0</brotli4j.version>
     <checkstyle.skip>false</checkstyle.skip>
@@ -176,6 +178,33 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>2.0.9</version>
+    </dependency>
+    <!--
+      SLF4J provider for the *relocated* org.slf4j, bundled in the shaded jar.
+      Without it, SLF4J finds no provider for com.blazemeter.jmeter.http2.shaded.org.slf4j and
+      falls back to NOP, so every log statement in this plugin and in the shaded Jetty is silently
+      discarded at runtime (JMeter's own log4j-slf4j-impl only binds the unrelocated org.slf4j).
+      This binding talks to the unrelocated org.apache.logging.log4j API, so records end up in
+      JMeter's log4j-core and therefore in jmeter.log. Version matches the log4j that JMeter ships.
+      See the org.apache.logging.slf4j relocation below, which is required to make this work.
+    -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+    <!-- Provided by JMeter's lib/; must not be bundled or it would shadow the runtime's own. -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -346,6 +375,19 @@
                   <pattern>org.slf4j</pattern>
                   <shadedPattern>com.blazemeter.jmeter.http2.shaded.org.slf4j</shadedPattern>
                 </relocation>
+                <!--
+                  log4j-slf4j2-impl's own classes live in org.apache.logging.slf4j, the same package
+                  JMeter's log4j-slf4j-impl (the SLF4J 1.7 binding) uses. Leaving them unrelocated
+                  makes the two bindings collide on class names such as Log4jLoggerFactory, and
+                  whichever the classloader picks first may be the one compiled against the *other*
+                  SLF4J API. Relocating keeps our binding self-consistent with the relocated
+                  org.slf4j above. Note org.apache.logging.log4j (the API) is deliberately NOT
+                  relocated: it has to resolve to JMeter's log4j-core so records reach jmeter.log.
+                -->
+                <relocation>
+                  <pattern>org.apache.logging.slf4j</pattern>
+                  <shadedPattern>com.blazemeter.jmeter.http2.shaded.org.apache.logging.slf4j</shadedPattern>
+                </relocation>
                 <!-- Do not relocate com.github.luben.zstd; zstd-jni uses native linkage. -->
                 <relocation>
                   <pattern>com.github.benmanes.caffeine</pattern>
@@ -400,6 +442,16 @@
         <configuration>
           <!-- avoid issue with jdk 11+ -->
           <useSystemClassLoader>false</useSystemClassLoader>
+          <!--
+            log4j-slf4j2-impl exists only to be bundled (relocated) in the shaded jar. Tests run
+            against unshaded classes, where it lands in the same org.apache.logging.slf4j package as
+            the SLF4J 1.7 binding that JMeter pulls in, and the two disagree on constructors
+            (NoSuchMethodError on Log4jLoggerFactory while initializing JMeterUtils). Keep it off
+            the test classpath; unit tests log through slf4j-simple as before.
+          -->
+          <classpathDependencyExcludes>
+            <classpathDependencyExclude>org.apache.logging.log4j:log4j-slf4j2-impl</classpathDependencyExclude>
+          </classpathDependencyExcludes>
           <!-- Allow slf4j-simple in unit tests to enable Jetty frame logging. -->
           <excludes>
             <exclude>**/*IntegrationTest.java</exclude>
@@ -495,6 +547,11 @@
           <includes>
             <include>**/*IntegrationTest.java</include>
           </includes>
+          <!-- Same clash as in surefire above: the shaded-jar-only SLF4J binding must stay off the
+               unshaded test classpath. -->
+          <classpathDependencyExcludes>
+            <classpathDependencyExclude>org.apache.logging.log4j:log4j-slf4j2-impl</classpathDependencyExclude>
+          </classpathDependencyExcludes>
         </configuration>
         <executions>
           <execution>

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListener.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListener.java
@@ -33,6 +33,17 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
   private ContentResponse response;
   private Throwable failure;
   private volatile boolean cancelled;
+  /**
+   * Set once a result has been handed to this listener from the outside via
+   * {@link #completeWith}, after which callbacks from its own request are ignored. See that method.
+   */
+  private volatile boolean sealed;
+  /**
+   * Protocol label when this listener belongs to one side of a protocol race ("HTTP/3", "HTTP/2").
+   * A failure on a raced attempt is not an error: it means that protocol was not negotiated for the
+   * origin, while the competing attempt still serves the request. See {@link #onComplete}.
+   */
+  private volatile String raceProtocol;
   private long responseStart;
   private long responseEnd;
 
@@ -59,6 +70,15 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
     return request;
   }
 
+  /** Marks this listener as one side of a protocol race. See {@link #raceProtocol}. */
+  public void setRaceProtocol(String raceProtocol) {
+    this.raceProtocol = raceProtocol;
+  }
+
+  public String getRaceProtocol() {
+    return raceProtocol;
+  }
+
   protected void setStart() {
     if (this.responseStart == 0) {
       this.responseStart = System.currentTimeMillis();
@@ -77,6 +97,18 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
     return this.responseEnd;
   }
 
+  /**
+   * Adopts a result produced by a different request, used when a protocol race resolves in favour
+   * of a competing attempt and the winner's response is reported through this listener.
+   *
+   * <p>Seals the listener: whoever calls this then aborts the losing request, and that abort makes
+   * Jetty invoke {@link #onComplete}/{@link #onFailure} here with a CancellationException. Letting
+   * those through would overwrite {@link #failure} after the winning response was already stored,
+   * and {@link #getResult()} reports "failed after response received" whenever a failure is present
+   * - so a won race would surface as an error to anyone reading this listener afterwards. The
+   * synchronous caller never noticed because it returns the winner directly instead of reading back
+   * from here; a consumer that polls {@link #isDone()} and then calls {@link #get()} does.
+   */
   public void completeWith(ContentResponse response, long responseStart, long responseEnd) {
     this.response = response;
     this.failure = null;
@@ -85,6 +117,7 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
     }
     this.responseEnd = responseEnd > 0 ? responseEnd : System.currentTimeMillis();
     this.onCompleteCalled = true;
+    this.sealed = true;
     this.latch.countDown();
   }
 
@@ -95,6 +128,11 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
    */
   @Override
   public void onFailure(Response response, Throwable failure) {
+    if (sealed) {
+      // Losing side of a resolved race being aborted; see completeWith.
+      lowLevelDebug("onFailure() ignored, listener already completed by a competing attempt");
+      return;
+    }
     lowLevelDebug("=== onFailure() CALLED ===");
     lowLevelDebug("Thread: {}", Thread.currentThread().getName());
     lowLevelDebug("Response: {}", response != null ? "present" : "null");
@@ -141,6 +179,11 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
 
   @Override
   public void onComplete(Result result) {
+    if (sealed) {
+      // Losing side of a resolved race being aborted; see completeWith.
+      lowLevelDebug("onComplete() ignored, listener already completed by a competing attempt");
+      return;
+    }
     // CRITICAL: Mark that onComplete was called
     onCompleteCalled = true;
     
@@ -207,17 +250,32 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
     }
     
     if (failure != null) {
-      LOG.error("Request failed with exception: type={}, message={}", 
-          failure.getClass().getName(), failure.getMessage());
-      if (failure instanceof IOException) {
-        IOException ioException = (IOException) failure;
-        String message = ioException.getMessage();
-        LOG.error("IOException message: {}", message);
-        if (message != null && message.contains("protocol_error")) {
-          LOG.error("HTTP/2 protocol_error in onComplete() - ALPN negotiation likely failed");
+      if (failure instanceof CancellationException) {
+        // The losing side of a resolved protocol race, or an explicit cancel(): expected, and the
+        // winner's response is reported elsewhere. Logging it as an error filled the log with
+        // failures that are not failures, one per raced request.
+        LOG.debug("{} attempt cancelled: {}",
+            raceProtocol != null ? raceProtocol : "Request", failure.getMessage());
+      } else if (raceProtocol != null) {
+        // One side of a race failing on its own is the expected outcome when the origin does not
+        // support that protocol: the other attempt serves the request, and the race only gives up
+        // once both sides fail - at which point the caller reports the real failure. Saying "not
+        // negotiated" rather than "failed" keeps this from reading as a broken request.
+        LOG.debug("{} not negotiated for {}: {}", raceProtocol,
+            request != null ? request.getURI() : "unknown", failure.getMessage());
+      } else {
+        LOG.error("Request failed with exception: type={}, message={}",
+            failure.getClass().getName(), failure.getMessage());
+        if (failure instanceof IOException) {
+          IOException ioException = (IOException) failure;
+          String message = ioException.getMessage();
+          LOG.error("IOException message: {}", message);
+          if (message != null && message.contains("protocol_error")) {
+            LOG.error("HTTP/2 protocol_error in onComplete() - ALPN negotiation likely failed");
+          }
         }
+        lowLevelDebug("Full failure stack trace:", failure);
       }
-      lowLevelDebug("Full failure stack trace:", failure);
     }
     
     latch.countDown();
@@ -431,8 +489,21 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
       } else {
         // It is a failure caused after obtaining the response,
         // analyzing what type of failure it is, and incorporating mechanisms to manage it.
-        LOG.warn("Request failed after response received: status={}, version={}, exception={}",
-            response.getStatus(), response.getVersion(), failure.getClass().getName());
+        if (failure instanceof CancellationException) {
+          // The losing side of a protocol race ends cancelled once the winner has answered. That is
+          // the algorithm working, not a failure, and warning about it made a healthy run look
+          // broken once per raced request.
+          lowLevelDebug("{} attempt cancelled after response: status={}, version={}",
+              raceProtocol != null ? raceProtocol : "Request", response.getStatus(),
+              response.getVersion());
+        } else if (raceProtocol != null) {
+          LOG.debug("{} not negotiated after response: status={}, version={}, exception={}",
+              raceProtocol, response.getStatus(), response.getVersion(),
+              failure.getClass().getName());
+        } else {
+          LOG.warn("Request failed after response received: status={}, version={}, exception={}",
+              response.getStatus(), response.getVersion(), failure.getClass().getName());
+        }
         
         // Check if this is a protocol_error even though we have a response
         if (ProtocolErrorException.isProtocolError(failure)

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -40,9 +40,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -194,7 +196,8 @@ public class HTTP2JettyClient {
   private static final Object HAPPY_EYEBALLS_LOCK = new Object();
   private static final AtomicInteger HAPPY_EYEBALLS_CLIENTS = new AtomicInteger(0);
   private static volatile ScheduledExecutorService happyEyeballsScheduler;
-  private static volatile ScheduledExecutorService happyEyeballsExecutor;
+  /** Runs the blocking response waiters of each protocol race; only needs {@code execute}. */
+  private static volatile ExecutorService happyEyeballsExecutor;
   private static final Map<String, AltSvcEntry> ALT_SVC_CACHE = new ConcurrentHashMap<>();
   private static final Map<String, Http1OnlyEntry> HTTP1_ONLY_CACHE = new ConcurrentHashMap<>();
   private static final Map<String, H2cEntry> H2C_CACHE = new ConcurrentHashMap<>();
@@ -214,7 +217,10 @@ public class HTTP2JettyClient {
   private int byteBufferPoolFactor = 4;
   private int maxConcurrentPushedStreams = 100;
   private int maxRequestsPerConnection = 100;
-  private boolean sharedThreadPoolEnabled = true;
+  // Off by default, matching httpJettyClient.sharedThreadPool; the property opts in. The field used
+  // to initialise to true, which only ever applied on a path that skipped loadProperties and made
+  // the intended default ambiguous to read.
+  private boolean sharedThreadPoolEnabled = false;
 
   // Experimental HTTP/2 SETTINGS frame configuration
   // These can be adjusted via properties to fix protocol_error with specific servers
@@ -248,6 +254,18 @@ public class HTTP2JettyClient {
   private DeflateContentDecoderFactory deflateDecoderFactory;
   private boolean decoderFactoriesInitialized = false;
   private int quicMaxIdleTimeout = 30000;
+  /**
+   * How long to wait for the QUIC handshake before giving up on HTTP/3, in milliseconds.
+   *
+   * <p>Applied by {@link #applyHttp3HandshakeTimeout}, which explains why it lands on the HTTP/3
+   * client rather than on the QUIC connector. It matters because a blocked UDP path does not fail
+   * fast on its own: without it the client keeps Jetty's default connect timeout, long enough that
+   * an HTTP/3 attempt looks like a stalled request rather than an unsupported protocol. Failing
+   * here is safe for any method, including POST - nothing was sent yet - and {@code getContent}
+   * turns it into "mark the origin broken and retry without HTTP/3". Deliberately short: the cost
+   * of being wrong is one request served over HTTP/2.
+   */
+  private int http3HandshakeTimeoutMs = 1000;
   private int quicMaxBidirectionalStreams = 100;
   private int quicMaxUnidirectionalStreams = 100;
   private long http3BrokenCooldownMs = DEFAULT_HTTP3_BROKEN_COOLDOWN_MS;
@@ -480,6 +498,11 @@ public class HTTP2JettyClient {
       try {
         ClientConnector quicConnector = createClientConnector(name + "-quic");
         quicConnector.setIdleTimeout(Duration.ofMillis(quicMaxIdleTimeout));
+        // No connect timeout here: setting one on this connector has no effect, because it is not
+        // the connector that establishes the connection. The transport below is what makes the
+        // attempt use QUIC, while the connecting is done by the main clientConnector, so the
+        // handshake deadline has to be applied to the client that owns it. See
+        // applyHttp3HandshakeTimeout.
 
         QuicheClientQuicConfiguration quicConfig =
             HTTP3ClientQuicConfiguration.configure(new QuicheClientQuicConfiguration());
@@ -522,6 +545,7 @@ public class HTTP2JettyClient {
 
     this.httpClient = new HttpClient(transport);
     configureHttpClient(this.httpClient, clientConnector);
+    applyHttp3HandshakeTimeout();
 
     if (FORCE_HTTP2_ONLY || !enableHttp3) {
       this.httpClientNoH3 = this.httpClient;
@@ -802,6 +826,9 @@ public class HTTP2JettyClient {
     quicMaxIdleTimeout = Integer
         .parseInt(BzmHttpPluginProperties.getPropDefault("httpJettyClient.quicMaxIdleTimeout",
             String.valueOf(quicMaxIdleTimeout)));
+    http3HandshakeTimeoutMs = Integer.parseInt(
+        BzmHttpPluginProperties.getPropDefault("httpJettyClient.http3HandshakeTimeoutMs",
+            String.valueOf(http3HandshakeTimeoutMs)));
     quicMaxBidirectionalStreams =
         Integer.parseInt(BzmHttpPluginProperties.getPropDefault(
             "httpJettyClient.quicMaxBidirectionalStreams",
@@ -1288,19 +1315,7 @@ public class HTTP2JettyClient {
       JmeterRequestHeadersSupport.prepareFromSampler(http11Request, (Boolean) useKeepAlive);
     }
     configureContentDecodersAndCapture(httpClientHttp1Only, http11Request);
-    Request.Content body = originalRequest.getBody();
-    if (body != null) {
-      // The original attempt may already have read some or all of this content before
-      // failing; rewind it back to the start before reuse, exactly as Jetty's own retry
-      // paths do (see AuthenticationProtocolHandler/HttpRedirector). Skipping this can send
-      // a fallback request that declares the right Content-Length but no actual body bytes,
-      // hanging the server until its idle timeout instead of failing fast.
-      if (!body.rewind()) {
-        throw new IllegalStateException(
-            "Request body for " + uri + " is not reproducible for HTTP/1.1 fallback retry");
-      }
-      http11Request.body(body);
-    }
+    copyBodyForRetry(originalRequest, http11Request, "HTTP/1.1 fallback");
     SslClientCertAliasSupport.copyFromRequest(originalRequest, http11Request);
     return http11Request;
   }
@@ -1426,9 +1441,7 @@ public class HTTP2JettyClient {
     }
     ensureHostHeader(h2cRequest, uri);
     configureContentDecodersAndCapture(httpClientH2cPrior, h2cRequest);
-    if (originalRequest.getBody() != null) {
-      h2cRequest.body(originalRequest.getBody());
-    }
+    copyBodyForRetry(originalRequest, h2cRequest, "HTTP/2 cleartext fallback");
 
     ContentResponse response = h2cRequest.send();
     updateH2cCache(h2cRequest, response);
@@ -1581,6 +1594,29 @@ public class HTTP2JettyClient {
     lowLevelDebug("Request prepared, ready to send");
     return request;
 
+  }
+
+  /**
+   * Prepares and fires an asynchronous request, returning it already in flight.
+   *
+   * <p>The caller must not send the returned request: dispatching belongs here because whether the
+   * request goes out on its own or as one side of an HTTP/3 vs HTTP/2 race is a protocol decision,
+   * and the race has to be started by whoever owns that decision. Previously the sampler called
+   * Jetty's {@code Request.send} directly, which skipped that decision: an asynchronous request
+   * selected for HTTP/3 went out with no competing attempt. The protocol fallbacks were still
+   * reached, since the second stage goes through {@link #sampleFromListener} into
+   * {@code getContent} either way - what was lost is the race.
+   */
+  public Request dispatchAsync(HTTP2Sampler sampler, HTTPSampleResult result,
+                               HTTP2FutureResponseListener listener) throws Exception {
+    Request request = sampleAsync(sampler, result, listener);
+    if (shouldUseHappyEyeballs(request)) {
+      lowLevelDebug("Dispatching async request through protocol race: {}", request.getURI());
+      startProtocolRace(request, listener);
+    } else {
+      request.send(listener);
+    }
+    return request;
   }
 
   private void errorWhenNotSupportedMethod(String method) throws UnsupportedOperationException {
@@ -1900,19 +1936,120 @@ public class HTTP2JettyClient {
     if (!fallbackEnabled || !enableHttp3 || !enableHttp2) {
       return false;
     }
+    if (http3PriorKnowledgeEnabled) {
+      // Prior knowledge asserts the origin speaks HTTP/3, so there is nothing to discover and a
+      // competing HTTP/2 attempt would be wasted work: go straight to HTTP/3, exactly like h2c
+      // prior knowledge skips the Upgrade. A failure still reaches the HTTP/1.1 fallback.
+      return false;
+    }
+    if (!isSafeToRace(request)) {
+      return false;
+    }
     Object attempted = request.getAttributes().get(ATTR_HTTP3_ATTEMPTED);
     return Boolean.TRUE.equals(attempted);
+  }
+
+  /**
+   * A protocol race that has been started but not yet resolved.
+   *
+   * <p>Splitting "start" from "wait" is what lets the asynchronous sampling path use the race at
+   * all: it cannot block on a latch, because the JMeter thread has to return and come back later to
+   * collect the result. It polls the shared listener instead, which the race resolves through
+   * {@link HTTP2FutureResponseListener#completeWith}.
+   */
+  private static final class ProtocolRace {
+    private final java.util.concurrent.CountDownLatch done;
+    private final AtomicReference<ContentResponse> winner;
+    private final AtomicReference<Throwable> failure;
+    private final java.util.concurrent.atomic.AtomicBoolean resolved;
+    private final Runnable timeoutCleanup;
+
+    private ProtocolRace(java.util.concurrent.CountDownLatch done,
+                         AtomicReference<ContentResponse> winner,
+                         AtomicReference<Throwable> failure,
+                         java.util.concurrent.atomic.AtomicBoolean resolved,
+                         Runnable timeoutCleanup) {
+      this.done = done;
+      this.winner = winner;
+      this.failure = failure;
+      this.resolved = resolved;
+      this.timeoutCleanup = timeoutCleanup;
+    }
+
+    /** Blocks for the winner. Only the synchronous path calls this. */
+    private ContentResponse await(int timeoutMs)
+        throws InterruptedException, TimeoutException, ExecutionException {
+      if (timeoutMs > 0) {
+        if (!done.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+          if (resolved.compareAndSet(false, true)) {
+            timeoutCleanup.run();
+          }
+          throw new TimeoutException();
+        }
+      } else {
+        done.await();
+      }
+      ContentResponse response = winner.get();
+      if (response != null) {
+        return response;
+      }
+      Throwable t = failure.get();
+      if (t instanceof ExecutionException) {
+        throw (ExecutionException) t;
+      }
+      if (t instanceof TimeoutException) {
+        throw (TimeoutException) t;
+      }
+      throw new ExecutionException(t);
+    }
+  }
+
+  /**
+   * Whether a request may be sent twice at once.
+   *
+   * <p>The race duplicates the whole request, so both attempts can reach the server before one is
+   * aborted, and that is only acceptable with no side effects and no body. Racing a POST could
+   * apply it twice. A body rules it out for a second reason: the clone shares the original's
+   * {@link Request.Content} instance, and one content source cannot feed two requests reading it at
+   * the same time - unlike a retry, where the body is rewound and read once (see
+   * {@link #copyBodyForRetry}).
+   */
+  private boolean isSafeToRace(Request request) {
+    String method = request.getMethod();
+    boolean idempotent = HTTPConstants.GET.equalsIgnoreCase(method)
+        || HTTPConstants.HEAD.equalsIgnoreCase(method);
+    if (!idempotent) {
+      lowLevelDebug("Not racing {} request: only GET/HEAD may be duplicated", method);
+      return false;
+    }
+    if (request.getBody() != null) {
+      lowLevelDebug("Not racing request with a body: one content source cannot feed both attempts");
+      return false;
+    }
+    return true;
   }
 
   private ContentResponse sendWithHappyEyeballs(Request h3Request,
                                                 HTTP2FutureResponseListener h3Listener)
       throws InterruptedException, TimeoutException, ExecutionException {
+    return startProtocolRace(h3Request, h3Listener)
+        .await(requestTimeout > 0 ? requestTimeout + 2000 : 0);
+  }
+
+  /**
+   * Starts an HTTP/3 and an HTTP/2 attempt for the same request and returns immediately. The first
+   * one to respond wins, its response is published on {@code h3Listener}, and the loser is aborted.
+   * The race is given up only once both attempts have failed, at which point the caller's own
+   * HTTP/1.1 fallback takes over.
+   */
+  private ProtocolRace startProtocolRace(Request h3Request,
+                                         HTTP2FutureResponseListener h3Listener)
+      throws ExecutionException {
     URI uri = h3Request.getURI();
     ensureHappyEyeballsExecutors();
     long effectiveDelayMs = computeHappyEyeballsDelayMs(uri);
     lowLevelDebug("Happy Eyeballs enabled for HTTP/3: origin={}, delayMs={}",
         originKey(uri), effectiveDelayMs);
-    int timeoutMs = requestTimeout > 0 ? requestTimeout + 2000 : 0;
     AtomicReference<ContentResponse> winner = new AtomicReference<>();
     AtomicReference<Throwable> failure = new AtomicReference<>();
     AtomicInteger failures = new AtomicInteger(0);
@@ -1926,6 +2063,10 @@ public class HTTP2JettyClient {
         new HTTP2FutureResponseListener(JETTY_BUFFERING_UNLIMITED);
     Request h2Request = cloneRequest(h3Request, httpClientNoH3);
     h2Listener.setRequest(h2Request);
+    // Both sides are raced attempts: a failure on either is "that protocol was not negotiated for
+    // this origin", not a failed request, so it must not be reported as an error.
+    h3Listener.setRaceProtocol("HTTP/3");
+    h2Listener.setRaceProtocol("HTTP/2");
 
     java.util.concurrent.atomic.AtomicReference<java.util.concurrent.ScheduledFuture<?>>
         h2StartFuture = new java.util.concurrent.atomic.AtomicReference<>();
@@ -2026,30 +2167,7 @@ public class HTTP2JettyClient {
           effectiveDelayMs, TimeUnit.MILLISECONDS));
     }
 
-    boolean completed;
-    if (timeoutMs > 0) {
-      completed = done.await(timeoutMs, TimeUnit.MILLISECONDS);
-      if (!completed) {
-        if (resolved.compareAndSet(false, true)) {
-          completeTimeoutCleanup.run();
-        }
-        throw new TimeoutException();
-      }
-    } else {
-      done.await();
-    }
-    ContentResponse response = winner.get();
-    if (response != null) {
-      return response;
-    }
-    Throwable t = failure.get();
-    if (t instanceof ExecutionException) {
-      throw (ExecutionException) t;
-    }
-    if (t instanceof TimeoutException) {
-      throw (TimeoutException) t;
-    }
-    throw new ExecutionException(t);
+    return new ProtocolRace(done, winner, failure, resolved, completeTimeoutCleanup);
   }
 
   public ContentResponse getContent(HTTP2FutureResponseListener listener)
@@ -2131,7 +2249,16 @@ public class HTTP2JettyClient {
     } catch (ExecutionException e) {
       long elapsed = System.currentTimeMillis() - getStart;
       Throwable cause = e.getCause();
-      LOG.error("Request failed after {}ms with ExecutionException", elapsed, e);
+      if (cause instanceof CancellationException) {
+        // Losing side of a resolved protocol race; the winner is reported by the race itself.
+        lowLevelDebug("Request cancelled after {}ms: {}", elapsed, cause.getMessage());
+      } else if (listener != null && listener.getRaceProtocol() != null) {
+        // A raced attempt failing on its own: the competing protocol still serves the request.
+        LOG.debug("{} attempt did not complete after {}ms: {}", listener.getRaceProtocol(),
+            elapsed, cause != null ? cause.getMessage() : e.getMessage());
+      } else {
+        LOG.error("Request failed after {}ms with ExecutionException", elapsed, e);
+      }
 
       // Check if the cause is a ProtocolErrorException
       RetryableRequestException retryable =
@@ -2409,7 +2536,26 @@ public class HTTP2JettyClient {
     JmeterCompressionHeadersSupport.installCapture(request);
   }
 
+  /**
+   * Client selection for callers with no request at hand, such as a retry after GOAWAY. Treats the
+   * request as not recoverable, so an origin is only used over HTTP/3 when it is already known to
+   * speak it, never as exploration.
+   */
   private HttpClient selectHttpClient(URI uri) {
+    return selectHttpClient(uri, false);
+  }
+
+  /**
+   * Picks the client whose protocols match what is known about the origin. Whether the attempt is
+   * <em>raced</em> against HTTP/2 is decided separately, on the built request, by
+   * {@link #shouldUseHappyEyeballs}: that changes how HTTP/3 is attempted, not whether this origin
+   * is worth attempting it on.
+   *
+   * @param recoverable whether a failure to establish the connection can be retried over another
+   *                    protocol, which is what makes exploring HTTP/3 on an unknown origin safe.
+   *                    See {@link #isRecoverableIfHttp3Fails}.
+   */
+  private HttpClient selectHttpClient(URI uri, boolean recoverable) {
     if (uri != null && "http".equalsIgnoreCase(uri.getScheme())) {
       if (enableHttp1 && isHttp1Only(uri)) {
         lowLevelDebug("HTTP/1.1-only cache hit for cleartext origin {}", originKey(uri));
@@ -2419,30 +2565,38 @@ public class HTTP2JettyClient {
         return httpClientHttp1Only;
       }
       if (!enableHttp1 && enableHttp2) {
+        // Nothing to upgrade from, so h2c is only reachable by speaking it from the first byte.
         lowLevelDebug("HTTP/1.1 disabled; using H2C prior knowledge for origin {}",
             originKey(uri));
         return httpClientH2cPrior;
       }
+      // Past this point HTTP/1.1 and HTTP/2 are either both enabled or both disabled, and the
+      // choice is between three mutually exclusive strategies for reaching h2c.
       if (http1UpgradeRequired) {
+        // Strategy 1: the user asked for the Upgrade dance. Three outcomes, in this order.
         if (!enableHttp2) {
+          // Only reachable with HTTP/1.1 disabled as well, i.e. no cleartext protocol left at all.
           LOG.warn("H2C upgrade requested but HTTP/2 is disabled; using HTTP/1.1");
           return httpClientHttp1Only;
         }
         if (shouldUseH2cPriorKnowledge(uri)) {
+          // Skip the upgrade round trip: this origin is already known to speak h2c.
           lowLevelDebug("H2C prior knowledge enabled for origin {}", originKey(uri));
           return httpClientH2cPrior;
         }
         lowLevelDebug("H2C upgrade enabled for origin {}", originKey(uri));
         return httpClientH2cUpgrade;
-      }
-      if (shouldUseH2cPriorKnowledge(uri)) {
+      } else if (shouldUseH2cPriorKnowledge(uri)) {
+        // Strategy 2: no upgrade requested, but h2c is known to work here - either configured as
+        // prior knowledge, or learned from an earlier HTTP/2 response and still cached - so it can
+        // be spoken directly, which is the one cleartext path with no negotiation overhead.
         lowLevelDebug("H2C prior knowledge enabled for origin {}", originKey(uri));
         return httpClientH2cPrior;
+      } else {
+        // Strategy 3: nothing says h2c is available here and the Upgrade was not requested, so use
+        // the default client and let it settle on HTTP/1.1.
+        return httpClientNoH3;
       }
-      if (!enableHttp2 && enableHttp1) {
-        return httpClientHttp1Only;
-      }
-      return httpClientNoH3;
     }
     if (FORCE_HTTP2_ONLY) {
       if (enableHttp1 && isHttp1Only(uri)) {
@@ -2451,7 +2605,7 @@ public class HTTP2JettyClient {
       }
       return httpClientNoH3;
     }
-    boolean attemptHttp3 = shouldAttemptHttp3(uri);
+    boolean attemptHttp3 = shouldAttemptHttp3(uri, recoverable);
     if (attemptHttp3) {
       lowLevelDebug("HTTP/3 enabled for origin {}", originKey(uri));
     } else {
@@ -2460,8 +2614,19 @@ public class HTTP2JettyClient {
     if (attemptHttp3) {
       return httpClient;
     }
-    if (!enableHttp2 && enableHttp1) {
-      return httpClientHttp1Only;
+    if (!enableHttp2) {
+      // With HTTP/2 disabled there is no race to run and no HTTP/2 client to use: go straight to
+      // HTTP/3 when it is enabled (a failure there falls back to HTTP/1.1 through the usual paths,
+      // which check enableHttp1 themselves), and only then to HTTP/1.1. Falling through to the
+      // HTTP/2 client below would have ignored the user disabling HTTP/2 - and, when HTTP/1.1 was
+      // disabled too, would have negotiated exactly the two protocols that were turned off.
+      if (enableHttp3) {
+        lowLevelDebug("HTTP/2 disabled; using HTTP/3 for origin {}", originKey(uri));
+        return httpClient;
+      }
+      if (enableHttp1) {
+        return httpClientHttp1Only;
+      }
     }
     if (enableHttp1 && isHttp1Only(uri)) {
       lowLevelDebug("HTTP/1.1-only cache hit for origin {}", originKey(uri));
@@ -2470,7 +2635,7 @@ public class HTTP2JettyClient {
     return httpClientNoH3;
   }
 
-  private boolean shouldAttemptHttp3(URI uri) {
+  private boolean shouldAttemptHttp3(URI uri, boolean recoverable) {
     if (!enableHttp3) {
       return false;
     }
@@ -2485,14 +2650,29 @@ public class HTTP2JettyClient {
     }
     AltSvcEntry entry = ALT_SVC_CACHE.get(originKey(uri));
     if (entry == null) {
-      return false;
+      // First contact. Alt-Svc can only be learnt from a response, so waiting for the cache to say
+      // yes would mean HTTP/3 is never tried at all here: explore it, as long as the attempt can be
+      // walked back.
+      //
+      // This includes requests that cannot be raced, such as a POST. Those get no concurrent HTTP/2
+      // attempt to cover them, so what makes them safe is that the handshake has its own short
+      // deadline (see applyHttp3HandshakeTimeout) and that the fallback only fires for a failure to
+      // establish the connection - the request never reached the wire, so resending it cannot
+      // repeat a side effect. The outcome is cached either way, so it is the first request to an
+      // origin that pays for the exploration, not every one.
+      return recoverable;
     }
     long now = System.currentTimeMillis();
     if (entry.expiresAt <= now) {
+      // Stale: forget it and explore again rather than trusting an answer that has expired.
       ALT_SVC_CACHE.remove(originKey(uri));
+      return recoverable;
+    }
+    if (entry.brokenUntil > now) {
+      // HTTP/3 failed here recently; stay off it until the cooldown elapses.
       return false;
     }
-    return entry.h3 && now >= entry.brokenUntil;
+    return entry.h3;
   }
 
   private boolean isHttp1Only(URI uri) {
@@ -2586,6 +2766,9 @@ public class HTTP2JettyClient {
     }
     AltSvcEntry entry = ALT_SVC_CACHE.get(originKey(uri));
     if (entry == null) {
+      // First contact still gets the full stagger, on purpose: the delay is what gives HTTP/3 a
+      // chance to win outright so no HTTP/2 path is opened at all. Starting both at once would
+      // create a second connection to every new origin, which is the cost Happy Eyeballs avoids.
       return baseDelay;
     }
     long now = System.currentTimeMillis();
@@ -2720,11 +2903,19 @@ public class HTTP2JettyClient {
       return;
     }
     String origin = originKey(uri);
+    long brokenUntil = System.currentTimeMillis() + http3BrokenCooldownMs;
     AltSvcEntry entry = ALT_SVC_CACHE.get(origin);
     if (entry == null) {
-      return;
+      // The origin never advertised Alt-Svc, so HTTP/3 was tried as exploration. Record the failure
+      // anyway: without an entry there is nothing to hold the cooldown, and every later request
+      // would explore this origin again even though HTTP/3 just failed here. Expiring the entry
+      // when the cooldown ends is what lets exploration resume by itself.
+      entry = new AltSvcEntry();
+      entry.h3 = false;
+      entry.expiresAt = brokenUntil;
+      entry.lastH3SuccessAt = 0L;
     }
-    entry.brokenUntil = System.currentTimeMillis() + http3BrokenCooldownMs;
+    entry.brokenUntil = brokenUntil;
     ALT_SVC_CACHE.put(origin, entry);
     lowLevelDebug("HTTP/3 marked broken for origin {} until {}", origin, entry.brokenUntil);
   }
@@ -2824,6 +3015,45 @@ public class HTTP2JettyClient {
     return response;
   }
 
+  /**
+   * Carries the body of an already-attempted request over to the retry that replaces it.
+   *
+   * <p>The body must be rewound first, and skipping that is not a detail: aborting an attempt also
+   * fails its body {@link Request.Content}, and a failed content source keeps handing that same
+   * exception to whoever reads it next. Reusing the instance as-is makes the retry fail instantly
+   * with the error of the attempt it was supposed to rescue, which reads exactly like the fallback
+   * itself being broken. A partially consumed body is the other half of the problem: it would send
+   * a request declaring the right Content-Length with fewer bytes behind it, hanging the server
+   * until its idle timeout. Jetty's own retry paths rewind for the same reasons (see
+   * AuthenticationProtocolHandler/HttpRedirector).
+   *
+   * <p>A body that cannot be rewound cannot be retried. Failing loudly is deliberate: sending the
+   * retry without it would silently turn the request into a different one.
+   */
+  private static void copyBodyForRetry(Request originalRequest, Request retryRequest,
+      String retryDescription) {
+    Request.Content body = originalRequest.getBody();
+    if (body == null) {
+      return;
+    }
+    if (!body.rewind()) {
+      throw new IllegalStateException("Request body for " + originalRequest.getURI()
+          + " is not reproducible for " + retryDescription + " retry");
+    }
+    retryRequest.body(body);
+  }
+
+  /**
+   * Copies a request onto another client so the same target can be attempted over a different
+   * protocol.
+   *
+   * <p>Two callers, with different constraints worth keeping in mind when changing this:
+   * {@link #startProtocolRace}, where both the original and the copy are sent at once and so
+   * {@link #isSafeToRace} has already restricted it to GET/HEAD without a body; and
+   * {@link #sendWithHttp2Only}, the HTTP/3-to-HTTP/2 fallback, which replaces a request that failed
+   * to connect and therefore has to work for any method, body included. That is why the body goes
+   * through {@link #copyBodyForRetry} rather than being handed over as-is.
+   */
   private Request cloneRequest(Request originalRequest, HttpClient client)
       throws ExecutionException {
     URI uri = originalRequest.getURI();
@@ -2852,9 +3082,7 @@ public class HTTP2JettyClient {
         });
       }
     }
-    if (originalRequest.getBody() != null) {
-      request.body(originalRequest.getBody());
-    }
+    copyBodyForRetry(originalRequest, request, "protocol fallback");
     SslClientCertAliasSupport.copyFromRequest(originalRequest, request);
     configureContentDecodersAndCapture(client, request);
     return request;
@@ -3103,7 +3331,14 @@ public class HTTP2JettyClient {
             new HappyEyeballsThreadFactory("http3-he"));
       }
       if (happyEyeballsExecutor == null || happyEyeballsExecutor.isShutdown()) {
-        happyEyeballsExecutor = Executors.newScheduledThreadPool(2,
+        // Each race parks one thread per attempt waiting for its response, so a fixed pool caps how
+        // many races can resolve at once: with two threads a single race saturates it and every
+        // further race waits in the queue until its request deadline expires, which looks exactly
+        // like both protocols timing out. Concurrent embedded-resource downloads run several races
+        // per JMeter thread, so the pool has to grow on demand. Matches how JMeter sizes its own
+        // parallel-download pool (ResourcesDownloader uses an unbounded cached pool); threads are
+        // reclaimed once idle.
+        happyEyeballsExecutor = Executors.newCachedThreadPool(
             new HappyEyeballsThreadFactory("http3-he-worker"));
       }
     }
@@ -3111,7 +3346,7 @@ public class HTTP2JettyClient {
 
   private static void shutdownHappyEyeballsExecutors() {
     ScheduledExecutorService scheduler;
-    ScheduledExecutorService executor;
+    ExecutorService executor;
     synchronized (HAPPY_EYEBALLS_LOCK) {
       scheduler = happyEyeballsScheduler;
       executor = happyEyeballsExecutor;
@@ -3122,7 +3357,7 @@ public class HTTP2JettyClient {
     shutdownExecutor(executor);
   }
 
-  private static void shutdownExecutor(ScheduledExecutorService executor) {
+  private static void shutdownExecutor(ExecutorService executor) {
     if (executor == null) {
       return;
     }
@@ -3235,7 +3470,10 @@ public class HTTP2JettyClient {
       // Force HTTP/2 when HTTP/1.1 is disabled to avoid mixed-protocol frames.
       request.version(HttpVersion.HTTP_2);
     }
-    boolean http3Attempted = enableHttp3 && client == httpClient && shouldAttemptHttp3(uri);
+    // Selecting the HTTP/3-capable client already means shouldAttemptHttp3 said yes, so re-asking
+    // here would only risk a different answer: this has no request context and would treat every
+    // first contact as "no HTTP/3", clearing the flag that arms the race for those very requests.
+    boolean http3Attempted = enableHttp3 && client == httpClient;
     request.attribute(ATTR_HTTP3_ATTEMPTED, http3Attempted);
     request.attribute(ATTR_ORIGIN_KEY, originKey(uri));
     if ("https".equalsIgnoreCase(uri.getScheme())) {
@@ -3257,7 +3495,20 @@ public class HTTP2JettyClient {
       lowLevelDebug("Cleartext request with body; using HTTP/1.1-only client for {}", uri);
       return httpClientHttp1Only;
     }
-    return selectHttpClient(uri);
+    return selectHttpClient(uri, isRecoverableIfHttp3Fails(sampler));
+  }
+
+  /**
+   * Whether a failed HTTP/3 attempt for this request could still be served over another protocol,
+   * which is the condition for exploring HTTP/3 on an origin nothing is known about yet.
+   *
+   * <p>It comes down to the body: the fallback has to hand the same body to the retry, and a body
+   * read from a file cannot be rewound, so such a request has no way back once HTTP/3 has been
+   * attempted and failed. Form and string bodies rewind fine, so an ordinary POST is recoverable
+   * and does get to explore. Requests with no body always are.
+   */
+  private boolean isRecoverableIfHttp3Fails(HTTP2Sampler sampler) {
+    return sampler.getHTTPFiles().length == 0;
   }
 
   private boolean requestAdvertisesEncoding(HTTP2Sampler sampler, String encoding) {
@@ -3289,9 +3540,39 @@ public class HTTP2JettyClient {
     return false;
   }
 
+  /**
+   * Gives HTTP/3 establishment its own short deadline, so that an origin which cannot be reached
+   * over QUIC is abandoned quickly and the request falls back instead of stalling.
+   *
+   * <p>It is applied to {@code httpClient} even though the knob is about HTTP/3, and that is not a
+   * shortcut: {@code httpClient} is the only client HTTP/3 attempts are sent on, and its connect
+   * timeout is what actually bounds the QUIC handshake. Setting it on the QUIC connector instead
+   * reads as the obvious place and does nothing - see the comment where that connector is built.
+   *
+   * <p>Measured wall clock for a failed handshake is about twice this value, because establishment
+   * is attempted more than once before the failure surfaces.
+   */
+  private void applyHttp3HandshakeTimeout() {
+    if (FORCE_HTTP2_ONLY || !enableHttp3 || http3HandshakeTimeoutMs <= 0) {
+      return;
+    }
+    httpClient.setConnectTimeout(http3HandshakeTimeoutMs);
+    lowLevelDebug("HTTP/3 handshake deadline set to {}ms on the HTTP/3 client",
+        http3HandshakeTimeoutMs);
+  }
+
+  /** Whether the HTTP/3 client's connect timeout is reserved for the handshake deadline. */
+  private boolean http3HandshakeDeadlineApplies() {
+    return !FORCE_HTTP2_ONLY && enableHttp3 && http3HandshakeTimeoutMs > 0;
+  }
+
   private void setTimeouts(HTTP2Sampler sampler, Request request) {
     if (sampler.getConnectTimeout() > 0) {
-      httpClient.setConnectTimeout(sampler.getConnectTimeout());
+      // The HTTP/3 client keeps whichever is shorter: a connect timeout configured for the sampler
+      // must not stretch the handshake deadline that keeps the fallback fast.
+      httpClient.setConnectTimeout(http3HandshakeDeadlineApplies()
+          ? Math.min(sampler.getConnectTimeout(), http3HandshakeTimeoutMs)
+          : sampler.getConnectTimeout());
       if (httpClientNoH3 != httpClient) {
         httpClientNoH3.setConnectTimeout(sampler.getConnectTimeout());
       }

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -91,6 +91,9 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
       getPropDefault(
           "httpsampler.ignore_failed_embedded_resources", false); // $NON-NLS-1$
 
+  /** How often the concurrent embedded-resources drain checks a pending request for completion. */
+  private static final long EMBEDDED_POLL_INTERVAL_MILLIS = 10;
+
   private static final String HTTP1_UPGRADE_PROPERTY = "HTTP2Sampler.http1_upgrade";
   private static final String PROFILE_PROPERTY = "HTTP2Sampler.profile";
   private static final String ENABLE_HTTP3_PROPERTY = "HTTP2Sampler.enableHttp3";
@@ -404,8 +407,10 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
           HTTP2FutureResponseListener listener =
               new HTTP2FutureResponseListener(HTTP2JettyClient.getJettyBufferingMaxLength());
           this.asyncListener = listener;
-          Request req = client.sampleAsync(this, this.result, listener);
-          req.send(listener); // Fire the Async
+          // The client fires it: dispatching there is what lets an async request take part in the
+          // HTTP/3 vs HTTP/2 race. Sending it from here reached the fallbacks all the same, through
+          // the second stage, but went out as a lone HTTP/3 attempt with nothing racing it.
+          client.dispatchAsync(this, this.result, listener);
           return null;
         } else {
           // If there is a listener, it is processed using the result it had
@@ -634,6 +639,26 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
     embedded.setHttp1OnlyCooldownMs(getHttp1OnlyCooldownMs());
     embedded.setH2cCacheTtlMs(getH2cCacheTtlMs());
     embedded.setHttp1UpgradeEnabled(isHttp1UpgradeEnabled());
+    copyTimeoutsToEmbeddedSampler(embedded);
+  }
+
+  /**
+   * Propagates Connect Timeout and Response Timeout to an embedded-resource child sampler.
+   *
+   * <p>JMeter builds its embedded-resource samplers with {@code base.clone()}
+   * ({@code HTTPSamplerBase.ASyncSample}), so they inherit every configured property, timeouts
+   * included. This plugin builds them from a fresh {@link HTTP2Sampler} instead, which reports 0
+   * for both - and 0 means "no timeout" in JMeter, exactly as it does here. The result was that an
+   * embedded request never received a deadline even when the user had configured one on the parent:
+   * {@code HTTP2JettyClient} only calls {@code Request.timeout(..)} for a value above 0, so a
+   * stalled resource left the polling loop in {@link #downloadPageResources} waiting forever.
+   *
+   * <p>The raw property strings are copied rather than the {@code int} values so that "unset" stays
+   * unset instead of becoming a literal "0".
+   */
+  private void copyTimeoutsToEmbeddedSampler(HTTP2Sampler embedded) {
+    embedded.setConnectTimeout(getPropertyAsString(CONNECT_TIMEOUT));
+    embedded.setResponseTimeout(getPropertyAsString(RESPONSE_TIMEOUT));
   }
 
   /**
@@ -1114,6 +1139,17 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
 
       setSyncRequest(!isConcurrentDwn); // Change default from main request based on sub request
 
+      // Deadline for waiting on a single embedded resource. 0 means "no timeout", the same meaning
+      // JMeter gives it everywhere else: JMeter's own drain
+      // (ResourcesDownloader.invokeAllAndAwaitTermination) has no wait timeout at all and relies
+      // purely on the per-request timeouts, so with 0 configured we wait here as long as JMeter
+      // would. With a value configured, the request itself already carries that deadline (see
+      // HTTP2JettyClient#setTimeouts and copyTimeoutsToEmbeddedSampler), and this is only the
+      // backstop for a completion that never arrives.
+      int embeddedTimeout = this.getResponseTimeout() > 0
+          ? this.getResponseTimeout()
+          : this.requestTimeout;
+
       int fileEmbeddedIndex = 0;
       while (urls.hasNext()) {
         Object binURL = urls.next(); // See catch clause below
@@ -1159,6 +1195,15 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
               setParentSampleSuccess(subres,
                   subres.isSuccessful() && (binRes == null || binRes.isSuccessful()));
               continue;
+            }
+
+            // Honour the configured parallel-download pool size. Previously every URL on the page
+            // was dispatched at once, so the setting only ever mattered for the value 1.
+            if (isConcurrentDwn) {
+              interrupted = awaitEmbeddedDownloadSlot(samplers, subres, maxConcurrentDownloads);
+              if (interrupted) {
+                break;
+              }
             }
 
             HTTP2Sampler h2s = new HTTP2Sampler();
@@ -1214,56 +1259,10 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
           break;
         }
       }
-      int embeddedTimeout = 0; // Use the same timeout for response
-      if (this.getResponseTimeout() > 0) {
-        embeddedTimeout = this.getResponseTimeout();
-      } else {
-        embeddedTimeout = this.requestTimeout;
-      }
-      long start = System.currentTimeMillis();
-
-      // IF for download concurrent embedded resources
-      if (isConcurrentDwn && !samplers.isEmpty()) {
-
-        while (!samplers.isEmpty()) {
-
-          HTTP2Sampler http2Sam = (HTTP2Sampler) samplers.get(0);
-
-          HTTP2FutureResponseListener http2FListener =
-              http2Sam.getFutureResponseListener();
-          while (!interrupted && (http2FListener != null)) {
-            if (http2FListener.isDone() || http2FListener.isCancelled()) {
-              String urlProcesed = http2FListener.getRequest().getURI().toString();
-              LOG.debug("HTTP2 Future Finished, retrying the sample with that data {}",
-                  urlProcesed);
-
-              HTTPSampleResult binRes = (HTTPSampleResult) http2Sam.sample();
-              samplers.remove(0); // Remove the sample
-              LOG.debug("OnComplete " + urlProcesed);
-
-              subres.addSubResult(binRes);
-              setParentSampleSuccess(subres,
-                  subres.isSuccessful() && (binRes == null
-                      || binRes.isSuccessful()));
-              break;
-            }
-            try {
-              Thread.sleep(10);
-            } catch (InterruptedException e) {
-              samplers.clear();
-              interrupted = true;
-            }
-            if (embeddedTimeout > 0 && (System.currentTimeMillis() - start) >= embeddedTimeout) {
-              // TODO: This doesn't stop the async execution, only allow to don't lock execution
-              LOG.debug("Timeout on Wait!");
-              subres.addSubResult(errorResult(new Exception(
-                      "Error downloading embedded resources, execution timeout"),
-                  new HTTPSampleResult(subres)));
-              setParentSampleSuccess(subres, false);
-              break;
-            }
-          }
-        }
+      // Drain whatever is still in flight, in submission order, like JMeter iterates the futures
+      // returned by ResourcesDownloader.invokeAllAndAwaitTermination.
+      while (!interrupted && isConcurrentDwn && !samplers.isEmpty()) {
+        interrupted = drainFirstEmbeddedSampler(samplers, subres, embeddedTimeout);
       }
     }
     setSyncRequest(orgSyncRequest); // Restore the default setting to main request
@@ -1272,6 +1271,171 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
       Thread.currentThread().interrupt();
     }
     return res;
+  }
+
+  /**
+   * Blocks until fewer than {@code maxConcurrentDownloads} embedded requests are still in flight,
+   * so a new one can be dispatched.
+   *
+   * <p>Mirrors JMeter's {@code ResourcesDownloader.invokeAllAndAwaitTermination}, which keeps at
+   * most that many tasks running and starts the next one as soon as *any* of them completes.
+   * Waiting on the oldest request instead would leave the other slots idle for as long as it takes
+   * that one to finish, turning a slow resource into a stall for the whole page.
+   *
+   * <p>Requests that already completed stay queued: results are consumed separately, in submission
+   * order, so the reported sub-results keep matching the order the resources appear in the page.
+   *
+   * @return whether the wait was interrupted, in which case pending requests were aborted and the
+   *         queue cleared.
+   */
+  private boolean awaitEmbeddedDownloadSlot(List<TestElement> samplers, HTTPSampleResult subres,
+                                            int maxConcurrentDownloads) {
+    while (true) {
+      // Independent of slot accounting: harvest what is already finished so responses are not left
+      // buffered in the queue for the rest of the page. Never blocks on the head.
+      collectFinishedEmbeddedResults(samplers, subres);
+      if (countInFlightEmbeddedRequests(samplers) < maxConcurrentDownloads) {
+        return false;
+      }
+      try {
+        Thread.sleep(EMBEDDED_POLL_INTERVAL_MILLIS);
+      } catch (InterruptedException e) {
+        abortPendingEmbeddedRequests(samplers);
+        return true;
+      }
+    }
+  }
+
+  /**
+   * Turns the head of {@code samplers} into a sub-result and dequeues it. The caller must have
+   * established that its request finished.
+   */
+  private void consumeFirstEmbeddedSampler(List<TestElement> samplers, HTTPSampleResult subres) {
+    HTTP2Sampler embeddedSampler = (HTTP2Sampler) samplers.get(0);
+    HTTP2FutureResponseListener listener = embeddedSampler.getFutureResponseListener();
+    String processedUrl = listener != null && listener.getRequest() != null
+        ? listener.getRequest().getURI().toString()
+        : "unknown";
+    LOG.debug("Embedded resource finished, re-sampling with that data {}", processedUrl);
+    HTTPSampleResult binRes = (HTTPSampleResult) embeddedSampler.sample();
+    samplers.remove(0);
+    subres.addSubResult(binRes);
+    setParentSampleSuccess(subres,
+        subres.isSuccessful() && (binRes == null || binRes.isSuccessful()));
+  }
+
+  /**
+   * Consumes every already-finished resource at the head of the queue, without ever waiting.
+   *
+   * <p>Freeing a concurrency slot and collecting a result are deliberately separate: a slot is free
+   * as soon as its download finishes (see {@link #countInFlightEmbeddedRequests}), so a slow first
+   * resource never holds back the dispatch of the rest. But nothing used to collect until the whole
+   * page had been dispatched, which left every finished response buffered in the queue in the
+   * meantime. Draining here keeps that buffer as short as the head allows, while sub-results still
+   * come out in the order the resources appear in the page.
+   */
+  private void collectFinishedEmbeddedResults(List<TestElement> samplers,
+                                              HTTPSampleResult subres) {
+    while (!samplers.isEmpty()) {
+      HTTP2FutureResponseListener listener =
+          ((HTTP2Sampler) samplers.get(0)).getFutureResponseListener();
+      if (listener == null) {
+        // Never dispatched, so no completion can arrive: drop it rather than block the queue on it.
+        LOG.debug("Embedded resource has no pending request, dropping it from the queue");
+        samplers.remove(0);
+        continue;
+      }
+      if (!listener.isDone() && !listener.isCancelled()) {
+        return;
+      }
+      consumeFirstEmbeddedSampler(samplers, subres);
+    }
+  }
+
+  private int countInFlightEmbeddedRequests(List<TestElement> samplers) {
+    int inFlight = 0;
+    for (TestElement element : samplers) {
+      HTTP2FutureResponseListener listener =
+          ((HTTP2Sampler) element).getFutureResponseListener();
+      if (listener != null && !listener.isDone() && !listener.isCancelled()) {
+        inFlight++;
+      }
+    }
+    return inFlight;
+  }
+
+  /**
+   * Aborts whatever is still in flight and empties the queue, the way JMeter cancels the futures it
+   * submitted when the drain is interrupted (bug 51925), so a stopped test does not leak requests.
+   */
+  private void abortPendingEmbeddedRequests(List<TestElement> samplers) {
+    for (TestElement element : samplers) {
+      HTTP2FutureResponseListener listener =
+          ((HTTP2Sampler) element).getFutureResponseListener();
+      if (listener != null && !listener.isDone() && !listener.isCancelled()) {
+        listener.cancel(true);
+      }
+    }
+    samplers.clear();
+  }
+
+  /**
+   * Waits for the first still-pending embedded resource in {@code samplers}, appends its result to
+   * {@code subres} and dequeues it. Always dequeues, so the caller's loop makes progress on every
+   * call.
+   *
+   * @param embeddedTimeout how long to wait for this one resource, or 0 to wait indefinitely (see
+   *                        {@link #downloadPageResources} on why 0 matches JMeter).
+   * @return whether the wait was interrupted, in which case the queue has been cleared.
+   */
+  private boolean drainFirstEmbeddedSampler(List<TestElement> samplers, HTTPSampleResult subres,
+                                            int embeddedTimeout) {
+    HTTP2Sampler embeddedSampler = (HTTP2Sampler) samplers.get(0);
+    HTTP2FutureResponseListener listener = embeddedSampler.getFutureResponseListener();
+    if (listener == null) {
+      // The request was never dispatched (the async send threw), so no completion can ever arrive.
+      // Dequeue it: leaving it at the head made the caller re-select it forever without sleeping.
+      LOG.debug("Embedded resource has no pending request, dropping it from the queue");
+      samplers.remove(0);
+      return false;
+    }
+
+    // Measured per resource, from when its request was dispatched, so it lines up with the deadline
+    // the request itself carries. Timing from the moment this resource reaches the head of the
+    // queue instead would grant it a fresh full timeout on top of however long it already waited;
+    // timing the whole page from a single start (as this used to) went the other way and expired
+    // resources that had in fact completed normally.
+    long start = listener.getResponseStart() > 0
+        ? listener.getResponseStart()
+        : System.currentTimeMillis();
+    while (true) {
+      if (listener.isDone() || listener.isCancelled()) {
+        consumeFirstEmbeddedSampler(samplers, subres);
+        return false;
+      }
+      try {
+        Thread.sleep(EMBEDDED_POLL_INTERVAL_MILLIS);
+      } catch (InterruptedException e) {
+        abortPendingEmbeddedRequests(samplers);
+        return true;
+      }
+      if (embeddedTimeout > 0 && (System.currentTimeMillis() - start) >= embeddedTimeout) {
+        String pendingUrl = listener.getRequest() != null
+            ? listener.getRequest().getURI().toString()
+            : "unknown";
+        LOG.warn("Timeout after {}ms waiting for embedded resource {}", embeddedTimeout,
+            pendingUrl);
+        // Dequeue and abort before returning: without this the caller re-selects the same head, and
+        // aborting is what releases the underlying Jetty request instead of leaking it.
+        samplers.remove(0);
+        listener.cancel(true);
+        subres.addSubResult(errorResult(new Exception(
+                "Error downloading embedded resources, execution timeout"),
+            new HTTPSampleResult(subres)));
+        setParentSampleSuccess(subres, false);
+        return false;
+      }
+    }
   }
 
   @Override

--- a/src/test/java/com/blazemeter/jmeter/http2/core/FallbackRetryBodyDeliveryTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/FallbackRetryBodyDeliveryTest.java
@@ -1,0 +1,142 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.HOST_NAME;
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.SERVER_PATH_200_WITH_BODY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import com.blazemeter.jmeter.http2.sampler.JMeterTestUtils;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * The protocol fallbacks replace a request that already failed, and each one has to hand the body
+ * over intact. These tests take that all the way to a real server and assert on what it echoes back,
+ * so a body that arrives empty or truncated fails here instead of silently changing what was sent.
+ *
+ * <p>The mechanics of the hand-over are pinned separately by {@link RetryRequestBodyReuseTest}; what
+ * these add is that the request really does reach the server with its body after a retry.
+ */
+public class FallbackRetryBodyDeliveryTest extends HTTP2TestBase {
+
+  private static final String BODY_MARKER = "value1";
+
+  private TeardownableServer server;
+  private HTTP2JettyClient client;
+  private HTTP2Sampler sampler;
+  private int port = -1;
+
+  @BeforeClass
+  public static void setupClass() {
+    JMeterTestUtils.setupJmeterEnv();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    server = new ServerBuilder().withSSL().withALPN().withHTTP2().withHTTP2C().buildServer();
+    server.start();
+    port = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+
+    sampler = new HTTP2Sampler();
+    sampler.setDomain(HOST_NAME);
+    sampler.setProtocol(HTTPConstants.PROTOCOL_HTTPS);
+    sampler.setPort(port);
+    sampler.setMethod(HTTPConstants.POST);
+    sampler.addArgument("test1", BODY_MARKER);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (client != null) {
+      client.stop();
+    }
+    if (server != null && server.isStarted()) {
+      server.stop();
+    }
+  }
+
+  /**
+   * The HTTP/1.1 fallback taken for a protocol error, with a body. The HTTP/2 client is built
+   * expecting an HTTP/1.1 upgrade against a server that only speaks HTTP/2 over ALPN, which is what
+   * makes the first attempt fail as a protocol error and hands the request to the fallback.
+   */
+  @Test
+  public void shouldDeliverBodyThroughHttp11FallbackAfterProtocolError() throws Exception {
+    client = new HTTP2JettyClient(true, "fallback-body-delivery");
+    client.start();
+    HTTP2FutureResponseListener listener = new HTTP2FutureResponseListener();
+    sampler.setFutureResponseListener(listener);
+    HTTPSampleResult result = buildResult();
+
+    client.dispatchAsync(sampler, result, listener);
+    HTTPSampleResult sampleResult =
+        client.sampleFromListener(sampler, result, false, 0, listener);
+
+    assertThat(sampleResult.getResponseDataAsString())
+        .as("the body must survive the HTTP/1.1 fallback, not arrive empty or truncated")
+        .contains(BODY_MARKER);
+  }
+
+  /**
+   * Replaying a request whose body a first attempt already consumed, which is what any retry has to
+   * do. It drives {@code retryAfterGoAway} because that is the method implementing this replay - but
+   * <b>no GOAWAY is involved here</b>, hence the name: this covers the body hand-over only, never the
+   * detection of the frame. A real GOAWAY is exercised by {@link GoAwayReconnectTest}.
+   */
+  @Test
+  public void shouldDeliverBodyWhenRetryReplaysRequestWithConsumedBody() throws Exception {
+    client = new HTTP2JettyClient(false, "retry-body-delivery");
+    client.start();
+    HTTP2FutureResponseListener listener = new HTTP2FutureResponseListener();
+    sampler.setFutureResponseListener(listener);
+    HTTPSampleResult result = buildResult();
+
+    // A real send first, so the body is consumed exactly as the attempt that got the GOAWAY would
+    // have left it. The retry has to rewind it rather than resend nothing.
+    client.dispatchAsync(sampler, result, listener);
+    client.sampleFromListener(sampler, result, false, 0, listener);
+    Request sentRequest = listener.getRequest();
+
+    Method retry = HTTP2JettyClient.class.getDeclaredMethod("retryAfterGoAway", Request.class);
+    retry.setAccessible(true);
+    ContentResponse retried = (ContentResponse) retry.invoke(client, sentRequest);
+
+    assertThat(retried.getContentAsString())
+        .as("the retry after GOAWAY must resend the full body")
+        .contains(BODY_MARKER);
+  }
+
+  private HTTPSampleResult buildResult() throws MalformedURLException {
+    HTTPSampleResult result = new HTTPSampleResult();
+    URL url = createUrl();
+    result.setURL(url);
+    result.setHTTPMethod(HTTPConstants.POST);
+    result.setSampleLabel(url.toString());
+    return result;
+  }
+
+  private URL createUrl() throws MalformedURLException {
+    try {
+      return new URI(HTTPConstants.PROTOCOL_HTTPS, null, HOST_NAME, port,
+          SERVER_PATH_200_WITH_BODY, null, null).toURL();
+    } catch (URISyntaxException e) {
+      MalformedURLException ex = new MalformedURLException(e.getMessage());
+      ex.initCause(e);
+      throw ex;
+    }
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/GoAwayReconnectTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/GoAwayReconnectTest.java
@@ -1,0 +1,187 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.HOST_NAME;
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.SERVER_PATH_200;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import com.blazemeter.jmeter.http2.sampler.JMeterTestUtils;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.util.JMeterUtils;
+import org.eclipse.jetty.http2.ErrorCode;
+import org.eclipse.jetty.http2.api.Session;
+import org.eclipse.jetty.http2.server.internal.HTTP2ServerConnection;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.Callback;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * A GOAWAY is how a server protects itself: it tells the client to stop opening streams on this
+ * connection and to come back on a new one. Browsers absorb it and the user never sees an error, and
+ * a load test has to behave the same way - the reconnection may cost time, but the sample must not
+ * come out as an error.
+ *
+ * <p>The frame is real here, not simulated. A {@link Connection.Listener} on the server connector
+ * captures the HTTP/2 session of each accepted connection, and the test then makes that session emit
+ * GOAWAY through Jetty's own API. Emitting it per session rather than shutting the connector down is
+ * deliberate: the server has to keep accepting, because a retry can only succeed on a fresh
+ * connection.
+ *
+ * <p><b>What this does not cover.</b> The GOAWAY here arrives between requests, and that case is
+ * absorbed by Jetty's own connection pool - measured, by disabling {@code goawayRetryEnabled} and
+ * seeing the sample still succeed (the second test below pins exactly that). So these tests pin the
+ * requirement, not the plugin's {@code retryAfterGoAway} path. That path is for a narrower race: a
+ * GOAWAY whose {@code lastStreamId} is below a stream the client has already opened, meaning the
+ * server never processed it and the request has to be replayed on a new connection. Reproducing that
+ * deterministically is still open.
+ */
+public class GoAwayReconnectTest extends HTTP2TestBase {
+
+  private static final String GOAWAY_RETRY_PROP = "httpJettyClient.goawayRetryEnabled";
+
+  private final List<Session> serverSessions = new CopyOnWriteArrayList<>();
+  private final List<String> observedConnections = new CopyOnWriteArrayList<>();
+
+  private TeardownableServer server;
+  private HTTP2JettyClient client;
+  private HTTP2Sampler sampler;
+  private int port = -1;
+
+  @BeforeClass
+  public static void setupClass() {
+    JMeterTestUtils.setupJmeterEnv();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    // This exact combination is what actually negotiates HTTP/2; withSSL().withALPN().withHTTP2()
+    // alone makes the client fall back to HTTP/1.1, which would leave no session to GOAWAY.
+    server = new ServerBuilder().withHTTP2().withALPN().withHTTP2C().withSSL().buildServer();
+    ServerConnector connector = (ServerConnector) server.getConnectors()[0];
+    connector.addBean(new Connection.Listener() {
+      @Override
+      public void onOpened(Connection connection) {
+        observedConnections.add(connection.getClass().getName());
+        if (connection instanceof HTTP2ServerConnection) {
+          serverSessions.add(((HTTP2ServerConnection) connection).getSession());
+        }
+      }
+
+      @Override
+      public void onClosed(Connection connection) {
+        // Nothing to do: the test only needs the sessions as they are accepted.
+      }
+    });
+    server.start();
+    port = connector.getLocalPort();
+
+    sampler = new HTTP2Sampler();
+    sampler.setDomain(HOST_NAME);
+    sampler.setProtocol(HTTPConstants.PROTOCOL_HTTPS);
+    sampler.setPort(port);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    JMeterUtils.getJMeterProperties().remove(GOAWAY_RETRY_PROP);
+    if (client != null) {
+      client.stop();
+    }
+    if (server != null && server.isStarted()) {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void shouldNotFailSampleWhenServerSendsGoAway() throws Exception {
+    startClient();
+
+    assertSampleSurvivesGoAway();
+  }
+
+  /**
+   * Same scenario with the plugin's GOAWAY retry turned off, and it still succeeds. That is the
+   * measurement behind the caveat in this class: a GOAWAY between requests is handled by Jetty's
+   * connection pool, so neither test here exercises {@code retryAfterGoAway}.
+   *
+   * <p>That is also why this test is worth keeping rather than deleting the retry it makes look
+   * redundant: Jetty 11 did <em>not</em> absorb this in the pool, so the plugin's retry is what
+   * covered it. Keeping both means a future Jetty that stops absorbing it shows up here as a
+   * failure - the retry path becoming load-bearing again - instead of silently turning into failed
+   * samples in a real test run.
+   */
+  @Test
+  public void shouldNotFailSampleWhenServerSendsGoAwayEvenWithPluginRetryDisabled()
+      throws Exception {
+    JMeterUtils.getJMeterProperties().setProperty(GOAWAY_RETRY_PROP, "false");
+    startClient();
+
+    assertSampleSurvivesGoAway();
+  }
+
+  private void assertSampleSurvivesGoAway() throws Exception {
+    HTTPSampleResult first = sample();
+    assertThat(first.isSuccessful()).as("the first sample sets up the connection").isTrue();
+    assertThat(serverSessions)
+        .as("an HTTP/2 session must have been accepted, otherwise no GOAWAY can be emitted; "
+            + "connections opened were %s", observedConnections)
+        .isNotEmpty();
+
+    sendGoAway();
+
+    HTTPSampleResult second = sample();
+
+    assertThat(second.isSuccessful())
+        .as("a GOAWAY must be absorbed by reconnecting, never surface as a failed sample")
+        .isTrue();
+    assertThat(second.getResponseCode())
+        .as("and the sample must carry the real response, not a synthetic error")
+        .isEqualTo("200");
+  }
+
+  /** Emits GOAWAY(NO_ERROR) on every session accepted so far, as a server shedding load would. */
+  private void sendGoAway() {
+    for (Session session : serverSessions) {
+      session.close(ErrorCode.NO_ERROR.code, "test-goaway", Callback.NOOP);
+    }
+  }
+
+  private void startClient() throws Exception {
+    client = new HTTP2JettyClient();
+    client.loadProperties();
+    client.start();
+  }
+
+  private HTTPSampleResult sample() throws Exception {
+    URL url = createUrl();
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setURL(url);
+    result.setHTTPMethod(HTTPConstants.GET);
+    result.setSampleLabel(url.toString());
+    return client.sample(sampler, result, false, 0);
+  }
+
+  private URL createUrl() throws MalformedURLException {
+    try {
+      return new URI(HTTPConstants.PROTOCOL_HTTPS, null, HOST_NAME, port, SERVER_PATH_200,
+          null, null).toURL();
+    } catch (URISyntaxException e) {
+      MalformedURLException ex = new MalformedURLException(e.getMessage());
+      ex.initCause(e);
+      throw ex;
+    }
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListenerSealingTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListenerSealingTest.java
@@ -1,0 +1,37 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CancellationException;
+import org.junit.Test;
+
+/**
+ * Once a protocol race hands a winning response to the shared listener, the abort of the losing
+ * request must not turn that win into a failure.
+ *
+ * <p>The race resolves by calling {@link HTTP2FutureResponseListener#completeWith} on the listener
+ * of one attempt with the other attempt's response, then aborting the loser. That abort makes Jetty
+ * call back into this same listener with a CancellationException, and {@code getResult()} treats any
+ * stored failure as an error even when a response is present.
+ */
+public class HTTP2FutureResponseListenerSealingTest {
+
+  @Test
+  public void shouldKeepAdoptedResponseAfterLosingRequestIsAborted() throws Exception {
+    HTTP2FutureResponseListener listener =
+        new HTTP2FutureResponseListener(-1);
+
+    listener.completeWith(null, 100L, 200L);
+    assertTrue("listener should be done once a result was adopted", listener.isDone());
+
+    // Jetty delivering the loser's abort after the race was already resolved.
+    listener.onFailure(null, new CancellationException("race lost"));
+    listener.onComplete(null);
+
+    // Without sealing, the abort's failure would surface here instead of the adopted result.
+    assertEquals(200L, listener.getResponseEnd());
+    assertEquals(100L, listener.getResponseStart());
+    assertEquals("adopted result must survive the loser's callbacks", null, listener.get());
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
@@ -1750,8 +1750,10 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
     client = new HTTP2JettyClient(true, "Test");
     client.start();
     HTTPSampleResult result = buildBaseResult(createURL(SERVER_PATH_200), HTTPConstants.GET);
-    Request httpRequest = client.sampleAsync(sampler, result, sampler.getFutureResponseListener());
-    httpRequest.send(listener);
+    // dispatchAsync, not sampleAsync + Request.send: the client owns dispatching so the request can
+    // take part in the HTTP/3 vs HTTP/2 race. Sending it here instead selected HTTP/3 for this
+    // first contact and then fired it with no competing attempt, i.e. HTTP/3-only.
+    client.dispatchAsync(sampler, result, sampler.getFutureResponseListener());
     // Goes through sampleFromListener() -> getContent(), the single place that owns the
     // HTTP/1.1 fallback decision (the listener no longer resolves protocol_error on its own).
     HTTPSampleResult sampleResult = client.sampleFromListener(sampler, result, false, 0, listener);

--- a/src/test/java/com/blazemeter/jmeter/http2/core/Http3ConnectTimeoutFallbackTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/Http3ConnectTimeoutFallbackTest.java
@@ -1,0 +1,174 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.HOST_NAME;
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.SERVER_PATH_200;
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.SERVER_PATH_200_WITH_BODY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import com.blazemeter.jmeter.http2.sampler.JMeterTestUtils;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.util.JMeterUtils;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * When HTTP/3 is attempted against an origin that does not speak QUIC, the handshake has to fail
+ * fast and the request has to be served over HTTP/2 instead.
+ *
+ * <p>The test server is TCP-only, so every HTTP/3 attempt against it can only fail to connect.
+ * HTTP/3 is forced with prior knowledge, which is also what makes this an HTTP/3-only attempt with
+ * no competing HTTP/2 request (see {@code shouldUseHappyEyeballs}) - the shape a POST would take if
+ * first-contact exploration were extended to requests that cannot be raced.
+ *
+ * <p>{@code getContent} is supposed to turn the connect timeout into "mark the origin broken and
+ * retry without HTTP/3". These tests pin whether that actually happens, for a plain GET and for a
+ * request carrying a body.
+ */
+public class Http3ConnectTimeoutFallbackTest extends HTTP2TestBase {
+
+  private static final String PRIOR_KNOWLEDGE_PROP = "httpJettyClient.http3PriorKnowledge";
+  private static final String HANDSHAKE_TIMEOUT_PROP =
+      "httpJettyClient.http3HandshakeTimeoutMs";
+
+  private TeardownableServer server;
+  private HTTP2JettyClient client;
+  private HTTP2Sampler sampler;
+  private int port = -1;
+
+  @BeforeClass
+  public static void setupClass() {
+    JMeterTestUtils.setupJmeterEnv();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    // Force HTTP/3 to be attempted without any Alt-Svc knowledge, and keep the handshake deadline
+    // short so a blocked QUIC path is reported quickly instead of stalling the test.
+    JMeterUtils.getJMeterProperties().setProperty(PRIOR_KNOWLEDGE_PROP, "true");
+    JMeterUtils.getJMeterProperties().setProperty(HANDSHAKE_TIMEOUT_PROP, "500");
+
+    // Same combination the other client tests use: without withHTTP2C the HTTP/2 retry is answered
+    // with frame_size_error, which looks like a broken fallback when it is a server limitation.
+    server = new ServerBuilder().withHTTP2().withALPN().withHTTP2C().withSSL().buildServer();
+    server.start();
+    port = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+
+    sampler = new HTTP2Sampler();
+    sampler.setDomain(HOST_NAME);
+    sampler.setProtocol(HTTPConstants.PROTOCOL_HTTPS);
+    sampler.setPort(port);
+
+    client = new HTTP2JettyClient();
+    client.loadProperties();
+    client.start();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    JMeterUtils.getJMeterProperties().remove(PRIOR_KNOWLEDGE_PROP);
+    JMeterUtils.getJMeterProperties().remove(HANDSHAKE_TIMEOUT_PROP);
+    if (client != null) {
+      client.stop();
+    }
+    if (server != null && server.isStarted()) {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void shouldFallBackToHttp2WhenHttp3HandshakeFailsOnGet() throws Exception {
+    HTTPSampleResult result = sample(SERVER_PATH_200, HTTPConstants.GET);
+
+    assertThat(result.isSuccessful())
+        .as("HTTP/3 cannot connect here, so the GET must be served over HTTP/2")
+        .isTrue();
+  }
+
+  /**
+   * The case that blocks extending first-contact exploration to POST: a request with a body cannot
+   * be raced, so it would be an HTTP/3-only attempt and the fallback is the only thing that can
+   * save it.
+   */
+  @Test
+  public void shouldFallBackToHttp2WhenHttp3HandshakeFailsOnPostWithBody() throws Exception {
+    sampler.setMethod(HTTPConstants.POST);
+    sampler.addArgument("test1", "value1");
+
+    HTTPSampleResult result = sample(SERVER_PATH_200_WITH_BODY, HTTPConstants.POST);
+
+    assertThat(result.isSuccessful())
+        .as("HTTP/3 cannot connect here, so the POST must be served over HTTP/2")
+        .isTrue();
+    assertThat(result.getResponseDataAsString())
+        .as("the body must survive the fallback, not be sent truncated")
+        .contains("value1");
+  }
+
+  /**
+   * The handshake deadline is what makes the fallback fast, and it is easy to lose: it has to be
+   * applied to the client that performs the HTTP/3 attempt, because setting it on the QUIC
+   * connector has no effect at all. Unbounded, this same sample measured ~10s (twice Jetty's 5s
+   * default connect timeout); bounded at 500ms it measures ~1s.
+   */
+  @Test
+  public void shouldBoundHttp3HandshakeByConfiguredDeadline() throws Exception {
+    long startedAt = System.nanoTime();
+
+    HTTPSampleResult result = sample(SERVER_PATH_200, HTTPConstants.GET);
+
+    long elapsedMs = (System.nanoTime() - startedAt) / 1_000_000;
+    assertThat(result.isSuccessful()).as("the sample still has to succeed over HTTP/2").isTrue();
+    assertThat(elapsedMs)
+        .as("a 500ms handshake deadline must abandon HTTP/3 quickly, not wait for the default")
+        .isLessThan(5000);
+  }
+
+  /**
+   * A connect timeout configured for the sampler must not stretch the handshake deadline: the
+   * HTTP/3 client keeps whichever of the two is shorter.
+   */
+  @Test
+  public void shouldKeepHandshakeDeadlineWhenSamplerConnectTimeoutIsLonger() throws Exception {
+    sampler.setConnectTimeout("8000");
+    long startedAt = System.nanoTime();
+
+    HTTPSampleResult result = sample(SERVER_PATH_200, HTTPConstants.GET);
+
+    long elapsedMs = (System.nanoTime() - startedAt) / 1_000_000;
+    assertThat(result.isSuccessful()).as("the sample still has to succeed over HTTP/2").isTrue();
+    assertThat(elapsedMs)
+        .as("the shorter handshake deadline must win over the longer sampler connect timeout")
+        .isLessThan(5000);
+  }
+
+  private HTTPSampleResult sample(String path, String method) throws Exception {
+    client.loadProperties();
+    URL url = createUrl(path);
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setURL(url);
+    result.setHTTPMethod(method);
+    result.setSampleLabel(url.toString());
+    return client.sample(sampler, result, false, 0);
+  }
+
+  private URL createUrl(String path) throws MalformedURLException {
+    try {
+      return new URI(HTTPConstants.PROTOCOL_HTTPS, null, HOST_NAME, port, path, null, null).toURL();
+    } catch (URISyntaxException e) {
+      MalformedURLException ex = new MalformedURLException(e.getMessage());
+      ex.initCause(e);
+      throw ex;
+    }
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/Http3ExplorationPolicyTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/Http3ExplorationPolicyTest.java
@@ -1,0 +1,243 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import com.blazemeter.jmeter.http2.sampler.JMeterTestUtils;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.protocol.http.util.HTTPFileArg;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Pins when HTTP/3 is attempted, which is the difference between discovering HTTP/3 on a first
+ * contact and turning an unreachable QUIC path into a stalled request.
+ *
+ * <p>The decision depends on what is known about the origin, not on the request: an origin worth
+ * attempting HTTP/3 on is attempted regardless of method, so neither is a POST to a known HTTP/3
+ * site downgraded, nor is an origin first contacted by a POST left unable to ever learn HTTP/3.
+ * Whether the attempt is <em>raced</em> against HTTP/2 is a separate decision, covered by
+ * {@link ProtocolFlagClientSelectionTest} and the race tests.
+ */
+public class Http3ExplorationPolicyTest extends HTTP2TestBase {
+
+  private static final URI TLS_URI = URI.create("https://h3-policy.example.com/x");
+  private static final URI CLEARTEXT_URI = URI.create("http://h3-policy.example.com/x");
+
+  private HTTP2JettyClient client;
+
+  @BeforeClass
+  public static void setupClass() {
+    JMeterTestUtils.setupJmeterEnv();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    altSvcCache().clear();
+    client = new HTTP2JettyClient();
+    setBoolean(client, "enableHttp3", true);
+    setBoolean(client, "enableHttp2", true);
+    setBoolean(client, "enableHttp1", true);
+    setBoolean(client, "altSvcCacheEnabled", true);
+    setBoolean(client, "http3PriorKnowledgeEnabled", false);
+  }
+
+  // --- first contact -------------------------------------------------------------------------
+
+  @Test
+  public void shouldExploreHttp3OnFirstContact() throws Exception {
+    assertTrue(shouldAttemptHttp3(TLS_URI, true));
+  }
+
+
+  /**
+   * The same rule seen through the real entry point, where the method is known: a POST to an origin
+   * nothing is known about still goes to the HTTP/3 client. It gets no concurrent HTTP/2 attempt to
+   * cover it, so what makes this safe is that the handshake has its own short deadline and that the
+   * fallback only fires when the connection could not be established - the request never reached
+   * the wire, so resending it cannot repeat a side effect. Without this, an origin first contacted
+   * by a POST could never learn HTTP/3 at all.
+   */
+  @Test
+  public void shouldExploreHttp3ForPostToUnknownOrigin() throws Exception {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.POST);
+    sampler.addArgument("test1", "value1");
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setURL(TLS_URI.toURL());
+    result.setHTTPMethod(HTTPConstants.POST);
+
+    assertSame("a POST to an unknown origin must still explore HTTP/3",
+        field("httpClient"), resolveClientForRequest(sampler, result));
+  }
+
+  /**
+   * And the limit of that: a body read from a file cannot be rewound, so the fallback has nothing to
+   * hand the retry and the request would have no way back once HTTP/3 failed. Such a request must
+   * not be used to explore an unknown origin - it goes over HTTP/2, and exploration is left to the
+   * requests that can afford it.
+   */
+  @Test
+  public void shouldNotExploreHttp3ForRequestWithFileBody() throws Exception {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.POST);
+    sampler.setHTTPFiles(new HTTPFileArg[] {
+        new HTTPFileArg("some-file.txt", "upload", "text/plain")});
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setURL(TLS_URI.toURL());
+    result.setHTTPMethod(HTTPConstants.POST);
+
+    assertSame("a file body cannot be replayed, so it must not explore HTTP/3",
+        field("httpClientNoH3"), resolveClientForRequest(sampler, result));
+  }
+
+  // --- already known to speak HTTP/3 ---------------------------------------------------------
+
+  @Test
+  public void shouldUseHttp3ForKnownOriginEvenWhenRequestCannotBeRaced() throws Exception {
+    cacheAltSvc(true, TimeUnit.MINUTES.toMillis(10), 0L);
+
+    assertTrue("a POST to a site known to speak HTTP/3 must still use HTTP/3",
+        shouldAttemptHttp3(TLS_URI, true));
+  }
+
+  @Test
+  public void shouldNotUseHttp3WhenCachedEntrySaysOriginDoesNotSupportIt() throws Exception {
+    cacheAltSvc(false, TimeUnit.MINUTES.toMillis(10), 0L);
+
+    assertFalse(shouldAttemptHttp3(TLS_URI, true));
+  }
+
+  // --- cooldown and expiry --------------------------------------------------------------------
+
+  @Test
+  public void shouldNotUseHttp3WhileBrokenCooldownIsActive() throws Exception {
+    cacheAltSvc(true, TimeUnit.MINUTES.toMillis(10), TimeUnit.MINUTES.toMillis(5));
+
+    assertFalse("a recent HTTP/3 failure must be respected, whatever the request is",
+        shouldAttemptHttp3(TLS_URI, true));
+  }
+
+  @Test
+  public void shouldExploreAgainOnceCachedEntryExpired() throws Exception {
+    cacheAltSvc(true, -1L, 0L);
+
+    assertTrue("an expired answer must not be trusted; explore again",
+        shouldAttemptHttp3(TLS_URI, true));
+  }
+
+  /**
+   * A failure on an origin that never advertised Alt-Svc has to be remembered too, otherwise every
+   * later request explores an origin whose HTTP/3 just failed.
+   */
+  @Test
+  public void shouldRecordCooldownForExploredOriginWithoutAltSvcEntry() throws Exception {
+    assertTrue(shouldAttemptHttp3(TLS_URI, true));
+
+    Method mark = HTTP2JettyClient.class.getDeclaredMethod("markHttp3Broken", URI.class);
+    mark.setAccessible(true);
+    mark.invoke(client, TLS_URI);
+
+    assertFalse("the cooldown must apply even though the origin had no Alt-Svc entry",
+        shouldAttemptHttp3(TLS_URI, true));
+  }
+
+  // --- flags and scheme -----------------------------------------------------------------------
+
+  @Test
+  public void shouldNeverAttemptHttp3WhenDisabled() throws Exception {
+    setBoolean(client, "enableHttp3", false);
+    cacheAltSvc(true, TimeUnit.MINUTES.toMillis(10), 0L);
+
+    assertFalse(shouldAttemptHttp3(TLS_URI, true));
+  }
+
+  @Test
+  public void shouldNeverAttemptHttp3OverCleartext() throws Exception {
+    cacheAltSvc(true, TimeUnit.MINUTES.toMillis(10), 0L);
+
+    assertFalse("QUIC always uses TLS, so http:// can never be HTTP/3",
+        shouldAttemptHttp3(CLEARTEXT_URI, true));
+  }
+
+  @Test
+  public void shouldAttemptHttp3WithPriorKnowledgeWithoutAnyCacheEntry() throws Exception {
+    setBoolean(client, "http3PriorKnowledgeEnabled", true);
+
+    assertTrue(shouldAttemptHttp3(TLS_URI, true));
+  }
+
+  // --- helpers --------------------------------------------------------------------------------
+
+  private Object resolveClientForRequest(HTTP2Sampler sampler, HTTPSampleResult result)
+      throws Exception {
+    Method m = HTTP2JettyClient.class.getDeclaredMethod(
+        "resolveClientForRequest", HTTP2Sampler.class, HTTPSampleResult.class);
+    m.setAccessible(true);
+    return m.invoke(client, sampler, result);
+  }
+
+  private Object field(String name) throws Exception {
+    Field f = HTTP2JettyClient.class.getDeclaredField(name);
+    f.setAccessible(true);
+    return f.get(client);
+  }
+
+  private boolean shouldAttemptHttp3(URI uri, boolean recoverable) throws Exception {
+    Method m = HTTP2JettyClient.class.getDeclaredMethod(
+        "shouldAttemptHttp3", URI.class, boolean.class);
+    m.setAccessible(true);
+    return (boolean) m.invoke(client, uri, recoverable);
+  }
+
+  private void cacheAltSvc(boolean h3, long expiresInMs, long brokenForMs) throws Exception {
+    Class<?> entryClass = Class.forName(
+        "com.blazemeter.jmeter.http2.core.HTTP2JettyClient$AltSvcEntry");
+    Constructor<?> ctor = entryClass.getDeclaredConstructor();
+    ctor.setAccessible(true);
+    Object entry = ctor.newInstance();
+    long now = System.currentTimeMillis();
+    setEntryField(entry, "h3", h3);
+    setEntryField(entry, "expiresAt", now + expiresInMs);
+    setEntryField(entry, "brokenUntil", brokenForMs > 0 ? now + brokenForMs : 0L);
+    setEntryField(entry, "lastH3SuccessAt", 0L);
+    altSvcCache().put(originKey(TLS_URI), entry);
+  }
+
+  private static void setEntryField(Object entry, String name, Object value) throws Exception {
+    Field f = entry.getClass().getDeclaredField(name);
+    f.setAccessible(true);
+    f.set(entry, value);
+  }
+
+  private String originKey(URI uri) throws Exception {
+    Method m = HTTP2JettyClient.class.getDeclaredMethod("originKey", URI.class);
+    m.setAccessible(true);
+    return (String) m.invoke(client, uri);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> altSvcCache() throws Exception {
+    Field f = HTTP2JettyClient.class.getDeclaredField("ALT_SVC_CACHE");
+    f.setAccessible(true);
+    return (Map<String, Object>) f.get(null);
+  }
+
+  private static void setBoolean(HTTP2JettyClient client, String name, boolean value)
+      throws Exception {
+    Field f = HTTP2JettyClient.class.getDeclaredField(name);
+    f.setAccessible(true);
+    f.setBoolean(client, value);
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/ProtocolFlagClientSelectionTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/ProtocolFlagClientSelectionTest.java
@@ -1,0 +1,122 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.junit.Assert.assertSame;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.sampler.JMeterTestUtils;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URI;
+import org.eclipse.jetty.client.HttpClient;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Pins which Jetty client the protocol flags select, so that disabling a protocol in the UI is
+ * actually honoured.
+ *
+ * <p>Reaches {@code selectHttpClient} by reflection and only compares the returned reference against
+ * the client fields, so nothing has to be started or connected.
+ */
+public class ProtocolFlagClientSelectionTest extends HTTP2TestBase {
+
+  @BeforeClass
+  public static void setupClass() {
+    JMeterTestUtils.setupJmeterEnv();
+  }
+
+  @Test
+  public void shouldUseHttp1OnlyForCleartextWhenOnlyHttp1Enabled() throws Exception {
+    HTTP2JettyClient client = new HTTP2JettyClient();
+    setFlags(client, true, false, false);
+
+    assertSame(field(client, "httpClientHttp1Only"),
+        selectHttpClient(client, URI.create("http://example.com/x")));
+  }
+
+  @Test
+  public void shouldUseHttp1OnlyForTlsWhenOnlyHttp1Enabled() throws Exception {
+    HTTP2JettyClient client = new HTTP2JettyClient();
+    setFlags(client, true, false, false);
+
+    assertSame(field(client, "httpClientHttp1Only"),
+        selectHttpClient(client, URI.create("https://example.com/x")));
+  }
+
+  /**
+   * With HTTP/2 off and HTTP/3 on there is no race to run and no HTTP/2 client to fall through to:
+   * the request has to go out on HTTP/3, and only a failure there may fall back to HTTP/1.1.
+   */
+  @Test
+  public void shouldUseHttp3ForTlsWhenHttp2DisabledAndHttp3Enabled() throws Exception {
+    HTTP2JettyClient client = new HTTP2JettyClient();
+    setFlags(client, true, false, true);
+
+    assertSame(field(client, "httpClient"),
+        selectHttpClient(client, URI.create("https://example.com/x")));
+  }
+
+  /** Same, with HTTP/1.1 disabled too: still HTTP/3, never the client of a disabled protocol. */
+  @Test
+  public void shouldUseHttp3ForTlsWhenOnlyHttp3Enabled() throws Exception {
+    HTTP2JettyClient client = new HTTP2JettyClient();
+    setFlags(client, false, false, true);
+
+    assertSame(field(client, "httpClient"),
+        selectHttpClient(client, URI.create("https://example.com/x")));
+  }
+
+  /**
+   * Selection without a request in hand stays conservative: with nothing known about the origin and
+   * no way to tell whether a failed HTTP/3 attempt could be retried, it must not explore HTTP/3.
+   * Exploration belongs to the path that does know the request - see
+   * {@link Http3ExplorationPolicyTest}.
+   */
+  @Test
+  public void shouldNotExploreHttp3ForUnknownOriginWithoutRequestContext() throws Exception {
+    HTTP2JettyClient client = new HTTP2JettyClient();
+    setFlags(client, true, true, true);
+
+    assertSame(field(client, "httpClientNoH3"),
+        selectHttpClient(client, URI.create("https://unknown-origin.example.com/x")));
+  }
+
+  @Test
+  public void shouldUseHttp2ForTlsWhenHttp3Disabled() throws Exception {
+    HTTP2JettyClient client = new HTTP2JettyClient();
+    setFlags(client, true, true, false);
+
+    assertSame(field(client, "httpClientNoH3"),
+        selectHttpClient(client, URI.create("https://example.com/x")));
+  }
+
+  private static void setFlags(HTTP2JettyClient client, boolean http1, boolean http2, boolean http3)
+      throws Exception {
+    setField(client, "enableHttp1", http1);
+    setField(client, "enableHttp2", http2);
+    setField(client, "enableHttp3", http3);
+    // Keep the decision driven purely by the flags under test.
+    setField(client, "http1UpgradeRequired", false);
+    setField(client, "http3PriorKnowledgeEnabled", false);
+  }
+
+  private static void setField(HTTP2JettyClient client, String name, boolean value)
+      throws Exception {
+    Field f = HTTP2JettyClient.class.getDeclaredField(name);
+    f.setAccessible(true);
+    f.setBoolean(client, value);
+  }
+
+  private static HttpClient field(HTTP2JettyClient client, String name) throws Exception {
+    Field f = HTTP2JettyClient.class.getDeclaredField(name);
+    f.setAccessible(true);
+    return (HttpClient) f.get(client);
+  }
+
+  private static HttpClient selectHttpClient(HTTP2JettyClient client, URI uri) throws Exception {
+    Method m = HTTP2JettyClient.class.getDeclaredMethod("selectHttpClient", URI.class);
+    m.setAccessible(true);
+    return (HttpClient) m.invoke(client, uri);
+  }
+
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/RetryRequestBodyReuseTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/RetryRequestBodyReuseTest.java
@@ -1,0 +1,118 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.InputStreamRequestContent;
+import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.client.StringRequestContent;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.util.BufferUtil;
+import org.junit.Test;
+
+/**
+ * Every protocol fallback replaces a request that already failed with an equivalent one, and the
+ * body has to survive that hand-over. These tests cover both halves: the Jetty behaviour that makes
+ * naive reuse silently wrong, and {@code copyBodyForRetry}, which is what all the fallbacks go
+ * through.
+ */
+public class RetryRequestBodyReuseTest {
+
+  @Test
+  public void shouldKeepFailureWhenBodySourceWasFailed() {
+    StringRequestContent body = new StringRequestContent("text/plain", "value1");
+    SocketTimeoutException failure = new SocketTimeoutException("connect timeout");
+
+    body.fail(failure);
+    Content.Chunk chunk = body.read();
+
+    assertThat(Content.Chunk.isFailure(chunk))
+        .as("a failed body source must report the failure to whoever reads it next")
+        .isTrue();
+    assertThat(chunk.getFailure())
+        .as("and it must be the very same exception, which is what a retry would surface")
+        .isSameAs(failure);
+  }
+
+  /** And the way out: rewinding clears the failure, which is what makes a retry possible at all. */
+  @Test
+  public void shouldRecoverFailedBodySourceByRewinding() {
+    StringRequestContent body = new StringRequestContent("text/plain", "value1");
+    body.fail(new SocketTimeoutException("connect timeout"));
+
+    assertThat(body.rewind())
+        .as("a rewindable body must accept being rewound after a failed attempt")
+        .isTrue();
+
+    Content.Chunk chunk = body.read();
+
+    assertThat(Content.Chunk.isFailure(chunk))
+        .as("after rewinding, reading must no longer report the previous failure")
+        .isFalse();
+    assertThat(BufferUtil.toString(chunk.getByteBuffer()))
+        .as("and the original content must be readable again, whole")
+        .isEqualTo("value1");
+  }
+
+  /**
+   * The fallbacks rely on this: a body that already failed must reach the retry readable, or the
+   * retry dies instantly with the error it was supposed to rescue.
+   */
+  @Test
+  public void shouldHandFailedBodyToRetryReadable() throws Exception {
+    HttpClient client = new HttpClient();
+    Request original = client.newRequest("http://localhost:1/x");
+    Request retry = client.newRequest("http://localhost:1/x");
+    StringRequestContent body = new StringRequestContent("text/plain", "value1");
+    original.body(body);
+    body.fail(new SocketTimeoutException("connect timeout"));
+
+    copyBodyForRetry(original, retry, "test");
+
+    Content.Chunk chunk = retry.getBody().read();
+    assertThat(Content.Chunk.isFailure(chunk))
+        .as("the retry must not inherit the failure of the attempt it replaces")
+        .isFalse();
+    assertThat(BufferUtil.toString(chunk.getByteBuffer()))
+        .as("the retry must carry the same body content")
+        .isEqualTo("value1");
+  }
+
+  /**
+   * A body that cannot be rewound cannot be retried. Failing loudly is the point: sending the retry
+   * without the body would silently turn it into a different request.
+   */
+  @Test
+  public void shouldRefuseRetryWhenBodyCannotBeRewound() throws Exception {
+    HttpClient client = new HttpClient();
+    Request original = client.newRequest("http://localhost:1/x");
+    Request retry = client.newRequest("http://localhost:1/x");
+    original.body(new InputStreamRequestContent(
+        new ByteArrayInputStream("value1".getBytes(StandardCharsets.UTF_8))));
+
+    assertThatThrownBy(() -> copyBodyForRetry(original, retry, "test"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("not reproducible");
+  }
+
+  private static void copyBodyForRetry(Request original, Request retry, String description)
+      throws Exception {
+    Method m = HTTP2JettyClient.class.getDeclaredMethod(
+        "copyBodyForRetry", Request.class, Request.class, String.class);
+    m.setAccessible(true);
+    try {
+      m.invoke(null, original, retry, description);
+    } catch (InvocationTargetException e) {
+      if (e.getCause() instanceof RuntimeException) {
+        throw (RuntimeException) e.getCause();
+      }
+      throw e;
+    }
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/integration/HTTP3HappyEyeballsIntegrationTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/integration/HTTP3HappyEyeballsIntegrationTest.java
@@ -155,10 +155,12 @@ public class HTTP3HappyEyeballsIntegrationTest extends HTTP2TestBase {
       HTTP2JettyClient client = new HTTP2JettyClient(false, "IT-HTTP3-HE-Recent");
       try {
         client.start();
-        // Phase A: establish Alt-Svc and force one confirmed H3 success first.
+        // Phase A: establish Alt-Svc and force one confirmed H3 success first. No protocol is
+        // asserted on this first sample: first contact with an unknown origin explores HTTP/3, so
+        // either side of the race may win it. The warmup loop below is what guarantees the
+        // confirmed HTTP/3 success this test needs.
         HTTPSampleResult first = sample(client, sampler, url);
         assertThat(first.isSuccessful()).isTrue();
-        assertThat(first.getResponseHeaders()).startsWith("HTTP/2");
 
         h2DelayMs.set(500L);
         h3DelayMs.set(0L);
@@ -251,16 +253,42 @@ public class HTTP3HappyEyeballsIntegrationTest extends HTTP2TestBase {
       HTTP2JettyClient client = new HTTP2JettyClient(false, "IT-HTTP3-HE-Broken");
       try {
         client.start();
-        HTTPSampleResult first = sample(client, sampler, url);
-        assertThat(first.isSuccessful()).isTrue();
-        assertThat(first.getResponseHeaders()).startsWith("HTTP/2");
+        // Setup, in two steps, so that the cooldown ends up being the only thing that can stop
+        // HTTP/3 - otherwise this test passes without the cooldown doing any work.
+        //
+        // First, let HTTP/2 win a race so its Alt-Svc is recorded with h3=true. Marking an origin
+        // broken when nothing is cached for it creates an entry saying h3=false, and that alone
+        // stops HTTP/3 regardless of any cooldown.
+        h3DelayMs.set(1000L);
+        HTTPSampleResult altSvcLearn = sample(client, sampler, url);
+        assertThat(altSvcLearn.isSuccessful()).isTrue();
+        assertThat(altSvcLearn.getResponseHeaders())
+            .as("HTTP/2 has to answer this one for its Alt-Svc to be cached")
+            .startsWith("HTTP/2");
+        h3DelayMs.set(0L);
+
+        // Second, confirm HTTP/3 is actually being attempted now, so that its absence later means
+        // something. No protocol is asserted on these samples: either side of the race may win.
+        boolean http3Attempted = false;
+        for (int attempt = 0; attempt < 6 && !http3Attempted; attempt++) {
+          int before = h3Requests.get();
+          HTTPSampleResult warmup = sample(client, sampler, url);
+          assertThat(warmup.isSuccessful()).isTrue();
+          http3Attempted = h3Requests.get() > before;
+        }
+        assertThat(http3Attempted)
+            .as("the origin must be reaching HTTP/3 before the cooldown can be shown to stop it")
+            .isTrue();
 
         markHttp3Broken(client, url.toURI());
+        int h3RequestsWhenBroken = h3Requests.get();
 
         HTTPSampleResult second = sample(client, sampler, url);
         assertThat(second.isSuccessful()).isTrue();
         assertThat(second.getResponseHeaders()).startsWith("HTTP/2");
-        assertThat(h3Requests.get()).isEqualTo(0);
+        assertThat(h3Requests.get())
+            .as("no HTTP/3 may be attempted once the origin is in the broken cooldown")
+            .isEqualTo(h3RequestsWhenBroken);
       } finally {
         client.stop();
       }

--- a/src/test/java/com/blazemeter/jmeter/http2/integration/HTTP3HappyEyeballsIntegrationTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/integration/HTTP3HappyEyeballsIntegrationTest.java
@@ -83,13 +83,24 @@ public class HTTP3HappyEyeballsIntegrationTest extends HTTP2TestBase {
       HTTP2JettyClient client = new HTTP2JettyClient(false, "IT-HTTP3-HE-NoRecent");
       try {
         client.start();
+        // Setup: HTTP/2 has to answer this first sample, so its Alt-Svc is cached and no HTTP/3
+        // success is recorded - both are preconditions for the halved stagger asserted below.
+        // HTTP/3 is slowed right down for it because first contact now explores HTTP/3 with the
+        // full stagger: at its normal 150ms it would answer before HTTP/2 is due to start at 200ms
+        // and win, leaving nothing cached and the delay at its base value.
+        h3DelayMs.set(1000L);
         HTTPSampleResult first = sample(client, sampler, url);
         assertThat(first.isSuccessful()).isTrue();
         assertThat(first.getResponseHeaders()).startsWith("HTTP/2");
+        h3DelayMs.set(150L);
 
         long effectiveDelay = computeHappyEyeballsDelay(client, url.toURI());
-        assertThat(effectiveDelay).isEqualTo(100L);
+        assertThat(effectiveDelay)
+            .as("with no recent HTTP/3 success the stagger is halved, so HTTP/2 starts sooner")
+            .isEqualTo(100L);
 
+        // This one is the point: with the stagger halved to 100ms, HTTP/2 starts before HTTP/3's
+        // 150ms response is due and takes the race.
         HTTPSampleResult second = sample(client, sampler, url);
         assertThat(second.isSuccessful()).isTrue();
         assertThat(second.getResponseHeaders()).startsWith("HTTP/2");

--- a/src/test/java/com/blazemeter/jmeter/http2/sampler/EmbeddedResourceTimeoutInheritanceTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/sampler/EmbeddedResourceTimeoutInheritanceTest.java
@@ -1,0 +1,61 @@
+package com.blazemeter.jmeter.http2.sampler;
+
+import static org.junit.Assert.assertEquals;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import java.lang.reflect.Method;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Embedded-resource child samplers must inherit the parent's Connect Timeout and Response Timeout.
+ *
+ * <p>JMeter builds them with {@code base.clone()} ({@code HTTPSamplerBase.ASyncSample}) so they
+ * inherit every property; this plugin builds them from a fresh {@link HTTP2Sampler} and copies
+ * settings explicitly. When the timeouts were left out of that copy, an embedded request reported 0
+ * for both - meaning "no timeout" - so {@code HTTP2JettyClient} never applied a deadline to it and a
+ * stalled resource blocked the JMeter thread forever in the concurrent download drain.
+ */
+public class EmbeddedResourceTimeoutInheritanceTest extends HTTP2TestBase {
+
+  @BeforeClass
+  public static void setupClass() {
+    JMeterTestUtils.setupJmeterEnv();
+  }
+
+  @Test
+  public void shouldCopyParentTimeoutsToEmbeddedSampler() throws Exception {
+    HTTP2Sampler parent = new HTTP2Sampler();
+    parent.setConnectTimeout("5000");
+    parent.setResponseTimeout("20000");
+
+    HTTP2Sampler embedded = copySettings(parent);
+
+    assertEquals(5000, embedded.getConnectTimeout());
+    assertEquals(20000, embedded.getResponseTimeout());
+  }
+
+  /**
+   * An unset timeout has to stay unset rather than become a literal "0": both read back as 0, but
+   * only the pass-through keeps the plugin 1:1 with JMeter, where an absent value and 0 alike mean
+   * "wait indefinitely".
+   */
+  @Test
+  public void shouldKeepUnsetParentTimeoutsUnsetOnEmbeddedSampler() throws Exception {
+    HTTP2Sampler embedded = copySettings(new HTTP2Sampler());
+
+    assertEquals(0, embedded.getConnectTimeout());
+    assertEquals(0, embedded.getResponseTimeout());
+    assertEquals("", embedded.getPropertyAsString("HTTPSampler.connect_timeout"));
+    assertEquals("", embedded.getPropertyAsString("HTTPSampler.response_timeout"));
+  }
+
+  private static HTTP2Sampler copySettings(HTTP2Sampler parent) throws Exception {
+    HTTP2Sampler embedded = new HTTP2Sampler();
+    Method copy = HTTP2Sampler.class.getDeclaredMethod(
+        "copyJettyProtocolSettingsToEmbeddedSampler", HTTP2Sampler.class);
+    copy.setAccessible(true);
+    copy.invoke(parent, embedded);
+    return embedded;
+  }
+}


### PR DESCRIPTION
This pull request introduces significant improvements to the HTTP/2 and HTTP/3 protocol negotiation and resource download logic, as well as enhancements to logging and dependency management. The changes address protocol race handling, resource download timeouts, and logging clarity, while also updating the Maven build to ensure correct dependency shading and classpath behavior.

**Protocol negotiation and race handling:**

* Added the `sealed` and `raceProtocol` fields to `HTTP2FutureResponseListener`, along with logic to properly handle protocol races so that only the winning request reports a result and losing attempts are cleanly ignored. This prevents spurious error logs and ensures correct listener state. [[1]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aR36-R46) [[2]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aR100-R111) [[3]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aR120) [[4]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aR131-R135) [[5]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aR182-R186)
* Improved logging for protocol negotiation failures and cancellations to distinguish between expected race outcomes and real errors, reducing noise in logs. [[1]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aR253-R266) [[2]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aR492-R506)

**Embedded resource download and timeouts:**

* Ensured that embedded resource samplers inherit response and connect timeouts from their parent, preventing indefinite waits when timeouts are configured. Added the `copyTimeoutsToEmbeddedSampler` method and related documentation. [[1]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R642-R661) [[2]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R1142-R1152)
* Added polling and a configurable timeout for waiting on embedded resource downloads, matching JMeter’s semantics and preventing hangs. [[1]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R94-R96) [[2]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R1200-R1208)

**Dependency and build management:**

* Updated `pom.xml` to add and relocate the `log4j-slf4j2-impl` dependency for correct SLF4J binding in the shaded JAR, avoiding classloader conflicts and ensuring logs are routed to JMeter’s log. Excluded this binding from test classpaths to prevent test failures. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R35-R36) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R182-R208) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R378-R390) [[4]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R445-R454) [[5]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R550-R554)

**Other improvements:**

* Changed the async request dispatch in `HTTP2Sampler` to use `client.dispatchAsync` instead of sending directly, ensuring proper participation in protocol races.

These changes collectively improve protocol negotiation robustness, resource download reliability, logging clarity, and build correctness.