### PR TITLE
Fix flaky test execution

### DIFF
--- a/src/test/java/com/blazemeter/jmeter/http2/core/EmbeddedResourceInheritsSamplerProtocolRegressionTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/EmbeddedResourceInheritsSamplerProtocolRegressionTest.java
@@ -14,7 +14,6 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Map;
 import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.samplers.SampleResult;
@@ -46,7 +45,7 @@ public class EmbeddedResourceInheritsSamplerProtocolRegressionTest extends HTTP2
 
   @Before
   public void setUp() throws Exception {
-    clearHttp1OnlyOriginCache();
+    HTTP2JettyClientTestIsolation.resetSharedClientState();
 
     serverAssetOrigin = new ServerBuilder()
         .withHTTP2()
@@ -62,6 +61,7 @@ public class EmbeddedResourceInheritsSamplerProtocolRegressionTest extends HTTP2
     warmupHttp1OnlySampler.setEnableHttp3(false);
     warmupHttp1OnlySampler.setEnableHttp1(true);
     warmupHttp1OnlySampler.setEnableHttp2(false);
+    warmupHttp1OnlySampler.setAlpnEnabled(false);
     invokeSample(warmupHttp1OnlySampler, httpsUrl(assetPort, SERVER_PATH_200));
     warmupHttp1OnlySampler.threadFinished();
 
@@ -96,6 +96,9 @@ public class EmbeddedResourceInheritsSamplerProtocolRegressionTest extends HTTP2
     h2Sampler.setEnableHttp3(false);
     h2Sampler.setEnableHttp1(false);
     h2Sampler.setEnableHttp2(true);
+    // Without an explicit ALPN flag, a leaked suite-wide alpnEnabled=false drops h2 from the
+    // transport and the embedded download never produces an HTTP/2 subsample.
+    h2Sampler.setAlpnEnabled(true);
     try {
       HTTPSampleResult pageResult =
           invokeSample(h2Sampler, httpsUrl(pagePort, SERVER_PATH_200_EMBEDDED_CROSS_ORIGIN));
@@ -150,15 +153,6 @@ public class EmbeddedResourceInheritsSamplerProtocolRegressionTest extends HTTP2
       }
     }
     return null;
-  }
-
-  @SuppressWarnings("unchecked")
-  private static void clearHttp1OnlyOriginCache() throws Exception {
-    java.lang.reflect.Field field =
-        HTTP2JettyClient.class.getDeclaredField("HTTP1_ONLY_CACHE");
-    field.setAccessible(true);
-    Map<Object, Object> map = (Map<Object, Object>) field.get(null);
-    map.clear();
   }
 
   private static void stopQuietly(TeardownableServer server) {

--- a/src/test/java/com/blazemeter/jmeter/http2/core/GoAwayReconnectTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/GoAwayReconnectTest.java
@@ -67,6 +67,11 @@ public class GoAwayReconnectTest extends HTTP2TestBase {
 
   @Before
   public void setUp() throws Exception {
+    // Static HTTP/1-only cache entries survive across tests and are keyed by host:port. Ephemeral
+    // ports recycle in a full suite, so a prior HTTPS HTTP/1.1 sample can force this client onto
+    // HTTP/1.1 and leave no HTTP/2 session to GOAWAY. Same for leaked legacy profile properties.
+    HTTP2JettyClientTestIsolation.resetSharedClientState();
+
     // This exact combination is what actually negotiates HTTP/2; withSSL().withALPN().withHTTP2()
     // alone makes the client fall back to HTTP/1.1, which would leave no session to GOAWAY.
     server = new ServerBuilder().withHTTP2().withALPN().withHTTP2C().withSSL().buildServer();
@@ -160,8 +165,16 @@ public class GoAwayReconnectTest extends HTTP2TestBase {
   }
 
   private void startClient() throws Exception {
-    client = new HTTP2JettyClient();
-    client.loadProperties();
+    // Pin HTTP/2+ALPN regardless of any leftover suite-wide protocol properties.
+    HTTP2ClientProfileConfig profile = HTTP2ClientProfileConfig.builder()
+        .profile("browser-like-custom")
+        .enableHttp1(true)
+        .enableHttp2(true)
+        .enableHttp3(false)
+        .alpnEnabled(true)
+        .http1OnlyCacheEnabled(false)
+        .build();
+    client = new HTTP2JettyClient(false, "goaway-reconnect-test", profile);
     client.start();
   }
 

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientH2cFallbackTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientH2cFallbackTest.java
@@ -18,6 +18,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.server.ServerConnector;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -30,6 +31,14 @@ public class HTTP2JettyClientH2cFallbackTest extends HTTP2TestBase {
 
   private TeardownableServer server;
   private HttpClient probeClient;
+
+  @Before
+  public void setUp() throws Exception {
+    // A leaked legacy profile (enableHttp2=false) makes the upgrade client skip h2c entirely, so
+    // the HTTP/1-only cache is never populated and this assertion fails. Shared caches can also
+    // retain stale cleartext origins across recycled ports.
+    HTTP2JettyClientTestIsolation.resetSharedClientState();
+  }
 
   @After
   public void tearDown() throws Exception {

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTestIsolation.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTestIsolation.java
@@ -1,0 +1,69 @@
+package com.blazemeter.jmeter.http2.core;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import org.apache.jmeter.util.JMeterUtils;
+
+/**
+ * Resets process-wide Jetty client state that unit tests share.
+ *
+ * <p>{@link HTTP2JettyClient}'s protocol caches are static and keyed by origin (scheme/host/port).
+ * Ephemeral test ports recycle within a suite, so a prior HTTPS HTTP/1.1 sample can leave a
+ * five-minute {@code HTTP1_ONLY_CACHE} entry that makes a later HTTP/2 test negotiate HTTP/1.1
+ * instead. Global {@code blazemeter.http.*} / {@code httpJettyClient.*} properties similarly leak
+ * across classes when a test forces the legacy profile and cleanup is skipped or incomplete.
+ */
+final class HTTP2JettyClientTestIsolation {
+
+  private static final String[] PROTOCOL_PROPERTY_SUFFIXES = {
+      "profile",
+      "enableHttp1",
+      "enableHttp2",
+      "enableHttp3",
+      "alpnEnabled",
+      "fallbackEnabled",
+      "protocolErrorFallbackEnabled",
+      "altSvcCacheEnabled",
+      "http1OnlyCacheEnabled",
+      "h2cCacheEnabled",
+      "http2PriorKnowledge",
+      "http3PriorKnowledge",
+      "happyEyeballsDelayMs",
+      "http1OnlyCooldownMs",
+      "h2cCacheTtlMs",
+      "goawayRetryEnabled"
+  };
+
+  private HTTP2JettyClientTestIsolation() {
+  }
+
+  static void resetSharedClientState() throws Exception {
+    clearStaticMap("ALT_SVC_CACHE");
+    clearStaticMap("HTTP1_ONLY_CACHE");
+    clearStaticMap("H2C_CACHE");
+    clearProtocolProperties();
+  }
+
+  static void clearProtocolProperties() {
+    for (String suffix : PROTOCOL_PROPERTY_SUFFIXES) {
+      removeProperty("blazemeter.http." + suffix);
+      removeProperty("httpJettyClient." + suffix);
+      removeProperty("HTTP2Sampler." + suffix);
+    }
+  }
+
+  private static void removeProperty(String key) {
+    JMeterUtils.getJMeterProperties().remove(key);
+    System.clearProperty(key);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void clearStaticMap(String fieldName) throws Exception {
+    Field field = HTTP2JettyClient.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    Map<Object, Object> map = (Map<Object, Object>) field.get(null);
+    if (map != null) {
+      map.clear();
+    }
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HttpKeepAliveSampleHeadersTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HttpKeepAliveSampleHeadersTest.java
@@ -32,14 +32,22 @@ public class HttpKeepAliveSampleHeadersTest {
 
   @After
   public void tearDown() throws Exception {
-    if (executor != null) {
-      executor.shutdownNow();
-      executor.awaitTermination(5, TimeUnit.SECONDS);
-      executor = null;
+    try {
+      if (executor != null) {
+        executor.shutdownNow();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+        executor = null;
+      }
+    } finally {
+      // Always clear: if executor teardown throws, leaked legacy profile properties make later
+      // HTTP/2 tests negotiate HTTP/1.1 (or skip h2c upgrade caching) for the rest of the suite.
+      JMeterUtils.getJMeterProperties().remove("blazemeter.http.enableHttp2");
+      JMeterUtils.getJMeterProperties().remove("blazemeter.http.enableHttp3");
+      JMeterUtils.getJMeterProperties().remove("blazemeter.http.profile");
+      System.clearProperty("blazemeter.http.enableHttp2");
+      System.clearProperty("blazemeter.http.enableHttp3");
+      System.clearProperty("blazemeter.http.profile");
     }
-    JMeterUtils.getJMeterProperties().remove("blazemeter.http.enableHttp2");
-    JMeterUtils.getJMeterProperties().remove("blazemeter.http.enableHttp3");
-    JMeterUtils.getJMeterProperties().remove("blazemeter.http.profile");
   }
 
   @Test


### PR DESCRIPTION
This pull request improves the reliability and isolation of HTTP/2-related unit tests by ensuring that shared protocol state and legacy properties do not leak between tests. The main changes introduce a utility for resetting static client caches and protocol properties, and update test setup/teardown routines to consistently clear these states.

**Test isolation and shared state reset:**

* Added new utility class `HTTP2JettyClientTestIsolation` to clear static protocol caches and remove global protocol-related properties, preventing test cross-contamination.
* Updated `EmbeddedResourceInheritsSamplerProtocolRegressionTest`, `GoAwayReconnectTest`, and `HTTP2JettyClientH2cFallbackTest` to call `HTTP2JettyClientTestIsolation.resetSharedClientState()` in their setup methods, replacing ad-hoc cache clearing and ensuring each test starts with a clean state. [[1]](diffhunk://#diff-3585eff180ec1ee8737fa4996749984791c990f0bab42be0b2889ec620927a0cL49-R48) [[2]](diffhunk://#diff-3585eff180ec1ee8737fa4996749984791c990f0bab42be0b2889ec620927a0cL155-L163) [[3]](diffhunk://#diff-707de44b299c558aa4e97ab92af81122cd134313468d396d79968d695d4fb647R70-R74) [[4]](diffhunk://#diff-0076a9cb39438b2f96079671d2e3c28ef74908dc3b9a0a41479aadad46fa4441R35-R42)

**Test configuration and protocol negotiation:**

* Explicitly set ALPN and protocol flags (e.g., `setAlpnEnabled`, `setEnableHttp2`) in test samplers to avoid accidental protocol fallback due to leaked state. [[1]](diffhunk://#diff-3585eff180ec1ee8737fa4996749984791c990f0bab42be0b2889ec620927a0cR64) [[2]](diffhunk://#diff-3585eff180ec1ee8737fa4996749984791c990f0bab42be0b2889ec620927a0cR99-R101) [[3]](diffhunk://#diff-707de44b299c558aa4e97ab92af81122cd134313468d396d79968d695d4fb647L163-R177)
* Updated client construction in `GoAwayReconnectTest` to use a custom `HTTP2ClientProfileConfig`, ensuring HTTP/2+ALPN is always enabled for the test regardless of prior suite state.

**Teardown improvements:**

* Modified `HttpKeepAliveSampleHeadersTest` teardown to always clear legacy protocol properties from both `JMeterUtils` and system properties, even if executor shutdown fails, preventing test suite contamination.

These changes collectively ensure that protocol negotiation and cache state in HTTP/2 tests are fully isolated, eliminating flakiness caused by shared static state or global property leakage.