### PR TITLE
Improve controlled execution thread drop-off

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -1448,23 +1448,81 @@ public class HTTP2JettyClient {
     return response;
   }
 
+  /**
+   * Stops every Jetty {@link HttpClient} owned by this wrapper.
+   *
+   * <p>JMeter's Stop button interrupts the worker thread before {@code threadFinished} runs. Jetty
+   * awaits selector shutdown interruptibly, so leaving the interrupt flag set turns a normal
+   * teardown into {@link InterruptedException} plus {@code ClosedSelectorException} noise on the
+   * console. Clear the flag for the duration of the stop, shut each client down independently so
+   * one failure does not skip the rest, then restore the interrupt status for the caller.
+   */
   public void stop() throws Exception {
-    httpClient.stop();
-    if (httpClientNoH3 != httpClient) {
-      httpClientNoH3.stop();
-    }
-    httpClientHttp1Only.stop();
-    httpClientH2cPrior.stop();
-    httpClientH2cUpgrade.stop();
-    clearBufferPool();
-    if (heExecutorsRegistered) {
-      int remaining = HAPPY_EYEBALLS_CLIENTS.decrementAndGet();
-      if (remaining <= 0) {
-        HAPPY_EYEBALLS_CLIENTS.set(0);
-        shutdownHappyEyeballsExecutors();
+    boolean interrupted = Thread.interrupted();
+    Exception firstFailure = null;
+    try {
+      firstFailure = stopClient(httpClient, firstFailure);
+      if (httpClientNoH3 != httpClient) {
+        firstFailure = stopClient(httpClientNoH3, firstFailure);
       }
-      heExecutorsRegistered = false;
+      firstFailure = stopClient(httpClientHttp1Only, firstFailure);
+      firstFailure = stopClient(httpClientH2cPrior, firstFailure);
+      firstFailure = stopClient(httpClientH2cUpgrade, firstFailure);
+      clearBufferPool();
+      if (heExecutorsRegistered) {
+        int remaining = HAPPY_EYEBALLS_CLIENTS.decrementAndGet();
+        if (remaining <= 0) {
+          HAPPY_EYEBALLS_CLIENTS.set(0);
+          shutdownHappyEyeballsExecutors();
+        }
+        heExecutorsRegistered = false;
+      }
+      if (firstFailure != null) {
+        throw firstFailure;
+      }
+    } finally {
+      // Also absorb interrupts that arrived mid-stop so we still restore a single, clean flag.
+      if (interrupted || Thread.interrupted()) {
+        Thread.currentThread().interrupt();
+      }
     }
+  }
+
+  private static Exception stopClient(HttpClient client, Exception firstFailure) {
+    if (client == null || !client.isRunning()) {
+      return firstFailure;
+    }
+    try {
+      client.stop();
+      return firstFailure;
+    } catch (InterruptedException e) {
+      // Keep going: remaining clients must still be stopped. The interrupt is restored in stop().
+      Thread.interrupted();
+      return firstFailure;
+    } catch (Exception e) {
+      if (isExpectedShutdownException(e)) {
+        lowLevelDebug("Ignoring expected shutdown exception while stopping {}: {}",
+            client.getName(), e.toString());
+        return firstFailure;
+      }
+      LOG.warn("Failed to stop HttpClient {}: {}", client.getName(), e.toString());
+      return firstFailure != null ? firstFailure : e;
+    }
+  }
+
+  /**
+   * Exceptions that show up when JMeter interrupts a thread mid-stop, or when a selector is already
+   * closed by a concurrent shutdown. They are not actionable connection failures.
+   */
+  public static boolean isExpectedShutdownException(Throwable throwable) {
+    for (Throwable current = throwable; current != null; current = current.getCause()) {
+      if (current instanceof InterruptedException
+          || current instanceof java.nio.channels.ClosedSelectorException
+          || current instanceof java.nio.channels.ClosedChannelException) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private void samplePrepareRequest(Request request,

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -1516,8 +1516,16 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
     for (HTTP2JettyClient client : clients.values()) {
       try {
         client.stop();
+      } catch (InterruptedException e) {
+        // JMeter Stop interrupts the thread before threadFinished; Jetty shutdown is interruptible.
+        Thread.currentThread().interrupt();
+        LOG.debug("Interrupted while closing BlazeMeter HTTP connection (test stopped)");
       } catch (Exception e) {
-        LOG.error("Error while closing connection", e);
+        if (HTTP2JettyClient.isExpectedShutdownException(e)) {
+          LOG.debug("BlazeMeter HTTP connection closed during test stop: {}", e.toString());
+        } else {
+          LOG.error("Error while closing connection", e);
+        }
       }
     }
     clients.clear();

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientStopInterruptedTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientStopInterruptedTest.java
@@ -1,0 +1,59 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.ClosedSelectorException;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * JMeter Stop interrupts the worker before {@code threadFinished}; Jetty shutdown must absorb that
+ * instead of surfacing ERROR / ClosedSelectorException noise.
+ */
+public class HTTP2JettyClientStopInterruptedTest extends HTTP2TestBase {
+
+  private HTTP2JettyClient client;
+
+  @After
+  public void tearDown() throws Exception {
+    // Ensure later tests do not inherit a sticky interrupt from assertions below.
+    Thread.interrupted();
+    if (client != null) {
+      try {
+        client.stop();
+      } catch (Exception ignored) {
+        // already stopped in the test body
+      }
+      client = null;
+    }
+  }
+
+  @Test
+  public void stopWhileInterruptedCompletesAndRestoresInterruptFlag() throws Exception {
+    client = new HTTP2JettyClient(false, "stop-interrupted-test");
+    client.start();
+
+    Thread.currentThread().interrupt();
+    assertThatCode(() -> client.stop()).doesNotThrowAnyException();
+    assertThat(Thread.interrupted())
+        .as("interrupt status must be restored after stop so JMeter still sees the Stop request")
+        .isTrue();
+    client = null;
+  }
+
+  @Test
+  public void isExpectedShutdownExceptionRecognizesInterruptAndClosedSelector() {
+    assertThat(HTTP2JettyClient.isExpectedShutdownException(new InterruptedException())).isTrue();
+    assertThat(HTTP2JettyClient.isExpectedShutdownException(new ClosedSelectorException()))
+        .isTrue();
+    assertThat(HTTP2JettyClient.isExpectedShutdownException(new ClosedChannelException()))
+        .isTrue();
+    assertThat(HTTP2JettyClient.isExpectedShutdownException(
+        new RuntimeException(new InterruptedException("nested")))).isTrue();
+    assertThat(HTTP2JettyClient.isExpectedShutdownException(new IllegalStateException("boom")))
+        .isFalse();
+  }
+}


### PR DESCRIPTION
This pull request improves the shutdown process for the Jetty HTTP client in BlazeMeter's HTTP2 plugin, particularly to handle thread interrupts during test stops in JMeter more gracefully. It ensures that all Jetty clients are stopped reliably, expected shutdown exceptions are handled quietly, and the thread's interrupt status is correctly restored. Additionally, new tests have been added to verify this behavior.

**Shutdown and Exception Handling Improvements:**

* Refactored the `stop()` method in `HTTP2JettyClient` to stop all owned `HttpClient` instances independently, handle and log expected shutdown exceptions (such as `InterruptedException` and `ClosedSelectorException`), and ensure the thread's interrupt status is restored after shutdown. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR1451-R1470) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR1480-R1525)
* Added a static `isExpectedShutdownException` method to classify non-actionable exceptions during shutdown, used both in the client and sampler.

**Sampler Integration:**

* Updated `HTTP2Sampler.closeConnections()` to use the new exception handling logic, logging expected shutdown exceptions at debug level and restoring the interrupt flag if interrupted.

**Testing:**

* Added a new test class `HTTP2JettyClientStopInterruptedTest` to verify that the client shutdown completes cleanly when interrupted and that expected exceptions are properly recognized and handled.