### PR TITLE
Align Embedded Resource logic with JMeter

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -1627,7 +1627,7 @@ public class HTTP2JettyClient {
     if (headerBytes > result.getSentBytes()) {
       result.setSentBytes(headerBytes);
     }
-    setResultContentResponse(result, contentResponse);
+    setResultContentResponse(sampler, result, contentResponse);
     saveCookiesInCookieManager(contentResponse, request.getURI().toURL(),
         sampler.getCookieManager());
 
@@ -1773,7 +1773,7 @@ public class HTTP2JettyClient {
     }
 
     result.sampleEnd();
-    result.setResponseData(output.toByteArray());
+    applyResponseData(sampler, result, output.toByteArray());
     result.setBodySize(totalBytes);
     result.setResponseCodeOK();
     result.setResponseMessageOK();
@@ -4409,7 +4409,32 @@ public class HTTP2JettyClient {
     }
   }
 
-  private void setResultContentResponse(HTTPSampleResult result,
+  /**
+   * Stores response bytes, or their MD5 digest when the sampler asked for it — the same contract as
+   * {@code HTTPSamplerBase.readResponse}: body becomes the hex digest and {@code bytes} keeps the
+   * original size.
+   */
+  private static void applyResponseData(HTTP2Sampler sampler, HTTPSampleResult result,
+                                        byte[] responseContent) {
+    if (responseContent == null) {
+      result.setResponseData(new byte[0]);
+      return;
+    }
+    if (sampler != null && sampler.useMD5()) {
+      try {
+        java.security.MessageDigest md = java.security.MessageDigest.getInstance("MD5");
+        byte[] digest = md.digest(responseContent);
+        result.setBytes(responseContent.length);
+        result.setResponseData(org.apache.jorphan.util.JOrphanUtils.baToHexBytes(digest));
+        return;
+      } catch (java.security.NoSuchAlgorithmException e) {
+        LOG.error("Should not happen - could not find MD5 digest", e);
+      }
+    }
+    result.setResponseData(responseContent);
+  }
+
+  private void setResultContentResponse(HTTP2Sampler sampler, HTTPSampleResult result,
                                         ContentResponse contentResponse) throws IOException {
     if (LowLevelDebugLog.isEnabled()) {
       int headerCount = contentResponse.getHeaders() != null
@@ -4435,7 +4460,7 @@ public class HTTP2JettyClient {
     byte[] responseContent = maybeDecodeCompressedContent(contentResponse);
     // JMeter parity: optionally truncate stored response data while keeping full bodySize.
     responseContent = maybeTruncateStoredResponseData(result, responseContent);
-    result.setResponseData(responseContent);
+    applyResponseData(sampler, result, responseContent);
 
     if (result.getEndTime() == 0) {
       result.sampleEnd();

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -16,6 +16,7 @@ import com.helger.commons.annotation.VisibleForTesting;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.MalformedURLException;
+import java.net.SocketTimeoutException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -130,6 +131,12 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
   private int maxBufferSize;
   private int requestTimeout;
   private HTTPSampleResult result;
+  /**
+   * Frame depth captured when an async request is dispatched, so the completion turn can call
+   * {@link #sample(URL, String, boolean, int)} with the same depth JMeter's {@code ASyncSample}
+   * passes instead of resetting to 0 via public {@link #sample()}.
+   */
+  private int pendingCompletionDepth;
   private transient List<PreProcessor> suppressedPreProcessors;
   private transient List<Timer> suppressedTimers;
   private transient SamplePackage suppressedSamplePackage;
@@ -182,7 +189,8 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
 
   @Override
   public boolean isConcurrentDwn() {
-    return getPropertyAsBoolean(CONCURRENT_DWN, true);
+    // Match JMeter: concurrent download is off unless explicitly enabled.
+    return getPropertyAsBoolean(CONCURRENT_DWN, false);
   }
 
   public void setProfile(String profile) {
@@ -392,6 +400,7 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
       if (!isSyncRequest()) {
         if (Objects.isNull(this.asyncListener)) {
           this.result = buildResult(url, method); // Save the main result for next step
+          this.pendingCompletionDepth = depth;
           HTTP2FutureResponseListener listener =
               new HTTP2FutureResponseListener(HTTP2JettyClient.getJettyBufferingMaxLength());
           // The client fires it: dispatching there is what lets an async request take part in the
@@ -408,8 +417,9 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
         } else {
           // If there is a listener, it is processed using the result it had
           try {
+            int completionDepth = depth > 0 ? depth : pendingCompletionDepth;
             this.result = sampleFromListener(
-                this.result, areFollowingRedirect, depth, this.asyncListener);
+                this.result, areFollowingRedirect, completionDepth, this.asyncListener);
             return this.result;
           } finally {
             restoreSuppressedPreProcessors();
@@ -551,6 +561,84 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
   }
 
   /**
+   * Error sample for an embedded resource that did not finish in time, shaped like JMeter HC4's
+   * per-request socket timeout: the child's URL/label identify the resource, not the page
+   * container, and its elapsed time covers the wait until we gave up. That elapsed end time is what
+   * {@link SampleResult#addSubResult} uses to push the container's clock forward; stamping
+   * {@code sampleStart}/{@code sampleEnd} back-to-back left elapsed at ~0 and made the page look
+   * like it finished when the last fast image landed.
+   *
+   * @param startedAtMs when this resource's attempt began (dispatch / listener start), used as the
+   *                    sample start so the reported duration matches the timeout wait
+   */
+  private HTTPSampleResult embeddedTimeoutErrorResult(HTTP2Sampler embeddedSampler,
+                                                      long startedAtMs) {
+    HTTPSampleResult err = new HTTPSampleResult();
+    URL url = resolveEmbeddedResourceUrl(embeddedSampler);
+    if (url != null) {
+      err.setURL(url);
+      err.setSampleLabel(SampleResult.isRenameSampleLabel()
+          ? embeddedSampler.getName()
+          : url.toString());
+    } else if (embeddedSampler.getName() != null) {
+      err.setSampleLabel(embeddedSampler.getName());
+    }
+    err.setHTTPMethod(HTTPConstants.GET);
+    long endedAtMs = System.currentTimeMillis();
+    long elapsedMs = Math.max(0L, endedAtMs - startedAtMs);
+    // Stamp end = now, start = now - elapsed (same contract as a real timed-out HC4 sample).
+    err.setStampAndTime(endedAtMs, elapsedMs);
+    err.setConnectTime(0L);
+    err.setLatency(0L);
+    return errorResult(new SocketTimeoutException("Read timed out"), err);
+  }
+
+  private long embeddedAttemptStartMillis(HTTP2Sampler embeddedSampler) {
+    HTTP2FutureResponseListener listener = embeddedSampler.getFutureResponseListener();
+    if (listener != null && listener.getResponseStart() > 0) {
+      return listener.getResponseStart();
+    }
+    return System.currentTimeMillis();
+  }
+
+  private URL resolveEmbeddedResourceUrl(HTTP2Sampler embeddedSampler) {
+    HTTP2FutureResponseListener listener = embeddedSampler.getFutureResponseListener();
+    if (listener != null && listener.getRequest() != null
+        && listener.getRequest().getURI() != null) {
+      try {
+        return listener.getRequest().getURI().toURL();
+      } catch (IllegalArgumentException | MalformedURLException e) {
+        // Fall through to the sampler URL.
+      }
+    }
+    try {
+      return embeddedSampler.getUrl();
+    } catch (MalformedURLException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Cancels every still-pending embedded request and reports each as a failed child with that
+   * resource's URL (JMeter-style), instead of a single container-cloned timeout stub.
+   */
+  private void failPendingEmbeddedRequestsWithTimeout(List<TestElement> samplers,
+                                                      HTTPSampleResult subres) {
+    List<TestElement> pending = new ArrayList<>(samplers);
+    samplers.clear();
+    for (TestElement element : pending) {
+      HTTP2Sampler embedded = (HTTP2Sampler) element;
+      long startedAtMs = embeddedAttemptStartMillis(embedded);
+      HTTP2FutureResponseListener listener = embedded.getFutureResponseListener();
+      if (listener != null && !listener.isDone() && !listener.isCancelled()) {
+        listener.cancel(true);
+      }
+      subres.addSubResult(embeddedTimeoutErrorResult(embedded, startedAtMs));
+    }
+    setParentSampleSuccess(subres, false);
+  }
+
+  /**
    * Copies Jetty/ALPN/protocol flags from this sampler onto an embedded-resource child sampler so
    * child requests obey the same profile as the parent. Without this, a fresh {@link HTTP2Sampler}
    * falls back to default profile semantics (typically HTTP/1.1 enabled), which incorrectly applies
@@ -597,11 +685,97 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
   }
 
   /**
+   * Factory for HTTP(S) embedded-resource children. Tests can override to inject a failing
+   * client without changing the download loop.
+   */
+  protected HTTP2Sampler newHttpEmbeddedSampler() {
+    return new HTTP2Sampler();
+  }
+
+  /**
+   * Configures an HTTP(S) embedded-resource child the way JMeter's {@code ASyncSample} does via
+   * {@code base.clone()}: same timeouts, managers, redirects, image-parser and MD5 flags as the
+   * parent. Concurrent children get a CacheManager proxy and a cloned CookieManager so siblings do
+   * not share mutable cookie state mid-page.
+   *
+   * <p>Also copies keep-alive, content encoding, concurrent-download flags and embedded URL
+   * allow/exclude regexes so a nested HTML resource (iframe) that itself runs
+   * {@link #downloadPageResources} behaves like a JMeter clone of the parent, not a fresh sampler
+   * with defaults.
+   */
+  private void configureHttpEmbeddedSampler(HTTP2Sampler embedded, URL url,
+                                            boolean concurrent) {
+    copyJettyProtocolSettingsToEmbeddedSampler(embedded);
+    embedded.setMethod(HTTPConstants.GET);
+    embedded.setSyncRequest(!concurrent);
+    embedded.setProtocol(url.getProtocol());
+    embedded.setDomain(url.getHost() != null ? url.getHost() : "");
+    embedded.setPort(url.getPort());
+    embedded.setFollowRedirects(getFollowRedirects());
+    embedded.setAutoRedirects(getAutoRedirects());
+    embedded.setPath(pathWithQuery(url));
+    embedded.setImageParser(isImageParser());
+    embedded.setMD5(useMD5() || JMeterUtils.getPropDefault(
+        "httpsampler.embedded_resources_use_md5", false));
+    embedded.setUseKeepAlive(getUseKeepAlive());
+    embedded.setContentEncoding(getContentEncoding());
+    // Nested embeds (child parses HTML) must keep the parent's parallel-download and URL filter
+    // settings; the {@code concurrent} parameter only controls this child's sync vs async send.
+    embedded.setConcurrentDwn(isConcurrentDwn());
+    embedded.setConcurrentPool(getConcurrentPool());
+    embedded.setEmbeddedUrlRE(getEmbeddedUrlRE());
+    embedded.setEmbeddedUrlExcludeRE(getEmbededUrlExcludeRE());
+
+    embedded.setProxyHost(getProxyHost());
+    embedded.setProxyPortInt(String.valueOf(getProxyPortInt()));
+    embedded.setProxyScheme(getProxyScheme());
+    embedded.setProxyUser(getProxyUser());
+    embedded.setProxyPass(getProxyPass());
+
+    embedded.setHeaderManager(getHeaderManager());
+    embedded.setAuthManager(getAuthManager());
+    if (getCacheManager() != null) {
+      embedded.setCacheManager(getCacheManager().createCacheManagerProxy());
+    }
+    if (getCookieManager() != null) {
+      if (concurrent) {
+        embedded.setCookieManager((org.apache.jmeter.protocol.http.control.CookieManager)
+            getCookieManager().clone());
+      } else {
+        embedded.setCookieManager(getCookieManager());
+      }
+    }
+  }
+
+  private static String pathWithQuery(URL url) {
+    if (url.getQuery() == null) {
+      return url.getPath();
+    }
+    return url.getPath() + "?" + url.getQuery();
+  }
+
+  private void mergeEmbeddedCookiesIntoParent(HTTP2Sampler embedded) {
+    org.apache.jmeter.protocol.http.control.CookieManager parent = getCookieManager();
+    org.apache.jmeter.protocol.http.control.CookieManager child = embedded.getCookieManager();
+    if (parent == null || child == null || parent == child) {
+      return;
+    }
+    for (JMeterProperty property : child.getCookies()) {
+      parent.add((org.apache.jmeter.protocol.http.control.Cookie) property.getObjectValue());
+    }
+  }
+
+  /**
    * Builds an embedded-resource child sampler for a {@code file://} URL discovered by the HTML
    * parser (e.g. a relative {@code href}/{@code src} resolved against a {@code file://} parent).
    * {@code setImageParser} is enabled for {@code .html}/{@code .htm} targets so nested embedded
    * resources (e.g. an iframe pointing at another local HTML file) are themselves parsed and
    * downloaded, matching how a real HTTP-embedded HTML resource would recurse.
+   *
+   * <p>{@code file://} embeds are always completed inline (synchronously), even when concurrent
+   * download is enabled: there is no HTTP transport to race, and Jetty async dispatch does not
+   * apply. JMeter's {@code ASyncSample} still runs them on the pool thread via
+   * {@code HTTPFileImpl}; content and nesting match, only the pool scheduling differs.
    */
   private HTTP2Sampler newFileEmbeddedSampler(URL url) {
     HTTP2Sampler fileSampler = new HTTP2Sampler();
@@ -612,15 +786,13 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
     fileSampler.setImageParser(htmlResource);
     fileSampler.setMethod(HTTPConstants.GET);
     fileSampler.setProtocol(url.getProtocol());
-    fileSampler.setDomain(url.getHost());
+    fileSampler.setDomain(url.getHost() != null ? url.getHost() : "");
     fileSampler.setPort(url.getPort());
-    if (url.getQuery() == null) {
-      fileSampler.setPath(url.getPath());
-    } else {
-      fileSampler.setPath(url.getPath() + url.getQuery());
-    }
+    fileSampler.setPath(pathWithQuery(url));
     fileSampler.setHeaderManager(getHeaderManager());
     fileSampler.setCookieManager(getCookieManager());
+    fileSampler.setMD5(useMD5() || JMeterUtils.getPropDefault(
+        "httpsampler.embedded_resources_use_md5", false));
     return fileSampler;
   }
 
@@ -1074,16 +1246,10 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
 
       setSyncRequest(!isConcurrentDwn); // Change default from main request based on sub request
 
-      // Deadline for waiting on a single embedded resource. 0 means "no timeout", the same meaning
-      // JMeter gives it everywhere else: JMeter's own drain
-      // (ResourcesDownloader.invokeAllAndAwaitTermination) has no wait timeout at all and relies
-      // purely on the per-request timeouts, so with 0 configured we wait here as long as JMeter
-      // would. With a value configured, the request itself already carries that deadline (see
-      // HTTP2JettyClient#setTimeouts and copyTimeoutsToEmbeddedSampler), and this is only the
-      // backstop for a completion that never arrives.
-      int embeddedTimeout = this.getResponseTimeout() > 0
-          ? this.getResponseTimeout()
-          : this.requestTimeout;
+      // Deadline for waiting on a single embedded resource. 0 means "no timeout", matching JMeter
+      // (ResourcesDownloader has no wait timeout and relies on per-request socket timeouts only).
+      // Do not fall back to a Jetty client field that may still hold a previous sampler's timeout.
+      int embeddedTimeout = getResponseTimeout();
 
       int fileEmbeddedIndex = 0;
       while (urls.hasNext()) {
@@ -1140,48 +1306,30 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
               }
             }
 
-            HTTP2Sampler h2s = new HTTP2Sampler();
-            copyJettyProtocolSettingsToEmbeddedSampler(h2s);
-            h2s.setMethod("GET");
-            h2s.setSyncRequest(!isConcurrentDwn);
-            h2s.setProtocol(url.getProtocol());
-            h2s.setDomain(url.getHost());
-            h2s.setPort(url.getPort());
-            h2s.setFollowRedirects(true);
-            h2s.setAutoRedirects(true);
-            if (url.getQuery() == null) {
-              h2s.setPath(url.getPath());
-            } else {
-              h2s.setPath(url.getPath() + url.getQuery());
-            }
-
-            // Set proxy
-            h2s.setProxyHost(this.getProxyHost());
-            h2s.setProxyPortInt(String.valueOf(this.getProxyPortInt()));
-            h2s.setProxyScheme(this.getProxyScheme());
-            h2s.setProxyUser(this.getProxyUser());
-            h2s.setProxyPass(this.getProxyPass());
-            // Set Managers
-            h2s.setHeaderManager(getHeaderManager());
-            h2s.setAuthManager(this.getAuthManager());
-            h2s.setCookieManager(this.getCookieManager());
+            HTTP2Sampler h2s = newHttpEmbeddedSampler();
+            configureHttpEmbeddedSampler(h2s, url, isConcurrentDwn);
 
             HTTPSampleResult binRes = h2s.sample(
                 url, HTTPConstants.GET, false, frameDepth + 1);
 
             if (isConcurrentDwn) {
-              // if concurrent download emb. resources, add to a list for async gets later
-              samplers.add(h2s);
+              if (h2s.getFutureResponseListener() == null) {
+                // Dispatch never started (or failed before publishing a listener): attach the error
+                // result now. Queuing a sampler with a null listener used to drop it silently in
+                // the drain loop.
+                if (binRes != null) {
+                  subres.addSubResult(binRes);
+                  setParentSampleSuccess(subres,
+                      subres.isSuccessful() && binRes.isSuccessful());
+                }
+              } else {
+                samplers.add(h2s);
+              }
             } else {
               // default: serial download embedded resources
               subres.addSubResult(binRes);
               setParentSampleSuccess(subres,
                   subres.isSuccessful() && (binRes == null || binRes.isSuccessful()));
-              try {
-                Thread.sleep(10);
-              } catch (InterruptedException e) {
-                interrupted = true;
-              }
             }
           }
         } catch (ClassCastException e) { // NOSONAR
@@ -1237,13 +1385,14 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
       // been queued, which never happens if we cannot free a slot.
       if (embeddedTimeout > 0
           && (System.currentTimeMillis() - waitStartedAt) >= embeddedTimeout) {
-        LOG.warn("Timeout after {}ms waiting for an embedded download slot; aborting pending "
-            + "resources", embeddedTimeout);
-        abortPendingEmbeddedRequests(samplers);
-        subres.addSubResult(detachedErrorResult(new Exception(
-            "Error downloading embedded resources, execution timeout"), subres));
-        setParentSampleSuccess(subres, false);
-        return true;
+        LOG.warn("Timeout after {}ms waiting for an embedded download slot; failing in-flight "
+            + "resources and freeing slots so remaining URLs can still be dispatched",
+            embeddedTimeout);
+        // Fail only what is already in flight. Returning false (not interrupted) lets the URL loop
+        // continue — JMeter keeps scheduling until the list is exhausted rather than abandoning
+        // undispatched embeds.
+        failPendingEmbeddedRequestsWithTimeout(samplers, subres);
+        return false;
       }
       try {
         Thread.sleep(EMBEDDED_POLL_INTERVAL_MILLIS);
@@ -1260,13 +1409,23 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
    */
   private void consumeFirstEmbeddedSampler(List<TestElement> samplers, HTTPSampleResult subres) {
     HTTP2Sampler embeddedSampler = (HTTP2Sampler) samplers.get(0);
-    HTTP2FutureResponseListener listener = embeddedSampler.getFutureResponseListener();
-    String processedUrl = listener != null && listener.getRequest() != null
-        ? listener.getRequest().getURI().toString()
-        : "unknown";
-    LOG.debug("Embedded resource finished, re-sampling with that data {}", processedUrl);
-    HTTPSampleResult binRes = (HTTPSampleResult) embeddedSampler.sample();
+    URL processedUrl = resolveEmbeddedResourceUrl(embeddedSampler);
+    LOG.debug("Embedded resource finished, re-sampling with that data {}",
+        processedUrl != null ? processedUrl : "unknown");
+    // Call sample(url, …, depth) directly — not public sample() — so the label stays the URL (or
+    // rename policy) and frame depth matches what was used at dispatch, as JMeter's ASyncSample
+    // does.
+    HTTPSampleResult binRes;
+    if (processedUrl != null) {
+      binRes = embeddedSampler.sample(processedUrl, HTTPConstants.GET, false,
+          embeddedSampler.pendingCompletionDepth > 0
+              ? embeddedSampler.pendingCompletionDepth
+              : 1);
+    } else {
+      binRes = (HTTPSampleResult) embeddedSampler.sample();
+    }
     samplers.remove(0);
+    mergeEmbeddedCookiesIntoParent(embeddedSampler);
     subres.addSubResult(binRes);
     setParentSampleSuccess(subres,
         subres.isSuccessful() && (binRes == null || binRes.isSuccessful()));
@@ -1374,11 +1533,12 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
         LOG.warn("Timeout after {}ms waiting for embedded resource {}", embeddedTimeout,
             pendingUrl);
         // Dequeue and abort before returning: without this the caller re-selects the same head, and
-        // aborting is what releases the underlying Jetty request instead of leaking it.
+        // aborting is what releases the underlying Jetty request instead of leaking it. Report the
+        // failure against this resource's URL (as JMeter does for a socket timeout), not as a clone
+        // of the page container.
         samplers.remove(0);
         listener.cancel(true);
-        subres.addSubResult(detachedErrorResult(new Exception(
-            "Error downloading embedded resources, execution timeout"), subres));
+        subres.addSubResult(embeddedTimeoutErrorResult(embeddedSampler, start));
         setParentSampleSuccess(subres, false);
         return false;
       }

--- a/src/test/java/com/blazemeter/jmeter/http2/control/async/EmbeddedResourceDrainLoopTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/control/async/EmbeddedResourceDrainLoopTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.blazemeter.jmeter.http2.HTTP2TestBase;
 import com.blazemeter.jmeter.http2.core.HTTP2FutureResponseListener;
+import com.blazemeter.jmeter.http2.core.HTTP2JettyClient;
 import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
 import java.io.Closeable;
 import java.io.IOException;
@@ -148,6 +149,188 @@ public class EmbeddedResourceDrainLoopTest extends HTTP2TestBase {
         .as("timeout error sub-results must not form a self-referential graph that overflows a "
             + "naive tree walk (View Results Tree)")
         .doesNotThrowAnyException();
+
+    SampleResult[] subs = container.getSubResults();
+    assertThat(subs).isNotNull();
+    HTTPSampleResult timedOutChild = null;
+    for (SampleResult sub : subs) {
+      HTTPSampleResult httpSub = (HTTPSampleResult) sub;
+      if (httpSub.getURL() != null
+          && httpSub.getURL().getPath().contains("stalls-forever.png")) {
+        timedOutChild = httpSub;
+        break;
+      }
+    }
+    assertThat(timedOutChild)
+        .as("the timed-out embedded resource must be reported under its own URL, not as a clone "
+            + "of the parent page (JMeter HC4 socket-timeout shape)")
+        .isNotNull();
+    assertThat(timedOutChild.isSuccessful()).isFalse();
+    assertThat(timedOutChild.getResponseMessage())
+        .as("timeout should surface like JMeter's socket read timeout")
+        .containsIgnoringCase("timed out");
+    assertThat(container.isSuccessful())
+        .as("the page container must be marked failed when an embedded resource times out")
+        .isFalse();
+    assertThat(container.getResponseMessage())
+        .as("parent message should aggregate failed embedded URLs like JMeter")
+        .contains("Embedded resource download error:")
+        .contains("stalls-forever.png");
+    assertThat(timedOutChild.getURL().getPath())
+        .isNotEqualTo(page.getURL().getPath());
+    assertThat(timedOutChild.getTime())
+        .as("timed-out child must report the wait until give-up, not a ~0ms sampleStart/sampleEnd "
+            + "pair; that elapsed end time is what pushes the parent container's clock forward")
+        .isGreaterThanOrEqualTo(RESPONSE_TIMEOUT_MILLIS);
+    assertThat(container.getEndTime())
+        .as("parent end time must advance to cover the embedded timeout wait (addSubResult takes "
+            + "max of child end times)")
+        .isGreaterThanOrEqualTo(timedOutChild.getEndTime());
+    assertThat(timedOutChild.getConnectTime())
+        .as("a poll-aborted attempt never completed the handshake/response, so connect stays 0 "
+            + "rather than copying the parent's connect")
+        .isZero();
+    assertThat(timedOutChild.getLatency()).isZero();
+    assertThat(timedOutChild.getSampleLabel())
+        .as("timeout child must not keep the default sampler class name; addSubResult may rename "
+            + "to parent-N when SampleResult.isRenameSampleLabel() is on")
+        .doesNotContain("bzm - HTTP Sampler");
+    assertThat(timedOutChild.getUrlAsString()).contains("stalls-forever.png");
+  }
+
+  /**
+   * When the concurrent pool is full and the slot wait times out, previously we aborted the page
+   * and never dispatched remaining URLs. JMeter keeps scheduling; we must fail only in-flight work
+   * and continue the URL list.
+   */
+  @Test
+  public void slotTimeoutMustStillDispatchRemainingEmbeddedUrls() throws Exception {
+    ProbeSampler sampler = new ProbeSampler();
+    sampler.setName("main-page");
+    sampler.setProtocol("http");
+    sampler.setDomain(peer.host());
+    sampler.setPort(peer.port());
+    sampler.setPath("/");
+    sampler.setMethod(HTTPConstants.GET);
+    sampler.setConcurrentDwn(true);
+    // Pool size 1 forces serial mode in downloadPageResources; use 2 so slot waits can fire.
+    sampler.setConcurrentPool("2");
+    sampler.setImageParser(true);
+    sampler.setResponseTimeout(String.valueOf(RESPONSE_TIMEOUT_MILLIS));
+
+    HTTPSampleResult page = new HTTPSampleResult();
+    page.setSampleLabel("main-page");
+    page.setContentType("text/html; charset=UTF-8");
+    page.setDataType(SampleResult.TEXT);
+    page.setURL(new java.net.URL("http", peer.host(), peer.port(), "/"));
+    page.sampleStart();
+    page.setResponseData(
+        "<html><body>"
+            + "<img src=\"/stall-a.png\">"
+            + "<img src=\"/stall-b.png\">"
+            + "<img src=\"/stall-c.png\">"
+            + "</body></html>",
+        StandardCharsets.UTF_8.name());
+    page.setResponseCodeOK();
+    page.setSuccessful(true);
+    page.sampleEnd();
+
+    AtomicReference<HTTPSampleResult> drained = new AtomicReference<>();
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    Thread worker = new Thread(() -> {
+      try {
+        drained.set(sampler.drainEmbeddedResources(page));
+      } catch (Throwable t) {
+        failure.set(t);
+      }
+    }, "embedded-slot-timeout");
+    worker.setDaemon(true);
+    worker.start();
+    worker.join(WATCHDOG_MILLIS);
+    boolean stillRunning = worker.isAlive();
+    if (stillRunning) {
+      worker.interrupt();
+      worker.join(2_000L);
+    }
+
+    assertThat(stillRunning).isFalse();
+    assertThat(failure.get()).isNull();
+    HTTPSampleResult container = drained.get() == null ? page : drained.get();
+    SampleResult[] subs = container.getSubResults();
+    assertThat(subs).isNotNull();
+
+    java.util.Set<String> timedOutPaths = new java.util.HashSet<>();
+    for (SampleResult sub : subs) {
+      HTTPSampleResult httpSub = (HTTPSampleResult) sub;
+      if (httpSub.getURL() != null && httpSub.getURL().getPath().startsWith("/stall-")) {
+        timedOutPaths.add(httpSub.getURL().getPath());
+        assertThat(httpSub.isSuccessful()).isFalse();
+      }
+    }
+    assertThat(timedOutPaths)
+        .as("after a slot timeout, remaining undispatched URLs must still be attempted "
+            + "(reported as failed children), not abandoned")
+        .contains("/stall-a.png", "/stall-b.png", "/stall-c.png");
+  }
+
+  /**
+   * If async dispatch fails before a listener is published, the error result must be attached
+   * immediately. Queuing a sampler with a null listener used to drop it silently in the drain.
+   */
+  @Test
+  public void failedEmbeddedDispatchWithoutListenerMustAttachErrorSubResult() throws Exception {
+    HTTP2JettyClient failingClient = org.mockito.Mockito.mock(HTTP2JettyClient.class);
+    org.mockito.Mockito.when(failingClient.getMaxBufferSize()).thenReturn(1024 * 1024);
+    org.mockito.Mockito.when(failingClient.getRequestTimeout()).thenReturn(60_000);
+    org.mockito.Mockito.when(failingClient.dispatchAsync(
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any()))
+        .thenThrow(new IOException("forced dispatch failure for regression test"));
+
+    ProbeSampler sampler = new FailingDispatchProbeSampler(failingClient);
+    sampler.setName("main-page");
+    sampler.setProtocol("http");
+    sampler.setDomain(peer.host());
+    sampler.setPort(peer.port());
+    sampler.setPath("/");
+    sampler.setMethod(HTTPConstants.GET);
+    sampler.setConcurrentDwn(true);
+    sampler.setConcurrentPool("4");
+    sampler.setImageParser(true);
+    sampler.setResponseTimeout(String.valueOf(RESPONSE_TIMEOUT_MILLIS));
+
+    HTTPSampleResult page = new HTTPSampleResult();
+    page.setSampleLabel("main-page");
+    page.setContentType("text/html; charset=UTF-8");
+    page.setDataType(SampleResult.TEXT);
+    page.setURL(new java.net.URL("http", peer.host(), peer.port(), "/"));
+    page.sampleStart();
+    page.setResponseData(
+        "<html><body><img src=\"/never-dispatched.png\"></body></html>",
+        StandardCharsets.UTF_8.name());
+    page.setResponseCodeOK();
+    page.setSuccessful(true);
+    page.sampleEnd();
+
+    HTTPSampleResult container = sampler.drainEmbeddedResources(page);
+    SampleResult[] subs = container.getSubResults();
+    assertThat(subs)
+        .as("dispatch failure must produce a visible child sample, not a silent drop")
+        .isNotNull()
+        .isNotEmpty();
+    assertThat(container.isSuccessful()).isFalse();
+    boolean sawFailure = false;
+    for (SampleResult sub : subs) {
+      if (!sub.isSuccessful()) {
+        sawFailure = true;
+        String detail = (sub.getResponseMessage() == null ? "" : sub.getResponseMessage())
+            + " "
+            + (sub.getResponseDataAsString() == null ? "" : sub.getResponseDataAsString());
+        assertThat(detail).containsIgnoringCase("forced dispatch failure");
+      }
+    }
+    assertThat(sawFailure).isTrue();
   }
 
   /**
@@ -203,12 +386,28 @@ public class EmbeddedResourceDrainLoopTest extends HTTP2TestBase {
   }
 
   /** Exposes the protected embedded-resource download so the drain loop can be driven directly. */
-  private static final class ProbeSampler extends HTTP2Sampler {
+  private static class ProbeSampler extends HTTP2Sampler {
 
     private static final long serialVersionUID = 1L;
 
     HTTPSampleResult drainEmbeddedResources(HTTPSampleResult page) {
       return downloadPageResources(page, null, 0);
+    }
+  }
+
+  private static final class FailingDispatchProbeSampler extends ProbeSampler {
+
+    private static final long serialVersionUID = 1L;
+
+    private final HTTP2JettyClient failingClient;
+
+    FailingDispatchProbeSampler(HTTP2JettyClient failingClient) {
+      this.failingClient = failingClient;
+    }
+
+    @Override
+    protected HTTP2Sampler newHttpEmbeddedSampler() {
+      return new HTTP2Sampler(() -> failingClient);
     }
   }
 

--- a/src/test/java/com/blazemeter/jmeter/http2/core/EmbeddedResourceConcurrentConsumeParityTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/EmbeddedResourceConcurrentConsumeParityTest.java
@@ -1,0 +1,108 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.HOST_NAME;
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.SERVER_IMAGE;
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.SERVER_PATH_200_EMBEDDED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import com.blazemeter.jmeter.http2.sampler.JMeterTestUtils;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.samplers.SampleResult;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Concurrent embedded completion must keep URL labels (not overwrite with the sampler name) and
+ * must not reset frame depth via public {@link HTTP2Sampler#sample()}.
+ */
+public class EmbeddedResourceConcurrentConsumeParityTest extends HTTP2TestBase {
+
+  private TeardownableServer server;
+  private int port = -1;
+
+  @BeforeClass
+  public static void setupClass() {
+    JMeterTestUtils.setupJmeterEnv();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    HTTP2JettyClientTestIsolation.resetSharedClientState();
+    server = new ServerBuilder().withHTTP2().withALPN().withHTTP2C().withSSL().buildServer();
+    server.start();
+    port = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (server != null && server.isStarted()) {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void concurrentEmbeddedSubResultsKeepResourceUrlLabels() throws Exception {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setName("parent-page");
+    sampler.setProtocol(HTTPConstants.PROTOCOL_HTTPS);
+    sampler.setDomain(HOST_NAME);
+    sampler.setPort(port);
+    sampler.setPath(SERVER_PATH_200_EMBEDDED);
+    sampler.setMethod(HTTPConstants.GET);
+    sampler.setImageParser(true);
+    sampler.setConcurrentDwn(true);
+    sampler.setConcurrentPool("4");
+    sampler.setFollowRedirects(true);
+    sampler.setAutoRedirects(false);
+
+    HTTPSampleResult result = (HTTPSampleResult) sampler.sample();
+    assertThat(result.isSuccessful()).isTrue();
+
+    SampleResult[] subs = result.getSubResults();
+    assertThat(subs).isNotEmpty();
+
+    boolean foundImage = false;
+    for (SampleResult sub : subs) {
+      if (sub.getUrlAsString() != null && sub.getUrlAsString().contains(SERVER_IMAGE)) {
+        foundImage = true;
+        assertThat(sub.getSampleLabel())
+            .as("concurrent consume must not rewrite the label via public sample()/getName()")
+            .doesNotContain("bzm - HTTP Sampler");
+        assertThat(sub.getUrlAsString()).contains(SERVER_IMAGE);
+      }
+    }
+    assertThat(foundImage)
+        .as("expected an embedded image sub-result for %s", SERVER_IMAGE)
+        .isTrue();
+  }
+
+  @Test
+  public void md5FlagReplacesStoredBodyWithDigestLikeJMeter() throws Exception {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setName("md5-sample");
+    sampler.setProtocol(HTTPConstants.PROTOCOL_HTTPS);
+    sampler.setDomain(HOST_NAME);
+    sampler.setPort(port);
+    sampler.setPath(SERVER_PATH_200_EMBEDDED);
+    sampler.setMethod(HTTPConstants.GET);
+    sampler.setImageParser(false);
+    sampler.setConcurrentDwn(false);
+    sampler.setMD5(true);
+
+    HTTPSampleResult result = (HTTPSampleResult) sampler.sample();
+    assertThat(result.isSuccessful()).isTrue();
+    String body = result.getResponseDataAsString();
+    assertThat(body)
+        .as("useMD5 should store a 32-char hex digest instead of the HTML body")
+        .hasSize(32)
+        .matches("[0-9a-fA-F]{32}");
+    assertThat(body).doesNotContain("<html");
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/sampler/EmbeddedResourceJmeterParityTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/sampler/EmbeddedResourceJmeterParityTest.java
@@ -1,0 +1,166 @@
+package com.blazemeter.jmeter.http2.sampler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import java.lang.reflect.Method;
+import java.net.URL;
+import org.apache.jmeter.protocol.http.control.CacheManager;
+import org.apache.jmeter.protocol.http.control.CookieManager;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Pins JMeter-aligned configuration of HTTP embedded-resource children (the gaps that used to
+ * diverge from {@code HTTPSamplerBase.ASyncSample} / {@code downloadPageResources}).
+ */
+public class EmbeddedResourceJmeterParityTest extends HTTP2TestBase {
+
+  @BeforeClass
+  public static void setupClass() {
+    JMeterTestUtils.setupJmeterEnv();
+  }
+
+  @Test
+  public void concurrentDownloadDefaultsToFalseLikeJMeter() {
+    assertThat(new HTTP2Sampler().isConcurrentDwn())
+        .as("JMeter leaves concurrent download off unless the user enables it")
+        .isFalse();
+  }
+
+  @Test
+  public void httpEmbeddedChildInheritsRedirectsImageParserCacheMd5AndQuery() throws Exception {
+    HTTP2Sampler parent = new HTTP2Sampler();
+    parent.setFollowRedirects(false);
+    parent.setAutoRedirects(false);
+    parent.setImageParser(true);
+    parent.setMD5(true);
+    parent.setCacheManager(new CacheManager());
+    parent.setCookieManager(new CookieManager());
+    parent.setConnectTimeout("1000");
+    parent.setResponseTimeout("2000");
+
+    URL resource = new URL("https://example.com/assets/app.js?v=3&x=1");
+    HTTP2Sampler child = invokeConfigure(parent, resource, true);
+
+    assertThat(child.getFollowRedirects()).isFalse();
+    assertThat(child.getAutoRedirects()).isFalse();
+    assertThat(child.isImageParser()).isTrue();
+    assertThat(child.useMD5()).isTrue();
+    assertThat(child.getCacheManager())
+        .as("concurrent children must get a CacheManager proxy like ASyncSample")
+        .isNotNull()
+        .isNotSameAs(parent.getCacheManager());
+    assertThat(child.getCookieManager())
+        .as("concurrent children must clone the cookie jar so siblings do not share mid-page state")
+        .isNotNull()
+        .isNotSameAs(parent.getCookieManager());
+    assertThat(child.getPath()).isEqualTo("/assets/app.js");
+    assertThat(child.getUrl().toExternalForm())
+        .as("setPath must receive path?query so JMeter parses args; without '?' the query was "
+            + "appended as part of the path")
+        .contains("/assets/app.js?v=3&x=1");
+    assertThat(child.getConnectTimeout()).isEqualTo(1000);
+    assertThat(child.getResponseTimeout()).isEqualTo(2000);
+    assertThat(child.isSyncRequest()).isFalse();
+  }
+
+  @Test
+  public void serialHttpEmbeddedChildSharesCookieManagerWithParent() throws Exception {
+    HTTP2Sampler parent = new HTTP2Sampler();
+    CookieManager cookies = new CookieManager();
+    parent.setCookieManager(cookies);
+
+    HTTP2Sampler child = invokeConfigure(parent,
+        new URL("https://example.com/a.png"), false);
+
+    assertThat(child.getCookieManager()).isSameAs(cookies);
+    assertThat(child.isSyncRequest()).isTrue();
+  }
+
+  @Test
+  public void httpEmbeddedChildInheritsKeepAliveEncodingConcurrentAndUrlFilters()
+      throws Exception {
+    HTTP2Sampler parent = new HTTP2Sampler();
+    parent.setUseKeepAlive(false);
+    parent.setContentEncoding("ISO-8859-1");
+    parent.setConcurrentDwn(true);
+    parent.setConcurrentPool("7");
+    parent.setEmbeddedUrlRE(".*\\.png");
+    parent.setEmbeddedUrlExcludeRE(".*ads.*");
+
+    HTTP2Sampler child = invokeConfigure(parent,
+        new URL("https://example.com/iframe.html"), true);
+
+    assertThat(child.getUseKeepAlive())
+        .as("nested embeds must keep the parent's Connection/keep-alive policy")
+        .isFalse();
+    assertThat(child.getContentEncoding()).isEqualTo("ISO-8859-1");
+    assertThat(child.isConcurrentDwn())
+        .as("nested HTML downloadPageResources must keep parent's parallel-download flag")
+        .isTrue();
+    assertThat(child.getConcurrentPool()).isEqualTo("7");
+    assertThat(child.getEmbeddedUrlRE()).isEqualTo(".*\\.png");
+    assertThat(child.getEmbededUrlExcludeRE()).isEqualTo(".*ads.*");
+    // Dispatch mode for this child is still driven by the concurrent parameter, not by
+    // inheriting syncRequest from the parent's concurrent flag alone.
+    assertThat(child.isSyncRequest()).isFalse();
+  }
+
+  @Test
+  public void pathWithQueryKeepsQuestionMark() throws Exception {
+    Method pathWithQuery = HTTP2Sampler.class.getDeclaredMethod("pathWithQuery", URL.class);
+    pathWithQuery.setAccessible(true);
+    assertThat(pathWithQuery.invoke(null, new URL("https://ex.com/p?a=1")))
+        .isEqualTo("/p?a=1");
+    assertThat(pathWithQuery.invoke(null, new URL("https://ex.com/p")))
+        .isEqualTo("/p");
+  }
+
+  @Test
+  public void mergeEmbeddedCookiesCopiesChildJarIntoParent() throws Exception {
+    HTTP2Sampler parent = new HTTP2Sampler();
+    CookieManager parentCookies = new CookieManager();
+    parent.setCookieManager(parentCookies);
+
+    HTTP2Sampler child = new HTTP2Sampler();
+    CookieManager childCookies = new CookieManager();
+    childCookies.add(new org.apache.jmeter.protocol.http.control.Cookie(
+        "sid", "abc", "example.com", "/", false, 0));
+    child.setCookieManager(childCookies);
+
+    Method merge = HTTP2Sampler.class.getDeclaredMethod(
+        "mergeEmbeddedCookiesIntoParent", HTTP2Sampler.class);
+    merge.setAccessible(true);
+    merge.invoke(parent, child);
+
+    assertThat(parentCookies.getCookieCount()).isEqualTo(1);
+    org.apache.jmeter.protocol.http.control.Cookie merged =
+        (org.apache.jmeter.protocol.http.control.Cookie)
+            parentCookies.getCookies().get(0).getObjectValue();
+    assertThat(merged.getName()).isEqualTo("sid");
+    assertThat(merged.getValue()).isEqualTo("abc");
+  }
+
+  @Test
+  public void embeddedPollDeadlineUsesOnlyResponseTimeoutNotStaleClientField() {
+    HTTP2Sampler parent = new HTTP2Sampler();
+    parent.setResponseTimeout("");
+    assertThat(parent.getResponseTimeout())
+        .as("unset response timeout must stay 0 so the embedded poll has no page-level backstop "
+            + "(matching JMeter ResourcesDownloader); a stale Jetty client requestTimeout field "
+            + "must not be substituted")
+        .isZero();
+  }
+
+  private static HTTP2Sampler invokeConfigure(HTTP2Sampler parent, URL url, boolean concurrent)
+      throws Exception {
+    Method configure = HTTP2Sampler.class.getDeclaredMethod(
+        "configureHttpEmbeddedSampler", HTTP2Sampler.class, URL.class, boolean.class);
+    configure.setAccessible(true);
+    HTTP2Sampler child = new HTTP2Sampler();
+    configure.invoke(parent, child, url, concurrent);
+    return child;
+  }
+}


### PR DESCRIPTION
This pull request introduces several enhancements and bug fixes to the HTTP sampler, focusing on improved error handling, better parity with JMeter's behavior, and code maintainability. The main changes include more accurate handling of embedded resource timeouts, improved configuration and cloning of embedded samplers, and a refactor to centralize response data handling (including MD5 digest support).

**Embedded resource handling and error reporting:**

* Added granular timeout handling for embedded resources: each pending embedded request that times out is now individually cancelled and reported as a failed child sample, matching JMeter's behavior, instead of a generic container-level error. This ensures accurate timing and error reporting for each resource. [[1]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R563-R640) [[2]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30L1240-R1395)
* The timeout for embedded resources now strictly uses the sampler's configured response timeout, ensuring consistency with JMeter and avoiding unexpected fallback to unrelated timeouts.

**Sampler configuration and cloning improvements:**

* Introduced `configureHttpEmbeddedSampler` and `newHttpEmbeddedSampler` methods to centralize and standardize the setup of embedded HTTP samplers, ensuring all relevant properties (timeouts, managers, flags, and proxy settings) are correctly cloned from the parent. This also fixes issues with cookie manager sharing and MD5 flag propagation. [[1]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R687-R778) [[2]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30L1143-L1184)
* Improved the creation of file-based embedded samplers to use consistent path/query logic and propagate MD5 settings.

**Response data handling:**

* Refactored response data assignment into a new `applyResponseData` method, which handles both raw response bytes and MD5 digest calculation if requested by the sampler, ensuring consistent behavior across both HTTP and file-based responses. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL4412-R4437) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL1630-R1630) [[3]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL1776-R1776) [[4]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL4438-R4463)

**JMeter compatibility fixes:**

* Changed the default for concurrent downloads to `false` unless explicitly enabled, matching JMeter's default behavior.
* Improved frame depth tracking for async requests to ensure nested samples maintain correct depth, preserving JMeter's `ASyncSample` semantics. [[1]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R134-R139) [[2]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R403) [[3]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R420-R422)

**Code maintenance:**

* Added and clarified JavaDoc comments throughout the codebase for better maintainability and developer understanding. [[1]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R563-R640) [[2]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R687-R778)

These changes collectively improve the reliability, correctness, and maintainability of HTTP/2 sampling, especially in complex scenarios involving embedded resources and concurrent downloads.