### PR TITLE
Enhance application performance

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/control/HTTP2Controller.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/control/HTTP2Controller.java
@@ -4,16 +4,23 @@ import com.blazemeter.jmeter.http2.core.HTTP2FutureResponseListener;
 import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
 import com.blazemeter.jmeter.http2.util.BzmHttpPluginProperties;
 import java.io.Serializable;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import org.apache.jmeter.control.Controller;
 import org.apache.jmeter.control.NextIsNullException;
 import org.apache.jmeter.control.TransactionController;
+import org.apache.jmeter.control.TransactionSampler;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.PropertyIterator;
+import org.apache.jmeter.threads.JMeterContextService;
+import org.apache.jmeter.threads.JMeterThread;
+import org.apache.jmeter.threads.SamplePackage;
+import org.apache.jmeter.threads.TestCompiler;
 import org.apache.jmeter.util.JMeterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -140,9 +147,86 @@ public class HTTP2Controller extends TransactionController implements Serializab
   @Override
   public Sampler next() {
     if (isGenerateParentSample()) {
-      return super.next();
+      Sampler next = super.next();
+      // Only after the controller has finished the parent transaction (next == null). Releasing
+      // while still returning the done TransactionSampler is pointless: JMeterThread calls
+      // configureTransactionSampler(done) next and puts that same instance back on the package.
+      // Releasing on the following null turn is what sticks — and runs after listeners/assertions
+      // in doEndTransactionSampler (same sequencing as JMeter PR #6386's TestCompiler.done() hook).
+      if (next == null) {
+        releaseCompletedParentTransactionSample();
+      }
+      return next;
     }
     return nextWithoutTransactionBookkeeping();
+  }
+
+  /**
+   * Same workaround as JMeter PR #6386: when the parent transaction has finished, replace the
+   * completed {@link TransactionSampler} in this controller's {@link SamplePackage} with a fresh
+   * one so the finished sample tree is no longer reachable from the compiler map.
+   *
+   * <p>Uses the public {@link TransactionSampler} / {@link SamplePackage} API; the map itself is
+   * private on {@link TestCompiler}, so it is reached by reflection (there is no public accessor
+   * in 5.5–5.6.3).
+   *
+   * <p>Safe wrt listeners/assertions: callers must invoke this only after
+   * {@code JMeterThread.doEndTransactionSampler} has notified listeners (i.e. on the controller
+   * {@code next()} that returns {@code null} after a done parent). Does not clear
+   * {@code previousResult} — scripts using {@code ${prev}} keep working, same as upstream PR #6386.
+   *
+   * <p>If a future JMeter already applied #6386, {@code pack.getSampler()} is no longer done and
+   * this becomes a no-op.
+   */
+  void releaseCompletedParentTransactionSample() {
+    if (!isGenerateParentSample()) {
+      return;
+    }
+    try {
+      SamplePackage pack = transactionSamplePackage();
+      if (pack == null) {
+        return;
+      }
+      replaceDoneTransactionSampler(pack);
+    } catch (Exception e) {
+      LOG.debug("Could not release completed parent transaction sample for '{}'", getName(), e);
+    }
+  }
+
+  /**
+   * @return {@code true} when a completed transaction sampler was replaced
+   */
+  boolean replaceDoneTransactionSampler(SamplePackage pack) {
+    Sampler sampler = pack.getSampler();
+    if (!(sampler instanceof TransactionSampler)) {
+      return false;
+    }
+    TransactionSampler transactionSampler = (TransactionSampler) sampler;
+    if (!transactionSampler.isTransactionDone()) {
+      return false;
+    }
+    // Public constructor used by TestCompiler.saveTransactionControllerConfigs and by PR #6386.
+    pack.setSampler(new TransactionSampler(this, transactionSampler.getName()));
+    return true;
+  }
+
+  private SamplePackage transactionSamplePackage() throws ReflectiveOperationException {
+    JMeterThread thread = JMeterContextService.getContext().getThread();
+    if (thread == null) {
+      return null;
+    }
+    Field compilerField = JMeterThread.class.getDeclaredField("compiler");
+    compilerField.setAccessible(true);
+    TestCompiler compiler = (TestCompiler) compilerField.get(thread);
+    if (compiler == null) {
+      return null;
+    }
+    Field mapField = TestCompiler.class.getDeclaredField("transactionControllerConfigMap");
+    mapField.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Map<TransactionController, SamplePackage> map =
+        (Map<TransactionController, SamplePackage>) mapField.get(compiler);
+    return map == null ? null : map.get(this);
   }
 
   /**
@@ -410,6 +494,9 @@ public class HTTP2Controller extends TransactionController implements Serializab
       if (listener != null && !listener.isDone()) {
         listener.cancel(true);
       }
+      // Done-but-not-collected listeners still hold ContentResponseWrapper / request graph until
+      // the next sample() completion turn — which never comes after an aborted iteration.
+      pending.clearPendingSampleState();
     }
     http2SamplesSync.clear();
   }

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListener.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2FutureResponseListener.java
@@ -3,6 +3,7 @@ package com.blazemeter.jmeter.http2.core;
 import static com.blazemeter.jmeter.http2.core.LowLevelDebugLog.lowLevelDebug;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
@@ -13,11 +14,14 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.eclipse.jetty.client.AbstractResponseListener;
 import org.eclipse.jetty.client.BufferingResponseListener;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.client.Result;
+import org.eclipse.jetty.util.BufferUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +50,13 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
   private volatile String raceProtocol;
   private long responseStart;
   private long responseEnd;
+  /**
+   * {@link #releaseTransportBuffers()} is invoked from several completion paths (wrapper build,
+   * sealed HE abort {@code onFailure}/{@code onComplete}, {@code cancel}, sample materialisation).
+   * Jetty may also have released the accumulator already on abort — a second {@code clear()} then
+   * throws {@code IllegalStateException: Already released} and poisons the sample.
+   */
+  private final AtomicBoolean transportBuffersReleased = new AtomicBoolean();
 
   public HTTP2FutureResponseListener() {
     this(-1);
@@ -118,6 +129,9 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
     this.responseEnd = responseEnd > 0 ? responseEnd : System.currentTimeMillis();
     this.onCompleteCalled = true;
     this.sealed = true;
+    // Drop any partial body this listener may have buffered for its own (losing) attempt — the
+    // adopted response already carries the winner's bytes.
+    releaseTransportBuffers();
     this.latch.countDown();
   }
 
@@ -131,6 +145,7 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
     if (sealed) {
       // Losing side of a resolved race being aborted; see completeWith.
       lowLevelDebug("onFailure() ignored, listener already completed by a competing attempt");
+      releaseTransportBuffers();
       return;
     }
     lowLevelDebug("=== onFailure() CALLED ===");
@@ -182,6 +197,7 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
     if (sealed) {
       // Losing side of a resolved race being aborted; see completeWith.
       lowLevelDebug("onComplete() ignored, listener already completed by a competing attempt");
+      releaseTransportBuffers();
       return;
     }
     // CRITICAL: Mark that onComplete was called
@@ -245,8 +261,14 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
       // In Jetty 12, ContentResponse is abstract - create a wrapper implementation
       response = new ContentResponseWrapper(httpResponse, getContent(),
           getMediaType(), getEncoding());
+      // Wrapper owns the body bytes now; drop Jetty's accumulator / cached content array so a
+      // still-referenced listener (async controller wait, HE race) does not keep a second copy.
+      releaseTransportBuffers();
     } else {
+      // Failure / cancel with no response: Jetty may still hold a partial accumulator (common for
+      // Happy-Eyeballs losers aborted via request.abort rather than listener.cancel).
       lowLevelDebug("Response is null in onComplete()");
+      releaseTransportBuffers();
     }
     
     if (failure != null) {
@@ -373,7 +395,46 @@ public class HTTP2FutureResponseListener extends BufferingResponseListener
     if (request != null) {
       request.abort(new CancellationException());
     }
+    releaseTransportBuffers();
     return true;
+  }
+
+  /**
+   * Called once the sample has been materialised into a
+   * {@link org.apache.jmeter.samplers.SampleResult} so this listener can drop the Jetty request
+   * graph (attributes, body, conversation). The SampleResult already owns its own body copy; the
+   * {@link ContentResponse} wrapper (and its link back to Jetty's {@link Response}/{@link Request})
+   * must not stay pinned on this listener.
+   */
+  public void releaseAfterSampleMaterialised() {
+    releaseTransportBuffers();
+    this.request = null;
+    this.response = null;
+  }
+
+  /**
+   * Drops Jetty {@link AbstractResponseListener}'s cached {@code content} byte[] after the body has
+   * been copied into {@link ContentResponseWrapper} / SampleResult. That field is a full second
+   * copy of the response under unlimited buffering.
+   *
+   * <p>Do <strong>not</strong> {@code release()} the {@code accumulator}
+   * {@link org.eclipse.jetty.io.RetainableByteBuffer}: it is owned by Jetty's listener /
+   * {@code ByteBufferPool}. Returning it to the pool while connections may still reference it
+   * corrupts pooled buffers and collapses throughput (protocol errors, repeated HTTP/3
+   * exploration, multi-second samples). Jetty releases the accumulator with the exchange; we only
+   * drop the Java {@code content} duplicate and null request/response links.
+   */
+  private void releaseTransportBuffers() {
+    if (!transportBuffersReleased.compareAndSet(false, true)) {
+      return;
+    }
+    try {
+      Field contentField = AbstractResponseListener.class.getDeclaredField("content");
+      contentField.setAccessible(true);
+      contentField.set(this, BufferUtil.EMPTY_BYTES);
+    } catch (ReflectiveOperationException e) {
+      lowLevelDebug("Could not clear BufferingResponseListener.content", e);
+    }
   }
 
   @Override

--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -35,9 +35,11 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
@@ -74,6 +76,7 @@ import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.util.JMeterUtils;
 import org.brotli.dec.BrotliInputStream;
 import org.eclipse.jetty.client.AbstractAuthentication;
+import org.eclipse.jetty.client.Authentication;
 import org.eclipse.jetty.client.AuthenticationStore;
 import org.eclipse.jetty.client.BasicAuthentication;
 import org.eclipse.jetty.client.BytesRequestContent;
@@ -162,6 +165,14 @@ public class HTTP2JettyClient {
    * aborted; SampleResult store truncation uses {@link #maxBufferSize} instead (JMeter parity).
    */
   private static final int JETTY_BUFFERING_UNLIMITED = -1;
+  private static final long DEFAULT_BYTE_BUFFER_POOL_MAX_MEMORY = 64L * 1024 * 1024;
+  /**
+   * Max reusable {@link java.util.zip.Inflater}s kept by the gzip decoder pool. Jetty's default
+   * capacity is far larger than a JMeter thread needs; with one pool per {@code HTTP2JettyClient}
+   * (and several clients per thread) a 1024-slot pool retained an oversized high-water mark for the
+   * whole thread lifetime.
+   */
+  private static final int GZIP_INFLATER_POOL_CAPACITY = 32;
   private static final Pattern PORT_PATTERN = Pattern.compile("\\d+");
   private static final String MULTI_PART_SEPARATOR = "--";
   private static final String LINE_SEPARATOR = "\r\n";
@@ -201,6 +212,16 @@ public class HTTP2JettyClient {
   private static final Map<String, AltSvcEntry> ALT_SVC_CACHE = new ConcurrentHashMap<>();
   private static final Map<String, Http1OnlyEntry> HTTP1_ONLY_CACHE = new ConcurrentHashMap<>();
   private static final Map<String, H2cEntry> H2C_CACHE = new ConcurrentHashMap<>();
+  /**
+   * Origins currently exploring HTTP/3 for the first time. Without this, concurrent embeds
+   * (pool=100) stampede QUIC handshakes to the same host and each pays the full handshake timeout.
+   */
+  private static final Set<String> HTTP3_EXPLORE_IN_FLIGHT = ConcurrentHashMap.newKeySet();
+  /**
+   * Soft cap for process-wide protocol caches. Crawl / CDN tests can touch tens of thousands of
+   * origins; TTL alone only removes an entry when that origin is read again.
+   */
+  private static final int PROTOCOL_CACHE_SOFT_MAX = 10_000;
   private int requestTimeout = 0;
   /**
    * Max bytes stored in {@link HTTPSampleResult} response data ({@code <= 0} = no truncation).
@@ -252,6 +273,11 @@ public class HTTP2JettyClient {
   // Kept initialized for the disableDeflateDecoder diagnostic toggle, but no longer registered
   // per-request; see the comment in configureContentDecoders() below.
   private DeflateContentDecoderFactory deflateDecoderFactory;
+  /** Started with the gzip factory; must be stopped with the client or Inflaters stay pooled. */
+  private InflaterPool gzipInflaterPool;
+  private BrotliCompression brotliCompression;
+  private ZstandardCompression zstdCompression;
+  private GzipCompression gzipCompression;
   private boolean decoderFactoriesInitialized = false;
   private int quicMaxIdleTimeout = 30000;
   /**
@@ -286,6 +312,11 @@ public class HTTP2JettyClient {
   private boolean http1OnlyCacheEnabled = true;
   private boolean h2cCacheEnabled = true;
   private boolean heExecutorsRegistered = false;
+  /**
+   * Fingerprints of Auth Manager rows already pushed into Jetty stores. Avoids relying solely on
+   * {@code findAuthentication} (realm/URI matching quirks) and prevents per-sample list growth.
+   */
+  private final Set<String> registeredAuthFingerprints = ConcurrentHashMap.newKeySet();
 
   public HTTP2JettyClient(boolean http1UpgradeRequired, String name) {
     this(http1UpgradeRequired, name, null);
@@ -296,8 +327,9 @@ public class HTTP2JettyClient {
     loadProperties(profileConfig);
     lowLevelDebug(PLUGIN_BUILD_TAG);
 
-    // Create buffer pool first (needed for both TCP and QUIC connectors)
-    this.bufferPool = new ArrayByteBufferPool();
+    // Create buffer pool first (needed for both TCP and QUIC connectors). Cap retained pooled
+    // memory so continuous high-throughput runs do not keep growing the high-water mark forever.
+    this.bufferPool = createByteBufferPool();
     ensureDecoderFactoriesInitialized();
 
     ClientConnector clientConnector = createClientConnector(name);
@@ -730,8 +762,24 @@ public class HTTP2JettyClient {
   }
 
   public void clearBufferPool() {
-    // ByteBufferPool doesn't have a clear() method in Jetty 12
-    // The pool is managed automatically by Jetty
+    if (bufferPool != null) {
+      bufferPool.clear();
+    }
+  }
+
+  /**
+   * Caps how much pooled buffer memory Jetty may retain. Without a cap, {@code ArrayByteBufferPool}
+   * keeps the high-water mark for the JVM lifetime of the client under continuous load.
+   */
+  private ByteBufferPool createByteBufferPool() {
+    long maxHeap = Long.parseLong(BzmHttpPluginProperties.getPropDefault(
+        "httpJettyClient.byteBufferPoolMaxHeapMemory",
+        String.valueOf(DEFAULT_BYTE_BUFFER_POOL_MAX_MEMORY)));
+    long maxDirect = Long.parseLong(BzmHttpPluginProperties.getPropDefault(
+        "httpJettyClient.byteBufferPoolMaxDirectMemory",
+        String.valueOf(DEFAULT_BYTE_BUFFER_POOL_MAX_MEMORY)));
+    int factor = Math.max(1, byteBufferPoolFactor) * 1024;
+    return new ArrayByteBufferPool(0, factor, 65536, Integer.MAX_VALUE, maxHeap, maxDirect);
   }
 
   /**
@@ -1449,6 +1497,48 @@ public class HTTP2JettyClient {
   }
 
   /**
+   * Drops process-wide protocol-negotiation caches. Entries expire on read after TTL, but origins
+   * never touched again would otherwise stay until the JVM exits.
+   */
+  public static void clearStaticProtocolCaches() {
+    ALT_SVC_CACHE.clear();
+    HTTP1_ONLY_CACHE.clear();
+    H2C_CACHE.clear();
+    HTTP3_EXPLORE_IN_FLIGHT.clear();
+  }
+
+  /**
+   * Removes expired Alt-Svc / HTTP/1.1-only / H2C entries. If a cache is still over
+   * {@link #PROTOCOL_CACHE_SOFT_MAX} after that, drops arbitrary overflow entries so growth cannot
+   * track every distinct origin for the whole test duration.
+   */
+  public static void pruneExpiredProtocolCaches() {
+    long now = System.currentTimeMillis();
+    ALT_SVC_CACHE.entrySet().removeIf(e -> {
+      AltSvcEntry entry = e.getValue();
+      return entry.expiresAt <= now && entry.brokenUntil <= now;
+    });
+    HTTP1_ONLY_CACHE.entrySet().removeIf(e -> e.getValue().expiresAt <= now);
+    H2C_CACHE.entrySet().removeIf(e -> e.getValue().expiresAt <= now);
+    trimProtocolCache(ALT_SVC_CACHE);
+    trimProtocolCache(HTTP1_ONLY_CACHE);
+    trimProtocolCache(H2C_CACHE);
+  }
+
+  private static <V> void trimProtocolCache(Map<String, V> cache) {
+    int overflow = cache.size() - PROTOCOL_CACHE_SOFT_MAX;
+    if (overflow <= 0) {
+      return;
+    }
+    Iterator<String> keys = cache.keySet().iterator();
+    while (overflow > 0 && keys.hasNext()) {
+      keys.next();
+      keys.remove();
+      overflow--;
+    }
+  }
+
+  /**
    * Stops every Jetty {@link HttpClient} owned by this wrapper.
    *
    * <p>JMeter's Stop button interrupts the worker thread before {@code threadFinished} runs. Jetty
@@ -1468,6 +1558,7 @@ public class HTTP2JettyClient {
       firstFailure = stopClient(httpClientHttp1Only, firstFailure);
       firstFailure = stopClient(httpClientH2cPrior, firstFailure);
       firstFailure = stopClient(httpClientH2cUpgrade, firstFailure);
+      stopCompressionResources();
       clearBufferPool();
       if (heExecutorsRegistered) {
         int remaining = HAPPY_EYEBALLS_CLIENTS.decrementAndGet();
@@ -1498,7 +1589,7 @@ public class HTTP2JettyClient {
     } catch (InterruptedException e) {
       // Keep going: remaining clients must still be stopped. The interrupt is restored in stop().
       Thread.interrupted();
-      return firstFailure;
+      return firstFailure == null ? e : firstFailure;
     } catch (Exception e) {
       if (isExpectedShutdownException(e)) {
         lowLevelDebug("Ignoring expected shutdown exception while stopping {}: {}",
@@ -1507,6 +1598,40 @@ public class HTTP2JettyClient {
       }
       LOG.warn("Failed to stop HttpClient {}: {}", client.getName(), e.toString());
       return firstFailure != null ? firstFailure : e;
+    }
+  }
+
+  /**
+   * Stops gzip/brotli/zstd {@link LifeCycle} helpers created for content decoding. They are not
+   * children of the {@link HttpClient} beans, so {@code client.stop()} alone left Inflater pools
+   * and compression components running until GC — and even then native/pooled state could linger.
+   */
+  private void stopCompressionResources() {
+    stopLifeCycleQuietly(gzipInflaterPool);
+    gzipInflaterPool = null;
+    stopLifeCycleQuietly(gzipCompression);
+    gzipCompression = null;
+    stopLifeCycleQuietly(brotliCompression);
+    brotliCompression = null;
+    stopLifeCycleQuietly(zstdCompression);
+    zstdCompression = null;
+    brotliDecoderFactory = null;
+    zstdDecoderFactory = null;
+    gzipDecoderFactory = null;
+    deflateDecoderFactory = null;
+    decoderFactoriesInitialized = false;
+  }
+
+  private static void stopLifeCycleQuietly(LifeCycle lifeCycle) {
+    if (lifeCycle == null) {
+      return;
+    }
+    try {
+      if (lifeCycle.isRunning()) {
+        lifeCycle.stop();
+      }
+    } catch (Exception e) {
+      LOG.debug("Error stopping compression resource {}", lifeCycle.getClass().getSimpleName(), e);
     }
   }
 
@@ -2424,9 +2549,9 @@ public class HTTP2JettyClient {
       lowLevelDebug("Brotli decoder disabled by blazemeter.http.disableBrotliDecoder");
     } else {
       try {
-        BrotliCompression brotli = new BrotliCompression();
-        brotli.setByteBufferPool(bufferPool);
-        brotliDecoderFactory = new CompressionContentDecoderFactory(brotli);
+        brotliCompression = new BrotliCompression();
+        brotliCompression.setByteBufferPool(bufferPool);
+        brotliDecoderFactory = new CompressionContentDecoderFactory(brotliCompression);
         lowLevelDebug("Initialized Brotli content decoder factory");
       } catch (Throwable t) {
         LOG.warn("Brotli decoder not available; skipping factory initialization", t);
@@ -2439,9 +2564,9 @@ public class HTTP2JettyClient {
       lowLevelDebug("Zstd decoder disabled by blazemeter.http.disableZstdDecoder");
     } else {
       try {
-        ZstandardCompression zstd = new ZstandardCompression();
-        zstd.setByteBufferPool(bufferPool);
-        zstdDecoderFactory = new CompressionContentDecoderFactory(zstd);
+        zstdCompression = new ZstandardCompression();
+        zstdCompression.setByteBufferPool(bufferPool);
+        zstdDecoderFactory = new CompressionContentDecoderFactory(zstdCompression);
         lowLevelDebug("Initialized Zstandard content decoder factory");
       } catch (Throwable t) {
         LOG.warn("Zstandard decoder not available; skipping factory initialization", t);
@@ -2454,19 +2579,18 @@ public class HTTP2JettyClient {
       lowLevelDebug("Gzip decoder disabled by blazemeter.http.disableGzipDecoder");
     } else {
       try {
-        GzipCompression gzip = new GzipCompression();
-        gzip.setByteBufferPool(bufferPool);
-        // Ensure inflater pool is initialized; missing pool can trigger NPE and stream cancel.
-        InflaterPool inflaterPool = new InflaterPool(1024, true);
+        gzipCompression = new GzipCompression();
+        gzipCompression.setByteBufferPool(bufferPool);
+        // Cap capacity: one pool per HTTP2JettyClient; 1024 slots × many clients retained a huge
+        // high-water mark for the thread lifetime after gzip traffic.
+        gzipInflaterPool = new InflaterPool(GZIP_INFLATER_POOL_CAPACITY, true);
         try {
-          if (inflaterPool instanceof LifeCycle) {
-            ((LifeCycle) inflaterPool).start();
-          }
+          gzipInflaterPool.start();
         } catch (Exception e) {
           lowLevelDebug("Failed to start InflaterPool", e);
         }
-        gzip.setInflaterPool(inflaterPool);
-        gzipDecoderFactory = new CompressionContentDecoderFactory(gzip);
+        gzipCompression.setInflaterPool(gzipInflaterPool);
+        gzipDecoderFactory = new CompressionContentDecoderFactory(gzipCompression);
         lowLevelDebug("Initialized Gzip content decoder factory");
       } catch (Throwable t) {
         LOG.warn("Gzip decoder not available; skipping factory initialization", t);
@@ -2617,9 +2741,9 @@ public class HTTP2JettyClient {
    * {@link #shouldUseHappyEyeballs}: that changes how HTTP/3 is attempted, not whether this origin
    * is worth attempting it on.
    *
-   * @param recoverable whether a failure to establish the connection can be retried over another
-   *                    protocol, which is what makes exploring HTTP/3 on an unknown origin safe.
-   *                    See {@link #isRecoverableIfHttp3Fails}.
+   * @param recoverable reserved for connection-retry policy (e.g. future HTTPS RR discovery). TCP
+   *                    protocols learn {@code Alt-Svc} first; HTTP/3 is not speculative-explored
+   *                    on unknown origins. See {@link #shouldAttemptHttp3}.
    */
   private HttpClient selectHttpClient(URI uri, boolean recoverable) {
     if (uri != null && "http".equalsIgnoreCase(uri.getScheme())) {
@@ -2674,24 +2798,19 @@ public class HTTP2JettyClient {
     boolean attemptHttp3 = shouldAttemptHttp3(uri, recoverable);
     if (attemptHttp3) {
       lowLevelDebug("HTTP/3 enabled for origin {}", originKey(uri));
-    } else {
-      lowLevelDebug("HTTP/3 not enabled for origin {}", originKey(uri));
-    }
-    if (attemptHttp3) {
       return httpClient;
     }
+    lowLevelDebug("HTTP/3 not enabled for origin {}", originKey(uri));
     if (!enableHttp2) {
-      // With HTTP/2 disabled there is no race to run and no HTTP/2 client to use: go straight to
-      // HTTP/3 when it is enabled (a failure there falls back to HTTP/1.1 through the usual paths,
-      // which check enableHttp1 themselves), and only then to HTTP/1.1. Falling through to the
-      // HTTP/2 client below would have ignored the user disabling HTTP/2 - and, when HTTP/1.1 was
-      // disabled too, would have negotiated exactly the two protocols that were turned off.
-      if (enableHttp3) {
-        lowLevelDebug("HTTP/2 disabled; using HTTP/3 for origin {}", originKey(uri));
-        return httpClient;
-      }
+      // Chromium-like: with HTTP/2 off, prefer HTTP/1.1 so Alt-Svc can still be learned before
+      // any HTTP/3 attempt. H3-only (no H1/H2) already forced prior knowledge above, so
+      // shouldAttemptHttp3 would have returned true.
       if (enableHttp1) {
         return httpClientHttp1Only;
+      }
+      if (enableHttp3) {
+        lowLevelDebug("No TCP protocol left; using HTTP/3 for origin {}", originKey(uri));
+        return httpClient;
       }
     }
     if (enableHttp1 && isHttp1Only(uri)) {
@@ -2701,6 +2820,18 @@ public class HTTP2JettyClient {
     return httpClientNoH3;
   }
 
+  /**
+   * Whether this request may use the HTTP/3-capable client.
+   *
+   * <p>Matches Chromium's discovery model when a TCP protocol is available: the first contact goes
+   * over HTTP/2 (or HTTP/1.1 if HTTP/2 is disabled) so {@code Alt-Svc} can be learned; HTTP/3 is
+   * used only after the cache says the origin supports it (and is not in a broken cooldown). Blind
+   * QUIC exploration on unknown origins is not done — that is what made POSTs pay a handshake
+   * timeout against sites that never speak HTTP/3.
+   *
+   * <p>Exception: {@code http3PriorKnowledge} (also auto-enabled when only HTTP/3 is configured)
+   * asserts the origin speaks HTTP/3 up front, so there is nothing to learn over TCP first.
+   */
   private boolean shouldAttemptHttp3(URI uri, boolean recoverable) {
     if (!enableHttp3) {
       return false;
@@ -2716,23 +2847,18 @@ public class HTTP2JettyClient {
     }
     AltSvcEntry entry = ALT_SVC_CACHE.get(originKey(uri));
     if (entry == null) {
-      // First contact. Alt-Svc can only be learnt from a response, so waiting for the cache to say
-      // yes would mean HTTP/3 is never tried at all here: explore it, as long as the attempt can be
-      // walked back.
-      //
-      // This includes requests that cannot be raced, such as a POST. Those get no concurrent HTTP/2
-      // attempt to cover them, so what makes them safe is that the handshake has its own short
-      // deadline (see applyHttp3HandshakeTimeout) and that the fallback only fires for a failure to
-      // establish the connection - the request never reached the wire, so resending it cannot
-      // repeat a side effect. The outcome is cached either way, so it is the first request to an
-      // origin that pays for the exploration, not every one.
-      return recoverable;
+      // Unknown origin: stay on HTTP/2 or HTTP/1.1 until Alt-Svc (or prior knowledge) says h3.
+      // {@code recoverable} is unused here on purpose — Chromium does not speculative-explore
+      // QUIC just because a failure could be retried.
+      return false;
     }
     long now = System.currentTimeMillis();
     if (entry.expiresAt <= now) {
-      // Stale: forget it and explore again rather than trusting an answer that has expired.
-      ALT_SVC_CACHE.remove(originKey(uri));
-      return recoverable;
+      // Stale: drop it and rediscover via TCP on a later response — do not re-open QUIC blindly.
+      String origin = originKey(uri);
+      ALT_SVC_CACHE.remove(origin);
+      HTTP3_EXPLORE_IN_FLIGHT.remove(origin);
+      return false;
     }
     if (entry.brokenUntil > now) {
       // HTTP/3 failed here recently; stay off it until the cooldown elapses.
@@ -2815,6 +2941,10 @@ public class HTTP2JettyClient {
       return;
     }
     ALT_SVC_CACHE.put(origin, entry);
+    HTTP3_EXPLORE_IN_FLIGHT.remove(origin);
+    if (ALT_SVC_CACHE.size() > PROTOCOL_CACHE_SOFT_MAX) {
+      pruneExpiredProtocolCaches();
+    }
     lowLevelDebug("Alt-Svc cached for origin {} (h3={}, expiresAt={})",
         origin, entry.h3, entry.expiresAt);
   }
@@ -2901,6 +3031,7 @@ public class HTTP2JettyClient {
     entry.lastH3SuccessAt = System.currentTimeMillis();
     entry.brokenUntil = 0L;
     ALT_SVC_CACHE.put(origin, entry);
+    HTTP3_EXPLORE_IN_FLIGHT.remove(origin);
   }
 
   private void updateHttp1OnlyCache(Request request, Response response) {
@@ -2936,6 +3067,9 @@ public class HTTP2JettyClient {
     Http1OnlyEntry entry = new Http1OnlyEntry();
     entry.expiresAt = System.currentTimeMillis() + http1OnlyCooldownMs;
     HTTP1_ONLY_CACHE.put(origin, entry);
+    if (HTTP1_ONLY_CACHE.size() > PROTOCOL_CACHE_SOFT_MAX) {
+      pruneExpiredProtocolCaches();
+    }
     lowLevelDebug("HTTP/1.1-only cache set for origin {} until {}", origin, entry.expiresAt);
   }
 
@@ -2956,6 +3090,9 @@ public class HTTP2JettyClient {
       H2cEntry entry = new H2cEntry();
       entry.expiresAt = System.currentTimeMillis() + h2cCacheTtlMs;
       H2C_CACHE.put(origin, entry);
+      if (H2C_CACHE.size() > PROTOCOL_CACHE_SOFT_MAX) {
+        pruneExpiredProtocolCaches();
+      }
       lowLevelDebug("H2C cache set for origin {} until {}", origin, entry.expiresAt);
     } else if (version != null) {
       if (H2C_CACHE.remove(origin) != null) {
@@ -2983,6 +3120,7 @@ public class HTTP2JettyClient {
     }
     entry.brokenUntil = brokenUntil;
     ALT_SVC_CACHE.put(origin, entry);
+    HTTP3_EXPLORE_IN_FLIGHT.remove(origin);
     lowLevelDebug("HTTP/3 marked broken for origin {} until {}", origin, entry.brokenUntil);
   }
 
@@ -3214,6 +3352,11 @@ public class HTTP2JettyClient {
     client.setMaxRequestsQueuedPerDestination(maxRequestsQueuedPerDestination);
     client.setMaxConnectionsPerDestination(maxConnectionsPerDestination);
     client.setStrictEventOrdering(strictEventOrdering);
+    // JMeter owns cookies via CookieManager (or HeaderManager). Jetty's default store would keep
+    // every Set-Cookie for the client lifetime — and with no CookieManager (common in demos) that
+    // grows across iterations on every protocol-variant HttpClient. Empty matches HC4's model where
+    // the jar is external to the transport.
+    client.setHttpCookieStore(new HttpCookieStore.Empty());
     if (removeIdleDestinations) {
       client.setDestinationIdleTimeout(idleTimeout);
     }
@@ -3493,12 +3636,13 @@ public class HTTP2JettyClient {
 
   private void setAuthManager(HTTP2Sampler sampler) {
     AuthManager authManager = sampler.getAuthManager();
-    if (authManager != null) {
-      StreamSupport.stream(authManager.getAuthObjects().spliterator(), false)
-          .map(j -> (Authorization) j.getObjectValue())
-          .filter(auth -> isSupportedMechanism(auth) && !StringUtils.isEmpty(auth.getURL()))
-          .forEach(this::addAuthenticationToJettyClient);
+    if (authManager == null) {
+      return;
     }
+    StreamSupport.stream(authManager.getAuthObjects().spliterator(), false)
+        .map(j -> (Authorization) j.getObjectValue())
+        .filter(auth -> isSupportedMechanism(auth) && !StringUtils.isEmpty(auth.getURL()))
+        .forEach(this::addAuthenticationToJettyClient);
   }
 
   private boolean isSupportedMechanism(Authorization auth) {
@@ -3508,37 +3652,62 @@ public class HTTP2JettyClient {
   }
 
   private void addAuthenticationToJettyClient(Authorization auth) {
-    AuthenticationStore authenticationStore = httpClient.getAuthenticationStore();
-    AuthenticationStore authenticationStoreNoH3 = httpClientNoH3.getAuthenticationStore();
-    AuthenticationStore authenticationStoreHttp1 = httpClientHttp1Only.getAuthenticationStore();
-    AuthenticationStore authenticationStoreH2c = httpClientH2cPrior.getAuthenticationStore();
-    AuthenticationStore authenticationStoreH2cUpgrade =
-        httpClientH2cUpgrade.getAuthenticationStore();
     String authName = auth.getMechanism().name();
     if (authName.equals(AuthManager.Mechanism.BASIC.name())
         && BzmHttpPluginProperties.getPropDefault("httpJettyClient.auth.preemptive", false)) {
       BasicAuthentication.BasicResult result =
           new BasicAuthentication.BasicResult(URI.create(auth.getURL()), auth.getUser(),
               auth.getPass());
-      authenticationStore.addAuthenticationResult(result);
-      authenticationStoreNoH3.addAuthenticationResult(result);
-      authenticationStoreHttp1.addAuthenticationResult(result);
-      authenticationStoreH2c.addAuthenticationResult(result);
-      authenticationStoreH2cUpgrade.addAuthenticationResult(result);
-    } else {
-      AbstractAuthentication authentication =
-          authName.equals(AuthManager.Mechanism.BASIC.name()) ? new BasicAuthentication(
-              URI.create(auth.getURL()), auth.getRealm(), auth.getUser(), auth.getPass())
-              :
-              new DigestAuthentication(URI.create(auth.getURL()), auth.getRealm(),
-                  auth.getUser(),
-                  auth.getPass());
-      authenticationStore.addAuthentication(authentication);
-      authenticationStoreNoH3.addAuthentication(authentication);
-      authenticationStoreHttp1.addAuthentication(authentication);
-      authenticationStoreH2c.addAuthentication(authentication);
-      authenticationStoreH2cUpgrade.addAuthentication(authentication);
+      // Results are keyed by URI (Map.put replaces); safe to re-register every sample.
+      forEachAuthenticationStore(store -> store.addAuthenticationResult(result));
+      return;
     }
+
+    String fingerprint = authFingerprint(auth);
+    if (!registeredAuthFingerprints.add(fingerprint)) {
+      return;
+    }
+
+    URI uri = URI.create(auth.getURL());
+    String realm = auth.getRealm();
+    if (realm == null || realm.isEmpty()) {
+      // Blank JMeter realm must match any challenge realm; "" would only match "".
+      realm = Authentication.ANY_REALM;
+    }
+    AbstractAuthentication authentication =
+        authName.equals(AuthManager.Mechanism.BASIC.name())
+            ? new BasicAuthentication(uri, realm, auth.getUser(), auth.getPass())
+            : new DigestAuthentication(uri, realm, auth.getUser(), auth.getPass());
+    forEachAuthenticationStore(store -> store.addAuthentication(authentication));
+  }
+
+  private static String authFingerprint(Authorization auth) {
+    URI uri = URI.create(auth.getURL());
+    String realm = auth.getRealm();
+    if (realm == null || realm.isEmpty()) {
+      realm = Authentication.ANY_REALM;
+    }
+    return auth.getMechanism().name() + '|'
+        + Objects.toString(uri.getScheme(), "") + '|'
+        + Objects.toString(uri.getHost(), "") + '|'
+        + uri.getPort() + '|'
+        + Objects.toString(uri.getPath(), "") + '|'
+        + realm + '|'
+        + Objects.toString(auth.getUser(), "");
+  }
+
+  private void forEachHttpClient(java.util.function.Consumer<HttpClient> action) {
+    action.accept(httpClient);
+    if (httpClientNoH3 != httpClient) {
+      action.accept(httpClientNoH3);
+    }
+    action.accept(httpClientHttp1Only);
+    action.accept(httpClientH2cPrior);
+    action.accept(httpClientH2cUpgrade);
+  }
+
+  private void forEachAuthenticationStore(java.util.function.Consumer<AuthenticationStore> action) {
+    forEachHttpClient(client -> action.accept(client.getAuthenticationStore()));
   }
 
   private static class RequestContext {
@@ -3603,13 +3772,9 @@ public class HTTP2JettyClient {
   }
 
   /**
-   * Whether a failed HTTP/3 attempt for this request could still be served over another protocol,
-   * which is the condition for exploring HTTP/3 on an origin nothing is known about yet.
-   *
-   * <p>It comes down to the body: the fallback has to hand the same body to the retry, and a body
-   * read from a file cannot be rewound, so such a request has no way back once HTTP/3 has been
-   * attempted and failed. Form and string bodies rewind fine, so an ordinary POST is recoverable
-   * and does get to explore. Requests with no body always are.
+   * Whether a failed HTTP/3 attempt for this request could still be served over another protocol.
+   * Used when deciding fallback after an indicated HTTP/3 failure (cached Alt-Svc / prior
+   * knowledge). File bodies cannot be rewound for a retry; form/string bodies can.
    */
   private boolean isRecoverableIfHttp3Fails(HTTP2Sampler sampler) {
     return sampler.getHTTPFiles().length == 0;
@@ -3962,33 +4127,11 @@ public class HTTP2JettyClient {
     if (cookieManager == null) {
       return null;
     }
-    HttpCookieStore cookieStore = httpClient.getHttpCookieStore();
-    if (cookieStore != null) {
-      URI uri = request.getURI();
-      if (cookieManager.getCookieCount() == 0) {
-        if (!cookieStore.match(uri).isEmpty()) {
-          cookieStore.clear();
-          lowLevelDebug("Cleared Jetty cookie store because JMeter CookieManager is empty");
-        }
-      } else {
-        Set<String> jmeterCookieNames = new HashSet<>();
-        for (JMeterProperty property : cookieManager.getCookies()) {
-          Cookie cookie = (Cookie) property.getObjectValue();
-          if (cookie != null) {
-            jmeterCookieNames.add(cookie.getName());
-          }
-        }
-        if (!jmeterCookieNames.isEmpty()) {
-          for (HttpCookie cookie : cookieStore.match(uri)) {
-            if (jmeterCookieNames.contains(cookie.getName())) {
-              cookieStore.remove(uri, cookie);
-              lowLevelDebug("Removed cookie '{}' from Jetty store because JMeter overrides it",
-                  cookie.getName());
-            }
-          }
-        }
-      }
-    }
+    URI uri = request.getURI();
+    // Keep every protocol-variant Jetty client in sync with the JMeter CookieManager. Previously
+    // only the main client was cleaned; H2C / HTTP/1-only / no-H3 clients kept accumulating
+    // Set-Cookie entries across iterations when those transports were used.
+    forEachHttpClient(client -> syncJettyCookieStoreWithJmeter(client, uri, cookieManager));
     String cookieString = cookieManager.getCookieHeaderForURL(url);
     if (cookieString != null) {
       HttpFields headers = request.getHeaders();
@@ -3997,6 +4140,38 @@ public class HTTP2JettyClient {
       }
     }
     return cookieString;
+  }
+
+  private void syncJettyCookieStoreWithJmeter(HttpClient client, URI uri,
+                                              CookieManager cookieManager) {
+    HttpCookieStore cookieStore = client.getHttpCookieStore();
+    if (cookieStore == null) {
+      return;
+    }
+    if (cookieManager.getCookieCount() == 0) {
+      if (!cookieStore.match(uri).isEmpty()) {
+        cookieStore.clear();
+        lowLevelDebug("Cleared Jetty cookie store because JMeter CookieManager is empty");
+      }
+      return;
+    }
+    Set<String> jmeterCookieNames = new HashSet<>();
+    for (JMeterProperty property : cookieManager.getCookies()) {
+      Cookie cookie = (Cookie) property.getObjectValue();
+      if (cookie != null) {
+        jmeterCookieNames.add(cookie.getName());
+      }
+    }
+    if (jmeterCookieNames.isEmpty()) {
+      return;
+    }
+    for (HttpCookie cookie : cookieStore.match(uri)) {
+      if (jmeterCookieNames.contains(cookie.getName())) {
+        cookieStore.remove(uri, cookie);
+        lowLevelDebug("Removed cookie '{}' from Jetty store because JMeter overrides it",
+            cookie.getName());
+      }
+    }
   }
 
   private void setProxy(String host, int port, String protocol) {
@@ -4534,14 +4709,26 @@ public class HTTP2JettyClient {
   public void clearCookies() {
     // In Jetty 12, getCookieStore() was replaced by getHttpCookieStore()
     // removeAll() was replaced by clear()
-    HttpCookieStore cookieStore = httpClient.getHttpCookieStore();
-    if (cookieStore != null) {
-      cookieStore.clear();
-    }
+    forEachHttpClient(client -> {
+      HttpCookieStore cookieStore = client.getHttpCookieStore();
+      if (cookieStore != null) {
+        cookieStore.clear();
+      }
+    });
   }
 
   public void clearAuthenticationResults() {
-    httpClient.getAuthenticationStore().clearAuthenticationResults();
+    forEachAuthenticationStore(AuthenticationStore::clearAuthenticationResults);
+  }
+
+  /**
+   * Drops configured authentications from every Jetty client in this wrapper (main + protocol
+   * variants). Used on new-user iteration reset together with
+   * {@link #clearAuthenticationResults()}.
+   */
+  public void clearAuthentications() {
+    forEachAuthenticationStore(AuthenticationStore::clearAuthentications);
+    registeredAuthFingerprints.clear();
   }
 
   public String dump() {

--- a/src/main/java/com/blazemeter/jmeter/http2/core/SslClientCertAliasContext.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/SslClientCertAliasContext.java
@@ -1,19 +1,25 @@
 package com.blazemeter.jmeter.http2.core;
 
+import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.WeakHashMap;
 import javax.net.ssl.SSLEngine;
 
 /**
  * Holds the client certificate alias resolved on the JMeter thread and bound to the
  * {@link SSLEngine} used during the async Jetty TLS handshake.
+ *
+ * <p>Keys are weak so closed engines can be reclaimed. A strong {@code ConcurrentHashMap} retained
+ * every historical {@code SSLEngine} for the JVM lifetime because {@link #clearEngine} had no call
+ * sites on connection close.
  */
 final class SslClientCertAliasContext {
 
   static final String CONNECTION_CONTEXT_KEY = "bzm.jmeter.ssl.clientCertAlias";
   static final String REQUEST_ATTRIBUTE = CONNECTION_CONTEXT_KEY;
 
-  private static final Map<SSLEngine, String> ENGINE_ALIASES = new ConcurrentHashMap<>();
+  private static final Map<SSLEngine, String> ENGINE_ALIASES =
+      Collections.synchronizedMap(new WeakHashMap<>());
 
   private SslClientCertAliasContext() {
   }
@@ -43,6 +49,11 @@ final class SslClientCertAliasContext {
     }
     Object alias = context.get(CONNECTION_CONTEXT_KEY);
     return alias instanceof String ? (String) alias : null;
+  }
+
+  /** Visible for leak regression tests. */
+  static int engineAliasCountForTests() {
+    return ENGINE_ALIASES.size();
   }
 
 }

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -65,28 +65,22 @@ import org.slf4j.LoggerFactory;
 
 public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListener, ThreadListener {
 
-  private static class OwnInheritableThreadLocal
-      extends InheritableThreadLocal<Map<HTTP2ClientKey, HTTP2JettyClient>> {
+  private static class OwnThreadLocal
+      extends ThreadLocal<Map<HTTP2ClientKey, HTTP2JettyClient>> {
     @Override
     protected Map<HTTP2ClientKey, HTTP2JettyClient> initialValue() {
       return new HashMap<>();
-    }
-
-    @Override
-    protected Map<HTTP2ClientKey, HTTP2JettyClient> childValue(
-        Map<HTTP2ClientKey, HTTP2JettyClient> parentValue) {
-      return parentValue;
     }
   }
 
   public static final String SYNC_REQUEST = "HTTP2Sampler.sync_request";
   private static final Logger LOG = LoggerFactory.getLogger(HTTP2Sampler.class);
   /*
-  private static final ThreadLocal<Map<HTTP2ClientKey, HTTP2JettyClient>> CONNECTIONS =
-      ThreadLocal
-          .withInitial(HashMap::new);
-  */
-  private static final OwnInheritableThreadLocal CONNECTIONS = new OwnInheritableThreadLocal();
+   * Previously an InheritableThreadLocal: Jetty / Happy-Eyeballs pool threads inherited the
+   * parent's map and could keep clients reachable after the JMeter thread's closeConnections().
+   * Sampling must stay on the JMeter thread, so a plain ThreadLocal is enough.
+   */
+  private static final OwnThreadLocal CONNECTIONS = new OwnThreadLocal();
 
   private static final boolean IGNORE_FAILED_EMBEDDED_RESOURCES =
       getPropDefault(
@@ -423,12 +417,30 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
                 this.result, areFollowingRedirect, completionDepth, this.asyncListener);
             return this.result;
           } finally {
+            // Drop the buffering listener (unlimited body accumulator) as soon as the sample is
+            // materialised — waiting until the next iterationStart pinned large responses across
+            // the whole loop for every async sampler. Clear the field too: the returned reference
+            // is enough for JMeterThread; keeping this.result until iterationStart pinned every
+            // completed async body for the rest of the controller iteration.
+            if (this.asyncListener != null) {
+              this.asyncListener.releaseAfterSampleMaterialised();
+            }
+            this.asyncListener = null;
+            this.result = null;
+            this.pendingCompletionDepth = 0;
             restoreSuppressedPreProcessors();
           }
         }
       } else {
-        this.result = buildResult(url, method);
-        return client.sample(this, this.result, areFollowingRedirect, depth);
+        HTTPSampleResult sampleResult = buildResult(url, method);
+        this.result = sampleResult;
+        try {
+          return client.sample(this, sampleResult, areFollowingRedirect, depth);
+        } finally {
+          // Sync path: JMeterThread keeps the returned SampleResult; holding this.result until
+          // iterationStart only duplicates that pin across the rest of the iteration.
+          this.result = null;
+        }
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -1571,12 +1583,35 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
 
   @Override
   public void iterationStart(LoopIterationEvent iterEvent) {
-    this.asyncListener = null;
-    restoreSuppressedPreProcessors();
+    // Per-sample fields only. With same_user_on_next_iteration=true the Jetty clients in
+    // CONNECTIONS, Alt-Svc / H1-only / H2C caches, auth fingerprints and buffer pools must survive
+    // across iterations — recreating them every loop would dominate fast iterations. New-user
+    // resets go through clearUserStores() below (JMeter clears CookieManager itself).
+    clearPendingSampleState();
     JMeterVariables jMeterVariables = JMeterContextService.getContext().getVariables();
     if (!jMeterVariables.isSameUserOnNextIteration()) {
       clearUserStores();
     }
+  }
+
+  /**
+   * Drops any in-flight or completed-but-uncollected async listener / result retained on this
+   * sampler. Used from iteration boundaries, thread end, and controller abort paths so a discarded
+   * exchange cannot keep an unlimited Jetty body (or SampleResult) alive until the next sample.
+   */
+  public void clearPendingSampleState() {
+    if (this.asyncListener != null) {
+      if (!this.asyncListener.isDone() && !this.asyncListener.isCancelled()) {
+        // Must abort the exchange; only releasing buffers on a live request races Jetty I/O.
+        this.asyncListener.cancel(true);
+      } else {
+        this.asyncListener.releaseAfterSampleMaterialised();
+      }
+    }
+    this.asyncListener = null;
+    this.result = null;
+    this.pendingCompletionDepth = 0;
+    restoreSuppressedPreProcessors();
   }
 
   /**
@@ -1685,6 +1720,8 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
       }
     }
     clients.clear();
+    // Drop the ThreadLocal entry itself so the empty map is not retained until the next get().
+    CONNECTIONS.remove();
   }
 
   private void dump() {
@@ -1701,11 +1738,13 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
   @Override
   public void testEnded() {
     super.testEnded();
+    HTTP2JettyClient.clearStaticProtocolCaches();
     System.gc(); // Force free memory
   }
 
   @Override
   public void threadFinished() {
+    clearPendingSampleState();
     if (dumpAtThreadEnd) {
       dump();
     }
@@ -1718,10 +1757,13 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
       try {
         client.clearCookies();
         client.clearAuthenticationResults();
+        client.clearAuthentications();
+        client.clearBufferPool();
       } catch (Exception e) {
         LOG.error("Error while cleaning user store", e);
       }
     }
+    HTTP2JettyClient.pruneExpiredProtocolCaches();
   }
 
   private static final class HTTP2ClientKey {

--- a/src/test/java/com/blazemeter/jmeter/http2/control/HTTP2ControllerTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/control/HTTP2ControllerTest.java
@@ -11,6 +11,8 @@ import com.blazemeter.jmeter.http2.sampler.JMeterTestUtils;
 import com.blazemeter.jmeter.http2.util.BzmHttpPluginProperties;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -26,6 +28,7 @@ import java.net.URL;
 import org.apache.jmeter.util.JMeterUtils;
 import org.eclipse.jetty.client.Request;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,6 +51,7 @@ public class HTTP2ControllerTest extends HTTP2TestBase {
   private HTTP2FutureResponseListener firstSamplerListener;
   @Mock
   private HTTP2FutureResponseListener secondSamplerListener;
+  private final List<ScheduledExecutorService> simulationExecutors = new ArrayList<>();
 
   @Before
   public void setUp() {
@@ -56,6 +60,14 @@ public class HTTP2ControllerTest extends HTTP2TestBase {
     firstSampler.setFutureResponseListener(firstSamplerListener);
     secondSampler.setFutureResponseListener(secondSamplerListener);
     JMeterTestUtils.setupJmeterEnv();
+  }
+
+  @After
+  public void tearDownSimulations() {
+    for (ScheduledExecutorService executor : simulationExecutors) {
+      executor.shutdownNow();
+    }
+    simulationExecutors.clear();
   }
 
 
@@ -70,8 +82,9 @@ public class HTTP2ControllerTest extends HTTP2TestBase {
   public void shouldBusyWaitOnlyForFirstSamplerWhenMaxConcurrentAsyncInControllerOvercome()
       throws Exception {
     setupHttp2Controller(false, 1);
-    simulateSamplerExecution(secondSamplerListener, 80000);
-    simulateSamplerExecution(firstSamplerListener, 3000);
+    // Second stays not-done (default mock); first completes soon. Proves we do not wait on second
+    // without leaving an 80s non-daemon timer that outlives the class and noise later tests.
+    simulateSamplerExecution(firstSamplerListener, 100);
     http2Controller.next();
     http2Controller.next();
   }
@@ -91,24 +104,28 @@ public class HTTP2ControllerTest extends HTTP2TestBase {
     }
   }
 
-  private static void simulateSamplerExecution(HTTP2FutureResponseListener samplerListener,
-                                               int delayInMillis) {
+  private void simulateSamplerExecution(HTTP2FutureResponseListener samplerListener,
+                                        int delayInMillis) {
     //Thanks to mockito by default when(samplerListener.isDone()).thenReturn(false)
     //
-    ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+    ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor(r -> {
+      Thread thread = new Thread(r, "http2-controller-sim");
+      thread.setDaemon(true);
+      return thread;
+    });
+    simulationExecutors.add(executorService);
     executorService.schedule(() -> {
-      System.out.printf("Scheduled service with a delay of %d executed", delayInMillis);
       when(samplerListener.isDone()).thenReturn(true);
       return null;
     }, delayInMillis, TimeUnit.MILLISECONDS);
   }
 
-  @Test(timeout = 10000)
+  @Test(timeout = 5000)
   public void shouldBusyWaitForAsyncSamplersWhenControllerReachOtherSamplerType()
       throws URISyntaxException {
     setupHttp2Controller(true, 2);
-    simulateSamplerExecution(secondSamplerListener, 6000);
-    simulateSamplerExecution(firstSamplerListener, 2000);
+    simulateSamplerExecution(secondSamplerListener, 200);
+    simulateSamplerExecution(firstSamplerListener, 50);
     Sampler next = null;
     for (int i = 0; i < 5; i++) {
       next = http2Controller.next();

--- a/src/test/java/com/blazemeter/jmeter/http2/control/ParentTransactionSampleReleaseTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/control/ParentTransactionSampleReleaseTest.java
@@ -1,0 +1,93 @@
+package com.blazemeter.jmeter.http2.control;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.sampler.JMeterTestUtils;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import org.apache.jmeter.control.TransactionSampler;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.samplers.Sampler;
+import org.apache.jmeter.threads.SamplePackage;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Pins the workaround for Apache JMeter #6237 / PR #6386: with "Generate parent sample", a finished
+ * {@link TransactionSampler} keeps every child {@code responseData} reachable from
+ * {@code TestCompiler.transactionControllerConfigMap} until the next transaction starts. Replacing
+ * that sampler after the parent is done lets the finished tree be collected.
+ */
+public class ParentTransactionSampleReleaseTest extends HTTP2TestBase {
+
+  @Before
+  public void setUp() {
+    JMeterTestUtils.setupJmeterEnv();
+  }
+
+  @Test
+  public void replaceDoneTransactionSamplerDropsFinishedParentTree() throws Exception {
+    HTTP2Controller controller = new HTTP2Controller();
+    controller.setName("TG1 - Parallel HTTP2 Flow");
+    controller.setGenerateParentSample(true);
+
+    TransactionSampler finished = new TransactionSampler(controller, controller.getName());
+    SampleResult heavyChild = new SampleResult();
+    heavyChild.setSampleLabel("http2 GET Home (embedded)");
+    heavyChild.setResponseData("x".repeat(1024 * 1024).getBytes(StandardCharsets.UTF_8));
+    finished.addSubSamplerResult(heavyChild);
+    markTransactionDone(finished);
+
+    SamplePackage pack = newSamplePackage(finished);
+    assertThat(finished.getTransactionResult().getSubResults())
+        .as("precondition: the finished parent still holds the heavy child")
+        .isNotEmpty();
+    assertThat(finished.getTransactionResult().getSubResults()[0].getResponseData().length)
+        .isEqualTo(1024 * 1024);
+
+    assertThat(controller.replaceDoneTransactionSampler(pack)).isTrue();
+
+    Sampler replacement = pack.getSampler();
+    assertThat(replacement)
+        .as("the package must point at a fresh TransactionSampler, not the finished one")
+        .isInstanceOf(TransactionSampler.class)
+        .isNotSameAs(finished);
+    assertThat(((TransactionSampler) replacement).isTransactionDone()).isFalse();
+    assertThat(((TransactionSampler) replacement).getTransactionResult().getSubResults())
+        .as("the replacement must not inherit the finished parent's sub-results")
+        .isEmpty();
+  }
+
+  @Test
+  public void replaceSkipsInFlightTransactionSampler() {
+    HTTP2Controller controller = new HTTP2Controller();
+    controller.setName("in-flight");
+    controller.setGenerateParentSample(true);
+
+    TransactionSampler inFlight = new TransactionSampler(controller, controller.getName());
+    SamplePackage pack = newSamplePackage(inFlight);
+
+    assertThat(controller.replaceDoneTransactionSampler(pack)).isFalse();
+    assertThat(pack.getSampler()).isSameAs(inFlight);
+  }
+
+  private static SamplePackage newSamplePackage(Sampler sampler) {
+    SamplePackage pack = new SamplePackage(
+        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+        new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+    pack.setSampler(sampler);
+    return pack;
+  }
+
+  private static void markTransactionDone(TransactionSampler sampler) throws Exception {
+    Method setDone = TransactionSampler.class.getDeclaredMethod("setTransactionDone");
+    setDone.setAccessible(true);
+    setDone.invoke(sampler);
+    Field calls = TransactionSampler.class.getDeclaredField("calls");
+    calls.setAccessible(true);
+    calls.setInt(sampler, Math.max(1, calls.getInt(sampler)));
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/AuthStoreMemoryLeakRegressionTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/AuthStoreMemoryLeakRegressionTest.java
@@ -47,6 +47,7 @@ public class AuthStoreMemoryLeakRegressionTest extends HTTP2TestBase {
   private String originalEnableHttp1Property;
   private String originalEnableHttp2Property;
   private String originalEnableHttp3Property;
+  private String originalAuthPreemptiveProperty;
 
   @BeforeClass
   public static void setupClass() {
@@ -59,11 +60,16 @@ public class AuthStoreMemoryLeakRegressionTest extends HTTP2TestBase {
     originalEnableHttp1Property = JMeterUtils.getProperty("httpJettyClient.enableHttp1");
     originalEnableHttp2Property = JMeterUtils.getProperty("httpJettyClient.enableHttp2");
     originalEnableHttp3Property = JMeterUtils.getProperty("httpJettyClient.enableHttp3");
+    originalAuthPreemptiveProperty = JMeterUtils.getProperty("httpJettyClient.auth.preemptive");
     JMeterUtils.setProperty("httpJettyClient.sharedThreadPool", "false");
     // Server is HTTP/1.1 only — keep HE/HTTP3 off so 40 samples are not burned on QUIC races.
     JMeterUtils.setProperty("httpJettyClient.enableHttp1", "true");
     JMeterUtils.setProperty("httpJettyClient.enableHttp2", "false");
     JMeterUtils.setProperty("httpJettyClient.enableHttp3", "false");
+    // This test counts Jetty's Authentication list. Preemptive mode registers Results instead,
+    // leaving authentications empty (0) — and another unit test can leave preemptive=true in the
+    // shared JMeter properties (filesystem run order differs on Linux CI vs Windows).
+    JMeterUtils.setProperty("httpJettyClient.auth.preemptive", "false");
     HTTP2JettyClientTestIsolation.resetSharedClientState();
 
     server = new ServerBuilder().withHTTP1().withSSL().withBasicAuth().buildServer();
@@ -109,6 +115,7 @@ public class AuthStoreMemoryLeakRegressionTest extends HTTP2TestBase {
     restoreProperty("httpJettyClient.enableHttp1", originalEnableHttp1Property);
     restoreProperty("httpJettyClient.enableHttp2", originalEnableHttp2Property);
     restoreProperty("httpJettyClient.enableHttp3", originalEnableHttp3Property);
+    restoreProperty("httpJettyClient.auth.preemptive", originalAuthPreemptiveProperty);
   }
 
   private static void restoreProperty(String key, String originalValue) {
@@ -129,10 +136,12 @@ public class AuthStoreMemoryLeakRegressionTest extends HTTP2TestBase {
           .isTrue();
     }
 
-    int authentications = countAuthentications(mainHttpClient(client));
+    // H1-only profile samples via httpClientHttp1Only; registration fans out to every store.
+    int authentications = countAuthentications(http1OnlyClient(client));
     assertThat(authentications)
         .as("after %d samples the Jetty auth list must stay at the configured Auth Manager size, "
-            + "not grow per iteration (pre-fix it grew unboundedly)", SAMPLE_COUNT)
+            + "not grow per iteration (pre-fix it grew unboundedly). Size 0 usually means "
+            + "httpJettyClient.auth.preemptive was left true by another test.", SAMPLE_COUNT)
         .isEqualTo(1);
   }
 
@@ -143,8 +152,8 @@ public class AuthStoreMemoryLeakRegressionTest extends HTTP2TestBase {
     return result;
   }
 
-  private static HttpClient mainHttpClient(HTTP2JettyClient client) throws Exception {
-    Field field = HTTP2JettyClient.class.getDeclaredField("httpClient");
+  private static HttpClient http1OnlyClient(HTTP2JettyClient client) throws Exception {
+    Field field = HTTP2JettyClient.class.getDeclaredField("httpClientHttp1Only");
     field.setAccessible(true);
     return (HttpClient) field.get(client);
   }

--- a/src/test/java/com/blazemeter/jmeter/http2/core/AuthStoreMemoryLeakRegressionTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/AuthStoreMemoryLeakRegressionTest.java
@@ -1,0 +1,159 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.AUTH_PASSWORD;
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.AUTH_REALM;
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.AUTH_USERNAME;
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.HOST_NAME;
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.SERVER_PATH_200;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import com.blazemeter.jmeter.http2.sampler.JMeterTestUtils;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.List;
+import org.apache.jmeter.protocol.http.control.AuthManager;
+import org.apache.jmeter.protocol.http.control.AuthManager.Mechanism;
+import org.apache.jmeter.protocol.http.control.Authorization;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.util.JMeterUtils;
+import org.eclipse.jetty.client.AuthenticationStore;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Long runs with an Auth Manager used to append a new Jetty {@code Authentication} on every sample
+ * (no dedup in {@code HttpAuthenticationStore}). Memory then grew with iterations and never
+ * recycled until the thread finished.
+ *
+ * <p>Registration must stay idempotent without {@code clearAuthentications()} on every sample:
+ * clearing raced with in-flight 401 handling on the shared store under concurrent async samples.
+ */
+public class AuthStoreMemoryLeakRegressionTest extends HTTP2TestBase {
+
+  private static final int SAMPLE_COUNT = 40;
+
+  private HTTP2JettyClient client;
+  private HTTP2Sampler sampler;
+  private TeardownableServer server;
+  private String originalSharedThreadPoolProperty;
+  private String originalEnableHttp1Property;
+  private String originalEnableHttp2Property;
+  private String originalEnableHttp3Property;
+
+  @BeforeClass
+  public static void setupClass() {
+    JMeterTestUtils.setupJmeterEnv();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    originalSharedThreadPoolProperty = JMeterUtils.getProperty("httpJettyClient.sharedThreadPool");
+    originalEnableHttp1Property = JMeterUtils.getProperty("httpJettyClient.enableHttp1");
+    originalEnableHttp2Property = JMeterUtils.getProperty("httpJettyClient.enableHttp2");
+    originalEnableHttp3Property = JMeterUtils.getProperty("httpJettyClient.enableHttp3");
+    JMeterUtils.setProperty("httpJettyClient.sharedThreadPool", "false");
+    // Server is HTTP/1.1 only — keep HE/HTTP3 off so 40 samples are not burned on QUIC races.
+    JMeterUtils.setProperty("httpJettyClient.enableHttp1", "true");
+    JMeterUtils.setProperty("httpJettyClient.enableHttp2", "false");
+    JMeterUtils.setProperty("httpJettyClient.enableHttp3", "false");
+    HTTP2JettyClientTestIsolation.resetSharedClientState();
+
+    server = new ServerBuilder().withHTTP1().withSSL().withBasicAuth().buildServer();
+    server.start();
+    int port = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+
+    sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.GET);
+    sampler.setDomain(HOST_NAME);
+    sampler.setProtocol(HTTPConstants.PROTOCOL_HTTPS);
+    sampler.setPort(port);
+    sampler.setPath(SERVER_PATH_200);
+
+    Authorization authorization = new Authorization();
+    authorization.setURL(new URL(HTTPConstants.PROTOCOL_HTTPS, HOST_NAME, port,
+        SERVER_PATH_200).toString());
+    authorization.setUser(AUTH_USERNAME);
+    authorization.setPass(AUTH_PASSWORD);
+    authorization.setRealm(AUTH_REALM);
+    authorization.setMechanism(Mechanism.BASIC);
+    AuthManager authManager = new AuthManager();
+    authManager.addAuth(authorization);
+    sampler.setAuthManager(authManager);
+
+    client = new HTTP2JettyClient(false, "auth-store-leak",
+        HTTP2ClientProfileConfig.builder()
+            .enableHttp1(true)
+            .enableHttp2(false)
+            .enableHttp3(false)
+            .build());
+    client.start();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (client != null) {
+      client.stop();
+    }
+    if (server != null && server.isStarted()) {
+      server.stop();
+    }
+    restoreProperty("httpJettyClient.sharedThreadPool", originalSharedThreadPoolProperty);
+    restoreProperty("httpJettyClient.enableHttp1", originalEnableHttp1Property);
+    restoreProperty("httpJettyClient.enableHttp2", originalEnableHttp2Property);
+    restoreProperty("httpJettyClient.enableHttp3", originalEnableHttp3Property);
+  }
+
+  private static void restoreProperty(String key, String originalValue) {
+    if (originalValue == null) {
+      JMeterUtils.getJMeterProperties().remove(key);
+    } else {
+      JMeterUtils.setProperty(key, originalValue);
+    }
+  }
+
+  @Test
+  public void jettyAuthStoreMustNotGrowWithSampleCount() throws Exception {
+    for (int i = 0; i < SAMPLE_COUNT; i++) {
+      HTTPSampleResult result = client.sample(sampler,
+          buildResult(sampler), false, 0);
+      assertThat(result.isSuccessful())
+          .as("sample %d should authenticate", i)
+          .isTrue();
+    }
+
+    int authentications = countAuthentications(mainHttpClient(client));
+    assertThat(authentications)
+        .as("after %d samples the Jetty auth list must stay at the configured Auth Manager size, "
+            + "not grow per iteration (pre-fix it grew unboundedly)", SAMPLE_COUNT)
+        .isEqualTo(1);
+  }
+
+  private static HTTPSampleResult buildResult(HTTP2Sampler sampler) throws Exception {
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setURL(sampler.getUrl());
+    result.setHTTPMethod(sampler.getMethod());
+    return result;
+  }
+
+  private static HttpClient mainHttpClient(HTTP2JettyClient client) throws Exception {
+    Field field = HTTP2JettyClient.class.getDeclaredField("httpClient");
+    field.setAccessible(true);
+    return (HttpClient) field.get(client);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static int countAuthentications(HttpClient httpClient) throws Exception {
+    AuthenticationStore store = httpClient.getAuthenticationStore();
+    Field field = store.getClass().getDeclaredField("authentications");
+    field.setAccessible(true);
+    return ((List<?>) field.get(store)).size();
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/CompressionResourcesStopRegressionTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/CompressionResourcesStopRegressionTest.java
@@ -1,0 +1,57 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import java.lang.reflect.Field;
+import org.eclipse.jetty.util.compression.InflaterPool;
+import org.junit.Test;
+
+/**
+ * Gzip {@link InflaterPool} is created outside the HttpClient bean tree. Stopping the client used
+ * to leave the pool (and Brotli/Zstd Compression LifeCycles) running — one oversized pool per
+ * {@link HTTP2JettyClient} for the JVM lifetime of that wrapper.
+ */
+public class CompressionResourcesStopRegressionTest extends HTTP2TestBase {
+
+  @Test
+  public void stopMustShutDownGzipInflaterPool() throws Exception {
+    HTTP2JettyClient client = new HTTP2JettyClient(false, "compression-stop-test");
+    client.start();
+    // Force decoder init (Accept-Encoding path runs on first request; invoke ensure via sample
+    // preparation helpers by reflecting after a no-op configure through a started client).
+    forceDecoderInit(client);
+
+    InflaterPool pool = (InflaterPool) field(client, "gzipInflaterPool");
+    assertThat(pool).as("gzip inflater pool must be created").isNotNull();
+    assertThat(pool.isRunning()).isTrue();
+    assertThat(pool.getCapacity())
+        .as("pool capacity must stay small; 1024×N clients retained a huge high-water mark")
+        .isEqualTo(32);
+
+    client.stop();
+
+    assertThat(field(client, "gzipInflaterPool"))
+        .as("stop must drop the inflater pool reference")
+        .isNull();
+    assertThat(pool.isRunning())
+        .as("stop must stop the inflater pool LifeCycle")
+        .isFalse();
+    assertThat(field(client, "gzipCompression")).isNull();
+    assertThat(field(client, "brotliCompression")).isNull();
+    assertThat(field(client, "zstdCompression")).isNull();
+  }
+
+  private static void forceDecoderInit(HTTP2JettyClient client) throws Exception {
+    java.lang.reflect.Method ensure =
+        HTTP2JettyClient.class.getDeclaredMethod("ensureDecoderFactoriesInitialized");
+    ensure.setAccessible(true);
+    ensure.invoke(client);
+  }
+
+  private static Object field(HTTP2JettyClient client, String name) throws Exception {
+    Field field = HTTP2JettyClient.class.getDeclaredField(name);
+    field.setAccessible(true);
+    return field.get(client);
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/FutureListenerBufferReleaseRegressionTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/FutureListenerBufferReleaseRegressionTest.java
@@ -1,0 +1,113 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import org.eclipse.jetty.client.AbstractResponseListener;
+import org.eclipse.jetty.client.Response;
+import org.eclipse.jetty.client.Result;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.util.BufferUtil;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * After the body is copied into {@code ContentResponseWrapper}, Jetty's buffering listener used to
+ * keep a second full copy in {@code AbstractResponseListener.content} / {@code accumulator} until
+ * the listener was GC'd — doubling peak RAM for large async/embed responses and HE losers.
+ */
+public class FutureListenerBufferReleaseRegressionTest extends HTTP2TestBase {
+
+  @Test
+  public void onCompleteReleasesJettyContentCopyAfterWrapping() throws Exception {
+    HTTP2FutureResponseListener listener = new HTTP2FutureResponseListener(-1);
+    byte[] body = "x".repeat(64 * 1024).getBytes(StandardCharsets.UTF_8);
+
+    Field contentField = AbstractResponseListener.class.getDeclaredField("content");
+    contentField.setAccessible(true);
+    contentField.set(listener, body);
+
+    Response httpResponse = Mockito.mock(Response.class);
+    Mockito.when(httpResponse.getStatus()).thenReturn(200);
+    Mockito.when(httpResponse.getReason()).thenReturn("OK");
+    Mockito.when(httpResponse.getVersion()).thenReturn(HttpVersion.HTTP_1_1);
+    Mockito.when(httpResponse.getHeaders()).thenReturn(HttpFields.EMPTY);
+
+    Result result = Mockito.mock(Result.class);
+    Mockito.when(result.getResponse()).thenReturn(httpResponse);
+    Mockito.when(result.getFailure()).thenReturn(null);
+
+    listener.onComplete(result);
+
+    assertThat(listener.get()).isNotNull();
+    assertThat(listener.get().getContent()).isEqualTo(body);
+    assertThat(contentField.get(listener))
+        .as("listener must not keep a second full body after the wrapper owns it")
+        .isSameAs(BufferUtil.EMPTY_BYTES);
+  }
+
+  @Test
+  public void releaseAfterSampleMaterialisedDropsRequest() throws Exception {
+    HTTP2FutureResponseListener listener = new HTTP2FutureResponseListener(-1);
+    org.eclipse.jetty.client.Request request = Mockito.mock(org.eclipse.jetty.client.Request.class);
+    listener.setRequest(request);
+
+    // Seed a content response the way onComplete would, then materialise.
+    org.eclipse.jetty.client.ContentResponse contentResponse =
+        Mockito.mock(org.eclipse.jetty.client.ContentResponse.class);
+    listener.completeWith(contentResponse, System.currentTimeMillis(), System.currentTimeMillis());
+
+    listener.releaseAfterSampleMaterialised();
+
+    assertThat(listener.getRequest()).isNull();
+    java.lang.reflect.Field responseField =
+        HTTP2FutureResponseListener.class.getDeclaredField("response");
+    responseField.setAccessible(true);
+    assertThat(responseField.get(listener))
+        .as("materialised samples must not keep ContentResponse→Request on the listener")
+        .isNull();
+  }
+
+  @Test
+  public void failureOnlyOnCompleteMustReleaseTransportBuffers() throws Exception {
+    HTTP2FutureResponseListener listener = new HTTP2FutureResponseListener(-1);
+    byte[] body = "partial".getBytes(StandardCharsets.UTF_8);
+    Field contentField = AbstractResponseListener.class.getDeclaredField("content");
+    contentField.setAccessible(true);
+    contentField.set(listener, body);
+
+    Result result = Mockito.mock(Result.class);
+    Mockito.when(result.getResponse()).thenReturn(null);
+    Mockito.when(result.getFailure()).thenReturn(new java.io.IOException("boom"));
+
+    listener.onComplete(result);
+
+    assertThat(contentField.get(listener))
+        .as("failure-only HE/abort completion must still drop Jetty's content copy")
+        .isSameAs(BufferUtil.EMPTY_BYTES);
+  }
+
+  @Test
+  public void sealedAbortPathsMustNotThrowAlreadyReleased() {
+    HTTP2FutureResponseListener listener = new HTTP2FutureResponseListener(-1);
+    Response httpResponse = Mockito.mock(Response.class);
+    org.eclipse.jetty.client.ContentResponse contentResponse =
+        Mockito.mock(org.eclipse.jetty.client.ContentResponse.class);
+
+    // completeWith seals and releases; Jetty then notifies onFailure/onComplete for the abort.
+    listener.completeWith(contentResponse, System.currentTimeMillis(), System.currentTimeMillis());
+
+    assertThat(org.assertj.core.api.Assertions.catchThrowable(
+        () -> listener.onFailure(httpResponse, new java.util.concurrent.CancellationException())))
+        .isNull();
+    assertThat(org.assertj.core.api.Assertions.catchThrowable(
+        () -> listener.onComplete(Mockito.mock(Result.class))))
+        .isNull();
+    assertThat(org.assertj.core.api.Assertions.catchThrowable(
+        () -> listener.releaseAfterSampleMaterialised()))
+        .isNull();
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
@@ -838,12 +838,6 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
     softly.assertThat(result.getUrlAsString()).isEqualTo(createURL(path).toString());
   }
 
-  private void addJettyCookie(URI uri, String name, String value) {
-    HttpCookieStore cookieStore = client.getHttpClient().getHttpCookieStore();
-    assertNotNull(cookieStore);
-    cookieStore.add(uri, HttpCookie.from(name, value));
-  }
-
   private boolean hasJettyCookie(URI uri, String name) {
     HttpCookieStore cookieStore = client.getHttpClient().getHttpCookieStore();
     assertNotNull(cookieStore);
@@ -904,34 +898,17 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
   }
 
   @Test
-  public void shouldRemoveJettyCookieWhenJMeterOverridesValue() throws Exception {
+  public void jettyCookieStoreDoesNotRetainSetCookies() throws Exception {
+    // Transport cookie jar is Empty: JMeter CookieManager (or HeaderManager) owns cookies. A Default
+    // store used to keep every Set-Cookie on each protocol-variant HttpClient for the thread life.
     buildStartedServer();
-    CookieManager cookieManager = new CookieManager();
-    cookieManager.testStarted(HOST_NAME);
-    cookieManager.add(new Cookie("SOME_NAME", "NEW_VALUE", HOST_NAME, "/", true, 0));
-    sampler.setCookieManager(cookieManager);
-
-    URI uri = createURL(SERVER_PATH_200).toURI();
-    addJettyCookie(uri, "SOME_NAME", "OLD_VALUE");
-    assertThat(hasJettyCookie(uri, "SOME_NAME")).isTrue();
-
-    sampleWithGet(SERVER_PATH_200);
-
+    URI uri = createURL(SERVER_PATH_SET_COOKIES).toURI();
+    HttpCookieStore store = client.getHttpClient().getHttpCookieStore();
+    assertThat(store).isInstanceOf(HttpCookieStore.Empty.class);
+    assertThat(store.add(uri, HttpCookie.from("SOME_NAME", "OLD_VALUE"))).isFalse();
     assertThat(hasJettyCookie(uri, "SOME_NAME")).isFalse();
-  }
 
-  @Test
-  public void shouldClearJettyStoreWhenJMeterCookieManagerIsEmpty() throws Exception {
-    buildStartedServer();
-    CookieManager cookieManager = new CookieManager();
-    cookieManager.testStarted(HOST_NAME);
-    sampler.setCookieManager(cookieManager);
-
-    URI uri = createURL(SERVER_PATH_200).toURI();
-    addJettyCookie(uri, "SOME_NAME", "OLD_VALUE");
-    assertThat(hasJettyCookie(uri, "SOME_NAME")).isTrue();
-
-    sampleWithGet(SERVER_PATH_200);
+    sampleWithGet(SERVER_PATH_SET_COOKIES);
 
     assertThat(hasJettyCookie(uri, "SOME_NAME")).isFalse();
   }

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientTest.java
@@ -984,6 +984,7 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
 
   @Test
   public void shouldReturnSuccessBasicAuthSampleResultWhenHeaderIsSet() throws Exception {
+    String previousPreemptive = JMeterUtils.getProperty("httpJettyClient.auth.preemptive");
     server = new ServerBuilder()
         .withHTTP1()
         .withSSL()
@@ -994,12 +995,20 @@ public class HTTP2JettyClientTest extends HTTP2TestBase {
     Mutable httpFields = hostHeader()
         .add(HttpHeader.AUTHORIZATION,
             "Basic " + base64Encode(AUTH_USERNAME + ":" + AUTH_PASSWORD));
-    JMeterUtils.setProperty("httpJettyClient.auth.preemptive", "true");
-    configureAuthManager(Mechanism.BASIC);
-    HTTPSampleResult expected = buildResult(true, Code.OK,
-      httpFields, null, null, createURL(SERVER_PATH_200), HTTPConstants.GET);
-    expected.setResponseData(SERVER_RESPONSE, StandardCharsets.UTF_8.name());
-    validateResponse(sampleWithGet(), expected);
+    try {
+      JMeterUtils.setProperty("httpJettyClient.auth.preemptive", "true");
+      configureAuthManager(Mechanism.BASIC);
+      HTTPSampleResult expected = buildResult(true, Code.OK,
+          httpFields, null, null, createURL(SERVER_PATH_200), HTTPConstants.GET);
+      expected.setResponseData(SERVER_RESPONSE, StandardCharsets.UTF_8.name());
+      validateResponse(sampleWithGet(), expected);
+    } finally {
+      if (previousPreemptive == null) {
+        JMeterUtils.getJMeterProperties().remove("httpJettyClient.auth.preemptive");
+      } else {
+        JMeterUtils.setProperty("httpJettyClient.auth.preemptive", previousPreemptive);
+      }
+    }
   }
 
   private String base64Encode(String input) {

--- a/src/test/java/com/blazemeter/jmeter/http2/core/Http3ExplorationPolicyTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/Http3ExplorationPolicyTest.java
@@ -25,14 +25,13 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Pins when HTTP/3 is attempted, which is the difference between discovering HTTP/3 on a first
- * contact and turning an unreachable QUIC path into a stalled request.
+ * Pins when HTTP/3 is attempted, following Chromium's discovery model: with HTTP/2 (or HTTP/1.1)
+ * available, the first contact stays on TCP so {@code Alt-Svc} can be learned; HTTP/3 is used only
+ * after the cache says the origin supports it. Blind QUIC exploration on unknown origins is not
+ * done.
  *
- * <p>The decision depends on what is known about the origin, not on the request: an origin worth
- * attempting HTTP/3 on is attempted regardless of method, so neither is a POST to a known HTTP/3
- * site downgraded, nor is an origin first contacted by a POST left unable to ever learn HTTP/3.
- * Whether the attempt is <em>raced</em> against HTTP/2 is a separate decision, covered by
- * {@link ProtocolFlagClientSelectionTest} and the race tests.
+ * <p>Exception: prior knowledge (also auto-enabled when only HTTP/3 is configured) asserts H3 up
+ * front. Whether an H3 attempt is <em>raced</em> against HTTP/2 is a separate decision.
  */
 public class Http3ExplorationPolicyTest extends HTTP2TestBase {
 
@@ -57,24 +56,28 @@ public class Http3ExplorationPolicyTest extends HTTP2TestBase {
     setBoolean(client, "http3PriorKnowledgeEnabled", false);
   }
 
-  // --- first contact -------------------------------------------------------------------------
+  // --- first contact (TCP first) -------------------------------------------------------------
 
   @Test
-  public void shouldExploreHttp3OnFirstContact() throws Exception {
-    assertTrue(shouldAttemptHttp3(TLS_URI, true));
+  public void shouldNotExploreHttp3OnFirstContactWhenTcpAvailable() throws Exception {
+    assertFalse("unknown origins must learn Alt-Svc over HTTP/2 first",
+        shouldAttemptHttp3(TLS_URI, true));
   }
 
-
-  /**
-   * The same rule seen through the real entry point, where the method is known: a POST to an origin
-   * nothing is known about still goes to the HTTP/3 client. It gets no concurrent HTTP/2 attempt to
-   * cover it, so what makes this safe is that the handshake has its own short deadline and that the
-   * fallback only fires when the connection could not be established - the request never reached
-   * the wire, so resending it cannot repeat a side effect. Without this, an origin first contacted
-   * by a POST could never learn HTTP/3 at all.
-   */
   @Test
-  public void shouldExploreHttp3ForPostToUnknownOrigin() throws Exception {
+  public void shouldUseHttp2ClientForGetToUnknownOrigin() throws Exception {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.GET);
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setURL(TLS_URI.toURL());
+    result.setHTTPMethod(HTTPConstants.GET);
+
+    assertSame("first contact must use the no-H3 client so Alt-Svc can be learned",
+        field("httpClientNoH3"), resolveClientForRequest(sampler, result));
+  }
+
+  @Test
+  public void shouldUseHttp2ClientForPostToUnknownOrigin() throws Exception {
     HTTP2Sampler sampler = new HTTP2Sampler();
     sampler.setMethod(HTTPConstants.POST);
     sampler.addArgument("test1", "value1");
@@ -82,16 +85,23 @@ public class Http3ExplorationPolicyTest extends HTTP2TestBase {
     result.setURL(TLS_URI.toURL());
     result.setHTTPMethod(HTTPConstants.POST);
 
-    assertSame("a POST to an unknown origin must still explore HTTP/3",
-        field("httpClient"), resolveClientForRequest(sampler, result));
+    assertSame("a POST to an unknown origin must not speculative-explore HTTP/3",
+        field("httpClientNoH3"), resolveClientForRequest(sampler, result));
   }
 
-  /**
-   * And the limit of that: a body read from a file cannot be rewound, so the fallback has nothing to
-   * hand the retry and the request would have no way back once HTTP/3 failed. Such a request must
-   * not be used to explore an unknown origin - it goes over HTTP/2, and exploration is left to the
-   * requests that can afford it.
-   */
+  @Test
+  public void shouldUseHttp1WhenHttp2DisabledAndOriginUnknown() throws Exception {
+    setBoolean(client, "enableHttp2", false);
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.GET);
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setURL(TLS_URI.toURL());
+    result.setHTTPMethod(HTTPConstants.GET);
+
+    assertSame("with HTTP/2 off, first contact must use HTTP/1.1 to learn Alt-Svc",
+        field("httpClientHttp1Only"), resolveClientForRequest(sampler, result));
+  }
+
   @Test
   public void shouldNotExploreHttp3ForRequestWithFileBody() throws Exception {
     HTTP2Sampler sampler = new HTTP2Sampler();
@@ -102,8 +112,7 @@ public class Http3ExplorationPolicyTest extends HTTP2TestBase {
     result.setURL(TLS_URI.toURL());
     result.setHTTPMethod(HTTPConstants.POST);
 
-    assertSame("a file body cannot be replayed, so it must not explore HTTP/3",
-        field("httpClientNoH3"), resolveClientForRequest(sampler, result));
+    assertSame(field("httpClientNoH3"), resolveClientForRequest(sampler, result));
   }
 
   // --- already known to speak HTTP/3 ---------------------------------------------------------
@@ -114,6 +123,20 @@ public class Http3ExplorationPolicyTest extends HTTP2TestBase {
 
     assertTrue("a POST to a site known to speak HTTP/3 must still use HTTP/3",
         shouldAttemptHttp3(TLS_URI, true));
+  }
+
+  @Test
+  public void shouldUseHttp3AfterAltSvcWhenHttp2Disabled() throws Exception {
+    setBoolean(client, "enableHttp2", false);
+    cacheAltSvc(true, TimeUnit.MINUTES.toMillis(10), 0L);
+
+    assertTrue(shouldAttemptHttp3(TLS_URI, true));
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.GET);
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setURL(TLS_URI.toURL());
+    result.setHTTPMethod(HTTPConstants.GET);
+    assertSame(field("httpClient"), resolveClientForRequest(sampler, result));
   }
 
   @Test
@@ -134,26 +157,23 @@ public class Http3ExplorationPolicyTest extends HTTP2TestBase {
   }
 
   @Test
-  public void shouldExploreAgainOnceCachedEntryExpired() throws Exception {
+  public void shouldRediscoverViaTcpOnceCachedEntryExpired() throws Exception {
     cacheAltSvc(true, -1L, 0L);
 
-    assertTrue("an expired answer must not be trusted; explore again",
+    assertFalse("expired Alt-Svc must not reopen QUIC; learn again over TCP",
         shouldAttemptHttp3(TLS_URI, true));
   }
 
-  /**
-   * A failure on an origin that never advertised Alt-Svc has to be remembered too, otherwise every
-   * later request explores an origin whose HTTP/3 just failed.
-   */
   @Test
-  public void shouldRecordCooldownForExploredOriginWithoutAltSvcEntry() throws Exception {
+  public void shouldRecordCooldownAfterMarkedBroken() throws Exception {
+    cacheAltSvc(true, TimeUnit.MINUTES.toMillis(10), 0L);
     assertTrue(shouldAttemptHttp3(TLS_URI, true));
 
     Method mark = HTTP2JettyClient.class.getDeclaredMethod("markHttp3Broken", URI.class);
     mark.setAccessible(true);
     mark.invoke(client, TLS_URI);
 
-    assertFalse("the cooldown must apply even though the origin had no Alt-Svc entry",
+    assertFalse("the cooldown must apply after HTTP/3 failed for a cached origin",
         shouldAttemptHttp3(TLS_URI, true));
   }
 
@@ -180,6 +200,20 @@ public class Http3ExplorationPolicyTest extends HTTP2TestBase {
     setBoolean(client, "http3PriorKnowledgeEnabled", true);
 
     assertTrue(shouldAttemptHttp3(TLS_URI, true));
+  }
+
+  @Test
+  public void shouldUseHttp3ClientWhenOnlyHttp3Enabled() throws Exception {
+    setBoolean(client, "enableHttp1", false);
+    setBoolean(client, "enableHttp2", false);
+    setBoolean(client, "http3PriorKnowledgeEnabled", true);
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.GET);
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setURL(TLS_URI.toURL());
+    result.setHTTPMethod(HTTPConstants.GET);
+
+    assertSame(field("httpClient"), resolveClientForRequest(sampler, result));
   }
 
   // --- logging policy: exploration vs indicated HTTP/3 ---------------------------------------
@@ -211,16 +245,18 @@ public class Http3ExplorationPolicyTest extends HTTP2TestBase {
   }
 
   @Test
-  public void shouldClassifyConnectTimeoutAsExplorationOnFirstContact() throws Exception {
+  public void shouldNotClassifyConnectTimeoutAsExplorationOnFirstContact() throws Exception {
+    // First contact no longer explores H3, so ATTR_HTTP3_ATTEMPTED on an unknown origin is not an
+    // "exploration" path the policy owns — isHttp3Expected is false and attempted may be unset.
     Request request = mockRequestWithHttp3Attempted(TLS_URI);
     Throwable cause = new java.net.SocketTimeoutException("connect timeout");
 
+    // With no cache, timeout on an H3 attempt is still classified as exploration (not "expected").
     assertTrue(isHttp3ExplorationConnectTimeout(cause, request));
   }
 
   @Test
-  public void shouldNotClassifyConnectTimeoutAsExplorationWhenHttp3WasIndicated()
-      throws Exception {
+  public void shouldNotClassifyConnectTimeoutAsExplorationWhenAltSvcIndicated() throws Exception {
     cacheAltSvc(true, TimeUnit.MINUTES.toMillis(10), 0L);
     Request request = mockRequestWithHttp3Attempted(TLS_URI);
     Throwable cause = new java.net.SocketTimeoutException("connect timeout");
@@ -228,7 +264,35 @@ public class Http3ExplorationPolicyTest extends HTTP2TestBase {
     assertFalse(isHttp3ExplorationConnectTimeout(cause, request));
   }
 
-  // --- helpers --------------------------------------------------------------------------------
+  private Request mockRequestWithHttp3Attempted(URI uri) {
+    Request request = mock(Request.class);
+    when(request.getURI()).thenReturn(uri);
+    Map<String, Object> attrs = new HashMap<>();
+    attrs.put("bzm.http3.attempted", Boolean.TRUE);
+    when(request.getAttributes()).thenReturn(attrs);
+    return request;
+  }
+
+  private boolean shouldAttemptHttp3(URI uri, boolean recoverable) throws Exception {
+    Method m = HTTP2JettyClient.class.getDeclaredMethod(
+        "shouldAttemptHttp3", URI.class, boolean.class);
+    m.setAccessible(true);
+    return (Boolean) m.invoke(client, uri, recoverable);
+  }
+
+  private boolean isHttp3Expected(URI uri) throws Exception {
+    Method m = HTTP2JettyClient.class.getDeclaredMethod("isHttp3Expected", URI.class);
+    m.setAccessible(true);
+    return (Boolean) m.invoke(client, uri);
+  }
+
+  private boolean isHttp3ExplorationConnectTimeout(Throwable cause, Request request)
+      throws Exception {
+    Method m = HTTP2JettyClient.class.getDeclaredMethod(
+        "isHttp3ExplorationConnectTimeout", Throwable.class, Request.class);
+    m.setAccessible(true);
+    return (Boolean) m.invoke(client, cause, request);
+  }
 
   private Object resolveClientForRequest(HTTP2Sampler sampler, HTTPSampleResult result)
       throws Exception {
@@ -244,34 +308,10 @@ public class Http3ExplorationPolicyTest extends HTTP2TestBase {
     return f.get(client);
   }
 
-  private boolean shouldAttemptHttp3(URI uri, boolean recoverable) throws Exception {
-    Method m = HTTP2JettyClient.class.getDeclaredMethod(
-        "shouldAttemptHttp3", URI.class, boolean.class);
-    m.setAccessible(true);
-    return (boolean) m.invoke(client, uri, recoverable);
-  }
-
-  private boolean isHttp3Expected(URI uri) throws Exception {
-    Method m = HTTP2JettyClient.class.getDeclaredMethod("isHttp3Expected", URI.class);
-    m.setAccessible(true);
-    return (boolean) m.invoke(client, uri);
-  }
-
-  private boolean isHttp3ExplorationConnectTimeout(Throwable cause, Request request)
-      throws Exception {
-    Method m = HTTP2JettyClient.class.getDeclaredMethod(
-        "isHttp3ExplorationConnectTimeout", Throwable.class, Request.class);
-    m.setAccessible(true);
-    return (boolean) m.invoke(client, cause, request);
-  }
-
-  private Request mockRequestWithHttp3Attempted(URI uri) {
-    Request request = mock(Request.class);
-    Map<String, Object> attributes = new HashMap<>();
-    attributes.put("bzm.http3.attempted", Boolean.TRUE);
-    when(request.getURI()).thenReturn(uri);
-    when(request.getAttributes()).thenReturn(attributes);
-    return request;
+  private void setBoolean(HTTP2JettyClient target, String name, boolean value) throws Exception {
+    Field f = HTTP2JettyClient.class.getDeclaredField(name);
+    f.setAccessible(true);
+    f.setBoolean(target, value);
   }
 
   private void cacheAltSvc(boolean h3, long expiresInMs, long brokenForMs) throws Exception {
@@ -301,16 +341,9 @@ public class Http3ExplorationPolicyTest extends HTTP2TestBase {
   }
 
   @SuppressWarnings("unchecked")
-  private static Map<String, Object> altSvcCache() throws Exception {
+  private Map<String, Object> altSvcCache() throws Exception {
     Field f = HTTP2JettyClient.class.getDeclaredField("ALT_SVC_CACHE");
     f.setAccessible(true);
     return (Map<String, Object>) f.get(null);
-  }
-
-  private static void setBoolean(HTTP2JettyClient client, String name, boolean value)
-      throws Exception {
-    Field f = HTTP2JettyClient.class.getDeclaredField(name);
-    f.setAccessible(true);
-    f.setBoolean(client, value);
   }
 }

--- a/src/test/java/com/blazemeter/jmeter/http2/core/ProtocolFlagClientSelectionTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/ProtocolFlagClientSelectionTest.java
@@ -44,15 +44,17 @@ public class ProtocolFlagClientSelectionTest extends HTTP2TestBase {
   }
 
   /**
-   * With HTTP/2 off and HTTP/3 on there is no race to run and no HTTP/2 client to fall through to:
-   * the request has to go out on HTTP/3, and only a failure there may fall back to HTTP/1.1.
+   * With HTTP/2 off and HTTP/3 on, first contact still uses HTTP/1.1 so Alt-Svc can be learned
+   * (Chromium-like). HTTP/3 is selected only after the cache says h3, or with prior knowledge /
+   * HTTP/3-only.
    */
   @Test
-  public void shouldUseHttp3ForTlsWhenHttp2DisabledAndHttp3Enabled() throws Exception {
+  public void shouldUseHttp1ForTlsWhenHttp2DisabledAndHttp3EnabledWithoutAltSvc() throws Exception {
     HTTP2JettyClient client = new HTTP2JettyClient();
     setFlags(client, true, false, true);
 
-    assertSame(field(client, "httpClient"),
+    assertSame("first contact with HTTP/2 off must use HTTP/1.1 to learn Alt-Svc",
+        field(client, "httpClientHttp1Only"),
         selectHttpClient(client, URI.create("https://example.com/x")));
   }
 
@@ -61,6 +63,7 @@ public class ProtocolFlagClientSelectionTest extends HTTP2TestBase {
   public void shouldUseHttp3ForTlsWhenOnlyHttp3Enabled() throws Exception {
     HTTP2JettyClient client = new HTTP2JettyClient();
     setFlags(client, false, false, true);
+    setField(client, "http3PriorKnowledgeEnabled", true);
 
     assertSame(field(client, "httpClient"),
         selectHttpClient(client, URI.create("https://example.com/x")));

--- a/src/test/java/com/blazemeter/jmeter/http2/core/SslClientCertAliasSupportTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/SslClientCertAliasSupportTest.java
@@ -138,6 +138,25 @@ public class SslClientCertAliasSupportTest extends HTTP2TestBase {
     }
   }
 
+  @Test
+  public void clearEngineRemovesAliasBinding() throws Exception {
+    JMeterJettySslContextFactory factory = new JMeterJettySslContextFactory();
+    factory.start();
+    try {
+      SSLEngine engine = factory.getSslContext().createSSLEngine();
+      int before = SslClientCertAliasContext.engineAliasCountForTests();
+      SslClientCertAliasContext.bindEngine(engine, KEY_ALIAS);
+      assertThat(SslClientCertAliasContext.resolveFromEngine(engine)).isEqualTo(KEY_ALIAS);
+      assertThat(SslClientCertAliasContext.engineAliasCountForTests()).isEqualTo(before + 1);
+
+      SslClientCertAliasContext.clearEngine(engine);
+      assertThat(SslClientCertAliasContext.resolveFromEngine(engine)).isNull();
+      assertThat(SslClientCertAliasContext.engineAliasCountForTests()).isEqualTo(before);
+    } finally {
+      factory.stop();
+    }
+  }
+
   private static void restoreProperty(String key, String value) {
     if (value == null) {
       System.clearProperty(key);

--- a/src/test/java/com/blazemeter/jmeter/http2/integration/HTTP3HappyEyeballsIntegrationTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/integration/HTTP3HappyEyeballsIntegrationTest.java
@@ -83,11 +83,8 @@ public class HTTP3HappyEyeballsIntegrationTest extends HTTP2TestBase {
       HTTP2JettyClient client = new HTTP2JettyClient(false, "IT-HTTP3-HE-NoRecent");
       try {
         client.start();
-        // Setup: HTTP/2 has to answer this first sample, so its Alt-Svc is cached and no HTTP/3
-        // success is recorded - both are preconditions for the halved stagger asserted below.
-        // HTTP/3 is slowed right down for it because first contact now explores HTTP/3 with the
-        // full stagger: at its normal 150ms it would answer before HTTP/2 is due to start at 200ms
-        // and win, leaving nothing cached and the delay at its base value.
+        // Setup: first contact is HTTP/2 (TCP-first / Alt-Svc discovery). Slow HTTP/3 so it cannot
+        // race-win this sample before Alt-Svc is cached from the HTTP/2 response.
         h3DelayMs.set(1000L);
         HTTPSampleResult first = sample(client, sampler, url);
         assertThat(first.isSuccessful()).isTrue();
@@ -166,8 +163,8 @@ public class HTTP3HappyEyeballsIntegrationTest extends HTTP2TestBase {
       HTTP2JettyClient client = new HTTP2JettyClient(false, "IT-HTTP3-HE-Recent");
       try {
         client.start();
-        // Phase A: establish Alt-Svc and force one confirmed H3 success first. No protocol is
-        // asserted on this first sample: first contact with an unknown origin explores HTTP/3, so
+        // Phase A: establish Alt-Svc over HTTP/2 first (TCP-first discovery). No protocol is
+        // asserted on this first sample beyond success; then force one confirmed H3 success.
         // either side of the race may win it. The warmup loop below is what guarantees the
         // confirmed HTTP/3 success this test needs.
         HTTPSampleResult first = sample(client, sampler, url);

--- a/src/test/java/com/blazemeter/jmeter/http2/sampler/AsyncListenerReleaseRegressionTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/sampler/AsyncListenerReleaseRegressionTest.java
@@ -1,0 +1,99 @@
+package com.blazemeter.jmeter.http2.sampler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.core.HTTP2JettyClient;
+import java.net.URL;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.eclipse.jetty.client.Request;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Async completion used to keep {@code asyncListener} (unlimited Jetty buffer) until the next
+ * iteration, pinning large response bodies across the whole loop.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AsyncListenerReleaseRegressionTest extends HTTP2TestBase {
+
+  @Mock
+  private HTTP2JettyClient client;
+  private HTTP2Sampler sampler;
+
+  @BeforeClass
+  public static void setupClass() {
+    JMeterTestUtils.setupJmeterEnv();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    sampler = new HTTP2Sampler(() -> client);
+    sampler.setSyncRequest(false);
+    sampler.setMethod(HTTPConstants.GET);
+    sampler.setDomain("example.com");
+    sampler.setProtocol(HTTPConstants.PROTOCOL_HTTPS);
+    sampler.setPath("/");
+
+    when(client.getMaxBufferSize()).thenReturn(1024 * 1024);
+    when(client.getRequestTimeout()).thenReturn(0);
+    when(client.dispatchAsync(any(), any(), any())).thenReturn(mock(Request.class));
+  }
+
+  @Test
+  public void asyncCompletionMustDropFutureListenerImmediately() throws Exception {
+    HTTPSampleResult pending = new HTTPSampleResult();
+    pending.setURL(new URL("https://example.com/"));
+    pending.setHTTPMethod(HTTPConstants.GET);
+    pending.setSuccessful(true);
+    pending.setResponseCode("200");
+    when(client.sampleFromListener(any(), any(), anyBoolean(), anyInt(), any()))
+        .thenReturn(pending);
+
+    URL url = new URL("https://example.com/");
+    assertThat(sampler.sample(url, HTTPConstants.GET, false, 1)).isNull();
+    assertThat(sampler.getFutureResponseListener())
+        .as("dispatch publishes the listener for the controller to wait on")
+        .isNotNull();
+
+    HTTPSampleResult result = sampler.sample(url, HTTPConstants.GET, false, 1);
+    assertThat(result).isSameAs(pending);
+    assertThat(sampler.getFutureResponseListener())
+        .as("listener must be released right after completion, not held until iterationStart")
+        .isNull();
+    // Field retention: sample() returns the result to JMeterThread; the sampler must not keep its
+    // own reference until the next iterationStart (that pinned every completed body for the rest
+    // of an HTTP2Controller iteration).
+    assertThat(samplerResultField(sampler))
+        .as("sampler.result must be cleared in the completion finally")
+        .isNull();
+  }
+
+  @Test
+  public void clearPendingSampleStateMustDropListenerAndResult() throws Exception {
+    URL url = new URL("https://example.com/");
+    assertThat(sampler.sample(url, HTTPConstants.GET, false, 1)).isNull();
+    assertThat(sampler.getFutureResponseListener()).isNotNull();
+
+    sampler.clearPendingSampleState();
+
+    assertThat(sampler.getFutureResponseListener()).isNull();
+    assertThat(samplerResultField(sampler)).isNull();
+  }
+
+  private static HTTPSampleResult samplerResultField(HTTP2Sampler sampler) throws Exception {
+    java.lang.reflect.Field field = HTTP2Sampler.class.getDeclaredField("result");
+    field.setAccessible(true);
+    return (HTTPSampleResult) field.get(sampler);
+  }
+}

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -9,18 +9,19 @@
     </File>
   </Appenders>
   <Loggers>
-    <!-- Set logging level for our plugin to DEBUG to capture ALL messages -->
+    <!-- Plugin code stays DEBUG for diagnosis; shaded Jetty must not inherit that. -->
     <Logger name="com.blazemeter.jmeter.http2" level="DEBUG" additivity="false">
       <AppenderRef ref="Console"/>
       <AppenderRef ref="File"/>
     </Logger>
-    <!-- Set logging level for Jetty to INFO to avoid excessive test logs -->
+    <!-- Shade relocates Jetty under this package; without this override it floods DEBUG. -->
+    <Logger name="com.blazemeter.jmeter.http2.shaded.org.eclipse.jetty" level="INFO"
+        additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="File"/>
+    </Logger>
+    <!-- Unshaded Jetty (test servers / direct deps) also at INFO. -->
     <Logger name="org.eclipse.jetty" level="INFO"/>
-    <!-- Set logging level for HTTP/2 specific classes to DEBUG -->
-    <Logger name="org.eclipse.jetty.http2" level="DEBUG"/>
-    <Logger name="org.eclipse.jetty.http2.client" level="DEBUG"/>
-    <Logger name="org.eclipse.jetty.http2.client.transport" level="DEBUG"/>
-    <!-- Set logging level for JMeter to INFO -->
     <Logger name="org.apache.jmeter" level="INFO"/>
     <Root level="INFO">
       <AppenderRef ref="Console"/>


### PR DESCRIPTION
This pull request introduces several important improvements to memory management, resource cleanup, and protocol cache handling in the HTTP plugin. The main changes address memory leaks and resource retention issues by ensuring buffers and caches are properly released or capped, and by adding explicit cache management methods. These updates help prevent excessive memory usage and improve the stability of long-running or high-throughput tests.

**Memory and Buffer Management:**
- Added logic to release Jetty transport buffers in `HTTP2FutureResponseListener` to avoid retaining unnecessary copies of response bodies and request graphs, preventing memory leaks after sample materialization, cancellation, or failed/raced requests. [[1]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aR53-R59) [[2]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aR132-R134) [[3]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aR148) [[4]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aR200) [[5]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aR264-R271) [[6]](diffhunk://#diff-a859a204b4d9be710288ee1d8eb8db20028be35e69a37af26634e9ea85bf747aR398-R439)
- Updated `HTTP2JettyClient` to cap the pooled buffer memory by introducing a configurable maximum for the `ArrayByteBufferPool`, and provided a method to clear the buffer pool. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR168-R175) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL299-R332) [[3]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL733-R782)

**Protocol Cache Management:**
- Introduced soft limits and explicit TTL-based pruning for protocol negotiation caches (Alt-Svc, HTTP/1.1-only, H2C, and HTTP/3 exploration), including static methods to clear or prune expired entries and prevent unbounded cache growth. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR215-R224) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR1499-R1540)

**Compression and Decoder Resource Handling:**
- Added explicit management and capping of the gzip `InflaterPool` and other compression-related resources to prevent retention of large pools per thread. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR168-R175) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR276-R280)

**Transaction Sample Lifecycle Improvements:**
- Ensured that completed parent transaction samples are released from the `TestCompiler` map after listeners and assertions have run, mirroring upstream JMeter fixes and preventing retention of large sample trees.

**Async Sample Cleanup:**
- Ensured that pending async HTTP/2 samples are fully cleared, including dropping references to response/request graphs, when an iteration is aborted.