### PR TITLE
Fixed an issue when reaching timeout in subsample setting double time…

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -636,8 +636,8 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
     err.setHTTPMethod(HTTPConstants.GET);
     long endedAtMs = System.currentTimeMillis();
     long elapsedMs = Math.max(0L, endedAtMs - startedAtMs);
-    // Stamp end = now, start = now - elapsed (same contract as a real timed-out HC4 sample).
-    err.setStampAndTime(endedAtMs, elapsedMs);
+    // SampleResult.setStampAndTime(stamp, elapsed) treats stamp as start (end = stamp + elapsed).
+    err.setStampAndTime(startedAtMs, elapsedMs);
     err.setConnectTime(0L);
     err.setLatency(0L);
     return errorResult(new SocketTimeoutException("Read timed out"), err);


### PR DESCRIPTION
This pull request makes a small but important adjustment to how sample timing is recorded for embedded timeout error results in the `HTTP2Sampler` class. The change ensures that the sample's start and elapsed time are set consistently with how `SampleResult.setStampAndTime` interprets its parameters.

- Corrected the call to `setStampAndTime` so that the `startedAtMs` timestamp is used as the sample start time, aligning with the method's contract and improving timing accuracy for timeout error samples in `HTTP2Sampler.java`.… elapsed on parent sampler.