### PR TITLE
Add support for DNSCacheManager

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -60,6 +60,7 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.conn.DnsResolver;
 import org.apache.jmeter.protocol.http.control.AuthManager;
 import org.apache.jmeter.protocol.http.control.Authorization;
 import org.apache.jmeter.protocol.http.control.Cookie;
@@ -317,6 +318,12 @@ public class HTTP2JettyClient {
    * {@code findAuthentication} (realm/URI matching quirks) and prevents per-sample list growth.
    */
   private final Set<String> registeredAuthFingerprints = ConcurrentHashMap.newKeySet();
+  /**
+   * The sampler's DNS Cache Manager, or {@code null} when the plan has none. Held so
+   * {@link #configureHttpClient} can install {@link JMeterDnsSocketAddressResolver} on every
+   * protocol-variant client before any of them is started.
+   */
+  private final DnsResolver dnsResolver;
 
   public HTTP2JettyClient(boolean http1UpgradeRequired, String name) {
     this(http1UpgradeRequired, name, null);
@@ -324,6 +331,12 @@ public class HTTP2JettyClient {
 
   public HTTP2JettyClient(boolean http1UpgradeRequired, String name,
                           HTTP2ClientProfileConfig profileConfig) {
+    this(http1UpgradeRequired, name, profileConfig, null);
+  }
+
+  public HTTP2JettyClient(boolean http1UpgradeRequired, String name,
+                          HTTP2ClientProfileConfig profileConfig, DnsResolver dnsResolver) {
+    this.dnsResolver = dnsResolver;
     loadProperties(profileConfig);
     lowLevelDebug(PLUGIN_BUILD_TAG);
 
@@ -3348,6 +3361,7 @@ public class HTTP2JettyClient {
 
   private void configureHttpClient(HttpClient client, ClientConnector connector) {
     client.setUserAgentField(null);
+    configureDnsResolution(client);
     connector.setByteBufferPool(this.bufferPool);
     client.setMaxRequestsQueuedPerDestination(maxRequestsQueuedPerDestination);
     client.setMaxConnectionsPerDestination(maxConnectionsPerDestination);
@@ -3364,6 +3378,23 @@ public class HTTP2JettyClient {
     if (LowLevelDebugLog.isEnabled()) {
       addConnectionLogging(client);
     }
+  }
+
+  /**
+   * Routes host name resolution through the plan's DNS Cache Manager, when there is one.
+   *
+   * <p>With no manager configured nothing is set and {@code HttpClient.doStart} installs its own
+   * {@code SocketAddressResolver.Async}, which is the same default {@code HTTPHC4Impl} falls back
+   * to ({@code SystemDefaultDnsResolver}). Under a proxy this still resolves the proxy host rather
+   * than the target host, because Jetty resolves {@code HttpDestination.resolveOrigin()} - again
+   * matching HC4, which connects to the proxy hop of the route.
+   */
+  private void configureDnsResolution(HttpClient client) {
+    if (dnsResolver == null) {
+      return;
+    }
+    client.setSocketAddressResolver(new JMeterDnsSocketAddressResolver(dnsResolver,
+        client::getExecutor, client::getScheduler, client.getAddressResolutionTimeout()));
   }
 
   private static void addConnectionLogging(HttpClient client) {

--- a/src/main/java/com/blazemeter/jmeter/http2/core/JMeterDnsSocketAddressResolver.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/JMeterDnsSocketAddressResolver.java
@@ -1,0 +1,136 @@
+package com.blazemeter.jmeter.http2.core;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import org.apache.http.conn.DnsResolver;
+import org.eclipse.jetty.util.Promise;
+import org.eclipse.jetty.util.SocketAddressResolver;
+import org.eclipse.jetty.util.thread.Scheduler;
+
+/**
+ * Resolves host names through JMeter's DNS Cache Manager instead of {@code InetAddress}, so a test
+ * plan's custom DNS servers, static host entries and per-thread DNS cache apply to this plugin
+ * exactly as they do to {@code HTTPHC4Impl}.
+ *
+ * <p>{@code DNSCacheManager} is an {@code org.apache.http.conn.DnsResolver}, which is what
+ * {@code HTTPHC4Impl} hands to its connection operator on the one-time client init. This class is
+ * the Jetty-side equivalent: {@code HttpClient} resolves through a {@link SocketAddressResolver},
+ * and installing one is enough to cover every protocol, because HTTP/1.1, h2, h2c and HTTP/3 all
+ * reach the network through {@code HttpClient.newConnection}.
+ *
+ * <p>Deliberately modelled on {@link SocketAddressResolver.Async}, which it replaces: the lookup
+ * runs on the client executor rather than on the caller (which may be a selector thread), and a
+ * scheduled task fails the promise if the lookup outlives the timeout. The guard is not optional
+ * here - JMeter never calls {@code DNSCacheManager.setTimeoutMs}, so a custom resolver inherits
+ * dnsjava's own retry behaviour and a black-holed DNS server would otherwise pin an executor
+ * thread with nothing failing the request.
+ *
+ * <p>The executor and scheduler are read lazily because the resolver is installed while the
+ * {@code HttpClient} is still being built: {@code HttpClient.doStart} only creates its default
+ * {@code Async} resolver when none was set, so ours has to be in place before {@code start()},
+ * at which point {@code getExecutor()} and {@code getScheduler()} are still {@code null}.
+ */
+public class JMeterDnsSocketAddressResolver implements SocketAddressResolver {
+
+  private final DnsResolver dnsResolver;
+  private final Supplier<Executor> executorSupplier;
+  private final Supplier<Scheduler> schedulerSupplier;
+  private final long timeoutMs;
+
+  public JMeterDnsSocketAddressResolver(DnsResolver dnsResolver,
+                                        Supplier<Executor> executorSupplier,
+                                        Supplier<Scheduler> schedulerSupplier,
+                                        long timeoutMs) {
+    this.dnsResolver = dnsResolver;
+    this.executorSupplier = executorSupplier;
+    this.schedulerSupplier = schedulerSupplier;
+    this.timeoutMs = timeoutMs;
+  }
+
+  @Override
+  public void resolve(String host, int port, Map<String, Object> context,
+                      Promise<List<InetSocketAddress>> promise) {
+    Executor executor = executorSupplier.get();
+    if (executor == null) {
+      // Only reachable if a caller resolves before the client is started; resolving inline is
+      // still better than dropping the request on the floor.
+      resolveAndComplete(host, port, promise, new AtomicBoolean());
+      return;
+    }
+    executor.execute(() -> {
+      AtomicBoolean complete = new AtomicBoolean();
+      Scheduler.Task timeoutTask = scheduleTimeout(host, Thread.currentThread(), complete, promise);
+      try {
+        resolveAndComplete(host, port, promise, complete);
+      } finally {
+        if (timeoutTask != null) {
+          timeoutTask.cancel();
+        }
+        // The timeout task interrupts this thread to unblock the lookup; clear the flag so the
+        // pooled thread does not carry it into unrelated work.
+        Thread.interrupted();
+      }
+    });
+  }
+
+  private Scheduler.Task scheduleTimeout(String host, Thread resolvingThread,
+                                         AtomicBoolean complete,
+                                         Promise<List<InetSocketAddress>> promise) {
+    Scheduler scheduler = schedulerSupplier.get();
+    if (timeoutMs <= 0 || scheduler == null) {
+      return null;
+    }
+    return scheduler.schedule(() -> {
+      if (complete.compareAndSet(false, true)) {
+        promise.failed(new TimeoutException(
+            "DNS timeout " + timeoutMs + " ms resolving " + host));
+        resolvingThread.interrupt();
+      }
+    }, timeoutMs, TimeUnit.MILLISECONDS);
+  }
+
+  private void resolveAndComplete(String host, int port,
+                                  Promise<List<InetSocketAddress>> promise,
+                                  AtomicBoolean complete) {
+    try {
+      InetAddress[] addresses = resolveAddresses(host);
+      // DNSCacheManager returns null when a custom lookup cannot parse the name, and an empty
+      // array when a static host entry is matched case-insensitively by isStaticHost but read
+      // case-sensitively by fromStaticHost (a JMeter bug still present on master). Neither may
+      // reach Jetty as a success: HttpClient indexes straight into the returned list.
+      if (addresses == null || addresses.length == 0) {
+        throw new UnknownHostException(host);
+      }
+      List<InetSocketAddress> result = new ArrayList<>(addresses.length);
+      for (InetAddress address : addresses) {
+        result.add(new InetSocketAddress(address, port));
+      }
+      if (complete.compareAndSet(false, true)) {
+        promise.succeeded(result);
+      }
+    } catch (Throwable failure) {
+      if (complete.compareAndSet(false, true)) {
+        promise.failed(failure);
+      }
+    }
+  }
+
+  private InetAddress[] resolveAddresses(String host) throws UnknownHostException {
+    // DNSCacheManager keeps its cache in a plain LinkedHashMap and JMeter clones one instance per
+    // thread, but a single JMeter thread resolves concurrently here (embedded resources, and the
+    // HTTP/3 vs HTTP/2 race, run on plugin executors). Serializing keeps that map consistent;
+    // cache hits make the critical section negligible.
+    synchronized (dnsResolver) {
+      return dnsResolver.resolve(host);
+    }
+  }
+}

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -37,6 +37,7 @@ import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.engine.event.LoopIterationEvent;
 import org.apache.jmeter.engine.event.LoopIterationListener;
 import org.apache.jmeter.processor.PreProcessor;
+import org.apache.jmeter.protocol.http.control.DNSCacheManager;
 import org.apache.jmeter.protocol.http.parser.BaseParser;
 import org.apache.jmeter.protocol.http.parser.LinkExtractorParseException;
 import org.apache.jmeter.protocol.http.parser.LinkExtractorParser;
@@ -874,7 +875,7 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
     HTTP2ClientKey connectionKey = buildConnectionKey();
     HTTP2JettyClient client = new HTTP2JettyClient(isHttp1UpgradeEnabled(),
         "http2[" + connectionKey.target + ":" + Thread.currentThread().getId() + "]",
-        buildProfileConfig());
+        buildProfileConfig(), getDNSResolver());
     client.start();
     CONNECTIONS.get().put(connectionKey, client);
     return client;
@@ -923,7 +924,20 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
     appendLongKey(key, "h1cd", getHttp1OnlyCooldownMs());
     appendLongKey(key, "h2cttl", getH2cCacheTtlMs());
     appendBooleanKey(key, "h2cup", isHttp1UpgradeEnabled());
+    appendDnsResolverKey(key);
     return key.toString();
+  }
+
+  /**
+   * A cached client carries the DNS Cache Manager it was built with, so two samplers under
+   * different managers (or one with a manager and one without) must not share it. Identity is
+   * enough: JMeter clones the manager once per thread and the client cache is per thread too, so
+   * the instance is stable for as long as the entry can be reused.
+   */
+  private void appendDnsResolverKey(StringBuilder key) {
+    DNSCacheManager dnsCacheManager = getDNSResolver();
+    key.append(";dns=")
+        .append(dnsCacheManager == null ? "-" : System.identityHashCode(dnsCacheManager));
   }
 
   private void appendBooleanKey(StringBuilder key, String name, Boolean value) {

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientDnsCacheManagerTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientDnsCacheManagerTest.java
@@ -1,0 +1,191 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.http.conn.DnsResolver;
+import org.apache.jmeter.protocol.http.control.DNSCacheManager;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.SocketAddressResolver;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * A DNS Cache Manager in the plan has to reach this plugin's transport the same way it reaches
+ * {@code HTTPHC4Impl}: bound once when the per-thread client is created, applied to every protocol
+ * variant, and consulted for the host Jetty actually connects to - which under a proxy is the
+ * proxy, not the target.
+ *
+ * <p>End-to-end coverage here uses a static host entry rather than a mock DNS server. JMeter's own
+ * {@code DNSCacheManagerTest} points a mock server at an ephemeral port, which its
+ * {@code parseHostPort} makes possible only on master; on the 5.5 line this plugin targets,
+ * {@code createResolver} feeds host names straight to dnsjava's {@code ExtendedResolver} and a
+ * custom port cannot be expressed. A static host entry exercises the same integration and is the
+ * configuration load tests actually use.
+ */
+public class HTTP2JettyClientDnsCacheManagerTest extends HTTP2TestBase {
+
+  private static final String[] PROTOCOL_CLIENT_FIELDS = {
+      "httpClient", "httpClientNoH3", "httpClientHttp1Only", "httpClientH2cPrior",
+      "httpClientH2cUpgrade"
+  };
+  private static final String STATIC_HOST = "jmeter.example.org";
+
+  private TeardownableServer server;
+  private HTTP2JettyClient client;
+
+  @After
+  public void tearDown() throws Exception {
+    if (client != null) {
+      client.stop();
+    }
+    if (server != null) {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void installsJmeterResolverOnEveryProtocolClientWhenThePlanHasADnsCacheManager()
+      throws Exception {
+    client = new HTTP2JettyClient(false, "dns-manager-test", null, staticHostManager());
+
+    for (HttpClient protocolClient : protocolClients(client)) {
+      assertThat(protocolClient.getSocketAddressResolver())
+          .isInstanceOf(JMeterDnsSocketAddressResolver.class);
+    }
+  }
+
+  @Test
+  public void keepsJettyDefaultResolverWhenThePlanHasNoDnsCacheManager() throws Exception {
+    client = new HTTP2JettyClient(false, "dns-default-test");
+    client.start();
+
+    for (HttpClient protocolClient : protocolClients(client)) {
+      assertThat(protocolClient.getSocketAddressResolver())
+          .isInstanceOf(SocketAddressResolver.Async.class);
+    }
+  }
+
+  @Test
+  public void samplesThroughAStaticHostEntryInsteadOfSystemResolution() throws Exception {
+    int port = startServer();
+    client = new HTTP2JettyClient(false, "dns-static-host-test", null, staticHostManager());
+    client.start();
+
+    HTTPSampleResult result = sampleGet(STATIC_HOST, port);
+
+    assertThat(result.isSuccessful()).isTrue();
+    assertThat(result.getResponseCode()).isEqualTo("200");
+  }
+
+  @Test
+  public void resolvesTheProxyHostAndNeverTheTargetHost() throws Exception {
+    int port = startServer();
+    RecordingDnsResolver recordingResolver = new RecordingDnsResolver();
+    client = new HTTP2JettyClient(false, "dns-proxy-test", null, recordingResolver);
+    client.start();
+
+    HTTP2Sampler sampler = newSampler("target.invalid", port);
+    sampler.setProxyHost("localhost");
+    sampler.setProxyPortInt(String.valueOf(port));
+    sampler.setProxyScheme("http");
+    try {
+      client.sample(sampler, newResult("target.invalid", port), false, 0);
+    } catch (Exception acceptable) {
+      // The proxy here is a plain HTTP server, so the exchange may well fail. What is under test
+      // is which host reached the resolver, and that is recorded before any of that matters.
+    }
+
+    assertThat(recordingResolver.resolvedHosts).contains("localhost");
+    assertThat(recordingResolver.resolvedHosts).doesNotContain("target.invalid");
+  }
+
+  @Test
+  public void clientCacheKeySeparatesSamplersByDnsCacheManager() throws Exception {
+    HTTP2Sampler withoutManager = newSampler("localhost", 8080);
+    HTTP2Sampler withManager = newSampler("localhost", 8080);
+    withManager.setDNSResolver(staticHostManager());
+    HTTP2Sampler withAnotherManager = newSampler("localhost", 8080);
+    withAnotherManager.setDNSResolver(staticHostManager());
+
+    String keyWithoutManager = profileKey(withoutManager);
+    String keyWithManager = profileKey(withManager);
+    String keyWithAnotherManager = profileKey(withAnotherManager);
+
+    assertThat(keyWithoutManager).isNotEqualTo(keyWithManager);
+    assertThat(keyWithManager).isNotEqualTo(keyWithAnotherManager);
+    assertThat(profileKey(withManager)).isEqualTo(keyWithManager);
+  }
+
+  private int startServer() throws Exception {
+    server = new ServerBuilder().withHTTP1().buildServer();
+    server.start();
+    return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+  }
+
+  private DNSCacheManager staticHostManager() {
+    DNSCacheManager dnsCacheManager = new DNSCacheManager();
+    dnsCacheManager.addHost(STATIC_HOST, "127.0.0.1");
+    return dnsCacheManager;
+  }
+
+  private HTTPSampleResult sampleGet(String domain, int port) throws Exception {
+    return client.sample(newSampler(domain, port), newResult(domain, port), false, 0);
+  }
+
+  private HTTP2Sampler newSampler(String domain, int port) {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod("GET");
+    sampler.setDomain(domain);
+    sampler.setPort(port);
+    sampler.setPath(ServerBuilder.SERVER_PATH_200);
+    sampler.setProtocol("http");
+    return sampler;
+  }
+
+  private HTTPSampleResult newResult(String domain, int port) throws Exception {
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setSampleLabel("GET_DNS_CACHE_MANAGER");
+    result.setHTTPMethod("GET");
+    result.setURL(new URL("http", domain, port, ServerBuilder.SERVER_PATH_200));
+    return result;
+  }
+
+  private static List<HttpClient> protocolClients(HTTP2JettyClient client) throws Exception {
+    List<HttpClient> clients = new CopyOnWriteArrayList<>();
+    for (String fieldName : PROTOCOL_CLIENT_FIELDS) {
+      Field field = HTTP2JettyClient.class.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      clients.add((HttpClient) field.get(client));
+    }
+    return clients;
+  }
+
+  private static String profileKey(HTTP2Sampler sampler) throws Exception {
+    Method method = HTTP2Sampler.class.getDeclaredMethod("buildProfileKey");
+    method.setAccessible(true);
+    return (String) method.invoke(sampler);
+  }
+
+  private static final class RecordingDnsResolver implements DnsResolver {
+
+    private final List<String> resolvedHosts = new CopyOnWriteArrayList<>();
+
+    @Override
+    public InetAddress[] resolve(String host) throws UnknownHostException {
+      resolvedHosts.add(host);
+      return InetAddress.getAllByName("127.0.0.1");
+    }
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/JMeterDnsSocketAddressResolverTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/JMeterDnsSocketAddressResolverTest.java
@@ -1,0 +1,203 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.http.conn.DnsResolver;
+import org.eclipse.jetty.util.Promise;
+import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Pins the contract {@link JMeterDnsSocketAddressResolver} owes Jetty when it hands over a JMeter
+ * DNS Cache Manager: every address, in order, or a failure - never an empty success, because
+ * {@code HttpClient} indexes straight into the resolved list, and never an unbounded wait, because
+ * JMeter leaves the manager's own DNS timeout unset.
+ */
+public class JMeterDnsSocketAddressResolverTest {
+
+  private static final long TIMEOUT_MS = 300;
+  private static final int AWAIT_SECONDS = 10;
+
+  private ExecutorService executor;
+  private ScheduledExecutorScheduler scheduler;
+
+  @Before
+  public void setUp() throws Exception {
+    executor = Executors.newCachedThreadPool();
+    scheduler = new ScheduledExecutorScheduler("dns-resolver-test-scheduler", true);
+    scheduler.start();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (scheduler != null) {
+      scheduler.stop();
+    }
+    if (executor != null) {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  public void resolvesEveryAddressInTheOrderTheManagerReturnedThem() throws Exception {
+    InetAddress first = InetAddress.getByName("127.0.0.1");
+    InetAddress second = InetAddress.getByName("::1");
+    CapturingPromise promise = resolve(host -> new InetAddress[] {first, second});
+
+    assertThat(promise.awaitAddresses())
+        .containsExactly(new InetSocketAddress(first, 443), new InetSocketAddress(second, 443));
+  }
+
+  @Test
+  public void failsWithUnknownHostWhenTheManagerResolvesToNull() throws Exception {
+    // DNSCacheManager.customRequestLookup returns null when dnsjava cannot parse the name, and its
+    // cache is allowed to hold a null value for a host.
+    CapturingPromise promise = resolve(host -> null);
+
+    assertThat(promise.awaitFailure()).isInstanceOf(UnknownHostException.class);
+  }
+
+  @Test
+  public void failsWithUnknownHostWhenTheManagerResolvesToNoAddress() throws Exception {
+    // JMeter's isStaticHost matches case-insensitively but fromStaticHost re-reads the entry
+    // case-sensitively, so a static host declared with different casing resolves to an empty
+    // array instead of throwing.
+    CapturingPromise promise = resolve(host -> new InetAddress[0]);
+
+    assertThat(promise.awaitFailure()).isInstanceOf(UnknownHostException.class);
+  }
+
+  @Test
+  public void propagatesTheFailureRaisedByTheManager() throws Exception {
+    UnknownHostException raised = new UnknownHostException("no.such.host");
+    CapturingPromise promise = resolve(host -> {
+      throw raised;
+    });
+
+    assertThat(promise.awaitFailure()).isSameAs(raised);
+  }
+
+  @Test
+  public void failsWithTimeoutWhenTheLookupOutlivesTheConfiguredTimeout() throws Exception {
+    CountDownLatch release = new CountDownLatch(1);
+    try {
+      CapturingPromise promise = resolve(host -> {
+        awaitQuietly(release);
+        return new InetAddress[] {InetAddress.getLoopbackAddress()};
+      });
+
+      assertThat(promise.awaitFailure()).isInstanceOf(TimeoutException.class);
+    } finally {
+      release.countDown();
+    }
+  }
+
+  @Test
+  public void serializesConcurrentLookupsOverTheSameManager() throws Exception {
+    AtomicInteger inFlight = new AtomicInteger();
+    AtomicInteger maxInFlight = new AtomicInteger();
+    JMeterDnsSocketAddressResolver resolver = newResolver(host -> {
+      maxInFlight.accumulateAndGet(inFlight.incrementAndGet(), Math::max);
+      try {
+        Thread.sleep(30);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } finally {
+        inFlight.decrementAndGet();
+      }
+      return new InetAddress[] {InetAddress.getLoopbackAddress()};
+    }, TimeUnit.SECONDS.toMillis(AWAIT_SECONDS));
+
+    CapturingPromise[] promises = new CapturingPromise[4];
+    for (int i = 0; i < promises.length; i++) {
+      promises[i] = new CapturingPromise();
+      resolver.resolve("localhost", 80, Map.of(), promises[i]);
+    }
+    for (CapturingPromise promise : promises) {
+      assertThat(promise.awaitAddresses()).hasSize(1);
+    }
+
+    assertThat(maxInFlight.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void resolvesInlineWhileTheClientHasNotProvidedAnExecutorYet() throws Exception {
+    JMeterDnsSocketAddressResolver resolver = new JMeterDnsSocketAddressResolver(
+        host -> new InetAddress[] {InetAddress.getLoopbackAddress()},
+        () -> null, () -> scheduler, TIMEOUT_MS);
+    CapturingPromise promise = new CapturingPromise();
+
+    resolver.resolve("localhost", 8080, Map.of(), promise);
+
+    assertThat(promise.awaitAddresses())
+        .containsExactly(new InetSocketAddress(InetAddress.getLoopbackAddress(), 8080));
+  }
+
+  private CapturingPromise resolve(DnsResolver dnsResolver) throws Exception {
+    CapturingPromise promise = new CapturingPromise();
+    newResolver(dnsResolver, TIMEOUT_MS).resolve("localhost", 443, Map.of(), promise);
+    return promise;
+  }
+
+  private JMeterDnsSocketAddressResolver newResolver(DnsResolver dnsResolver, long timeoutMs) {
+    return new JMeterDnsSocketAddressResolver(dnsResolver, () -> executor, () -> scheduler,
+        timeoutMs);
+  }
+
+  private static void awaitQuietly(CountDownLatch latch) {
+    try {
+      latch.await(AWAIT_SECONDS, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private static final class CapturingPromise implements Promise<List<InetSocketAddress>> {
+
+    private final CountDownLatch done = new CountDownLatch(1);
+
+    private volatile List<InetSocketAddress> addresses;
+    private volatile Throwable failure;
+
+    @Override
+    public void succeeded(List<InetSocketAddress> result) {
+      addresses = result;
+      done.countDown();
+    }
+
+    @Override
+    public void failed(Throwable throwable) {
+      failure = throwable;
+      done.countDown();
+    }
+
+    private List<InetSocketAddress> awaitAddresses() throws InterruptedException {
+      await();
+      assertThat(failure).isNull();
+      return addresses;
+    }
+
+    private Throwable awaitFailure() throws InterruptedException {
+      await();
+      assertThat(addresses).isNull();
+      return failure;
+    }
+
+    private void await() throws InterruptedException {
+      assertThat(done.await(AWAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds support for using JMeter's DNS Cache Manager in the HTTP plugin, ensuring that custom DNS resolution (such as static host entries and custom DNS servers) applies to HTTP requests just as it does for the HTTPHC4 sampler. The changes also ensure that DNS resolution is properly isolated per sampler and per thread, preventing cross-contamination between samplers with different DNS configurations. Comprehensive tests are included to verify correct integration and behavior.

**DNS resolution integration and isolation:**

* Added a new `JMeterDnsSocketAddressResolver` class that adapts JMeter's `DNSCacheManager` (via `DnsResolver`) for use by Jetty's `HttpClient`, ensuring all protocol variants (HTTP/1.1, HTTP/2, HTTP/3) resolve hosts through the DNS Cache Manager when configured.
* Modified `HTTP2JettyClient` to accept a `DnsResolver` in its constructor, store it, and install the custom resolver on each protocol client during configuration. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR63) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR321-R339) [[3]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR3364) [[4]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR3383-R3399)
* Updated `HTTP2Sampler` to pass the correct DNS resolver to `HTTP2JettyClient` and to ensure the client cache key includes the DNS Cache Manager instance, preventing clients from being shared across samplers with different DNS configurations. [[1]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R40) [[2]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30L877-R878) [[3]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R927-R942)

**Testing and verification:**

* Added a new test class `HTTP2JettyClientDnsCacheManagerTest` to verify that the DNS Cache Manager is correctly installed, that static host entries are respected, that proxy resolution targets the proxy host, and that client cache keys are isolated by DNS manager instance.