### PR TITLE
Add BASIC_DIGEST support

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -183,6 +183,15 @@ public class HTTP2JettyClient {
   private static final String ATTR_SKIP_H2C_UPGRADE = "bzm.skipH2cUpgrade";
   private static final String ATTR_ORIGIN_KEY = "bzm.http3.origin";
   private static final String ATTR_REQUEST_HEADERS_SERIALIZED = "bzm.request.headers.serialized";
+  /**
+   * JMeter's deprecated "BASIC_DIGEST" Auth Manager mechanism, still selectable in the GUI and
+   * still present in older plans. HC4 keeps honouring it: {@code AuthManager.setupCredentials}
+   * registers the credentials without binding them to a scheme, so they answer either challenge,
+   * and the preemptive auth cache treats the row as Basic. Referenced by name so this file does
+   * not have to carry a deprecation suppression, the same way the surrounding code compares
+   * mechanisms by {@code name()}.
+   */
+  private static final String BASIC_DIGEST_MECHANISM = "BASIC_DIGEST";
   private static final String PROP_SKIP_REDUNDANT_MANUAL_DECODE =
       "blazemeter.http.skipManualDecodeWhenAdvertised";
   private static final Path DEBUG_LOG_PATH = resolveDebugLogPath();
@@ -3648,24 +3657,44 @@ public class HTTP2JettyClient {
   private boolean isSupportedMechanism(Authorization auth) {
     String authName = auth.getMechanism().name();
     return authName.equals(AuthManager.Mechanism.BASIC.name())
-        || authName.equals(AuthManager.Mechanism.DIGEST.name());
+        || authName.equals(AuthManager.Mechanism.DIGEST.name())
+        || authName.equals(BASIC_DIGEST_MECHANISM);
+  }
+
+  /**
+   * Whether the row may answer a {@code Basic} challenge, which {@code BASIC_DIGEST} rows may.
+   */
+  private static boolean answersBasicChallenge(Authorization auth) {
+    String authName = auth.getMechanism().name();
+    return authName.equals(AuthManager.Mechanism.BASIC.name())
+        || authName.equals(BASIC_DIGEST_MECHANISM);
+  }
+
+  /**
+   * Whether the row may answer a {@code Digest} challenge, which {@code BASIC_DIGEST} rows may.
+   */
+  private static boolean answersDigestChallenge(Authorization auth) {
+    String authName = auth.getMechanism().name();
+    return authName.equals(AuthManager.Mechanism.DIGEST.name())
+        || authName.equals(BASIC_DIGEST_MECHANISM);
   }
 
   private void addAuthenticationToJettyClient(Authorization auth) {
     String authName = auth.getMechanism().name();
-    if (authName.equals(AuthManager.Mechanism.BASIC.name())
-        && BzmHttpPluginProperties.getPropDefault("httpJettyClient.auth.preemptive", false)) {
+    boolean preemptive =
+        BzmHttpPluginProperties.getPropDefault("httpJettyClient.auth.preemptive", false);
+    if (preemptive && answersBasicChallenge(auth)) {
       BasicAuthentication.BasicResult result =
           new BasicAuthentication.BasicResult(URI.create(auth.getURL()), auth.getUser(),
               auth.getPass());
       // Results are keyed by URI (Map.put replaces); safe to re-register every sample.
       forEachAuthenticationStore(store -> store.addAuthenticationResult(result));
-      return;
-    }
-
-    String fingerprint = authFingerprint(auth);
-    if (!registeredAuthFingerprints.add(fingerprint)) {
-      return;
+      if (authName.equals(AuthManager.Mechanism.BASIC.name())) {
+        return;
+      }
+      // A BASIC_DIGEST row falls through: sending Basic up front is what HC4's auth cache does,
+      // but the credentials must still be able to answer whichever challenge the server sends
+      // back, which is the whole point of the mechanism.
     }
 
     URI uri = URI.create(auth.getURL());
@@ -3674,10 +3703,26 @@ public class HTTP2JettyClient {
       // Blank JMeter realm must match any challenge realm; "" would only match "".
       realm = Authentication.ANY_REALM;
     }
-    AbstractAuthentication authentication =
-        authName.equals(AuthManager.Mechanism.BASIC.name())
-            ? new BasicAuthentication(uri, realm, auth.getUser(), auth.getPass())
-            : new DigestAuthentication(uri, realm, auth.getUser(), auth.getPass());
+    if (answersBasicChallenge(auth)) {
+      registerAuthentication(auth,
+          new BasicAuthentication(uri, realm, auth.getUser(), auth.getPass()));
+    }
+    if (answersDigestChallenge(auth)) {
+      registerAuthentication(auth,
+          new DigestAuthentication(uri, realm, auth.getUser(), auth.getPass()));
+    }
+  }
+
+  /**
+   * Adds one Jetty authentication to every protocol-variant store, once per distinct row.
+   *
+   * <p>The fingerprint carries the Jetty authentication type because a single {@code BASIC_DIGEST}
+   * row produces two of them, and both have to get through.
+   */
+  private void registerAuthentication(Authorization auth, AbstractAuthentication authentication) {
+    if (!registeredAuthFingerprints.add(authFingerprint(auth) + '|' + authentication.getType())) {
+      return;
+    }
     forEachAuthenticationStore(store -> store.addAuthentication(authentication));
   }
 
@@ -4000,7 +4045,7 @@ public class HTTP2JettyClient {
     StreamSupport.stream(authManager.getAuthObjects().spliterator(), false)
         .map(j -> (Authorization) j.getObjectValue())
         .filter(auth -> auth != null
-            && AuthManager.Mechanism.BASIC.equals(auth.getMechanism())
+            && answersBasicChallenge(auth)
             && !StringUtils.isEmpty(auth.getURL()))
         .filter(auth -> url.toString().startsWith(auth.getURL()))
         .findFirst()

--- a/src/test/java/com/blazemeter/jmeter/http2/core/AuthBasicDigestMechanismTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/AuthBasicDigestMechanismTest.java
@@ -1,0 +1,234 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.AUTH_PASSWORD;
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.AUTH_REALM;
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.AUTH_USERNAME;
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.HOST_NAME;
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.SERVER_PATH_200;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import com.blazemeter.jmeter.http2.sampler.JMeterTestUtils;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.jmeter.protocol.http.control.AuthManager;
+import org.apache.jmeter.protocol.http.control.AuthManager.Mechanism;
+import org.apache.jmeter.protocol.http.control.Authorization;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.util.JMeterUtils;
+import org.eclipse.jetty.client.AbstractAuthentication;
+import org.eclipse.jetty.client.Authentication;
+import org.eclipse.jetty.client.AuthenticationStore;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * {@code BASIC_DIGEST} is deprecated in JMeter but still selectable and still present in older
+ * plans, and {@code HTTPHC4Impl} keeps honouring it: the credentials are registered without being
+ * bound to a scheme, so they answer either challenge. This plugin used to drop those rows in
+ * {@code isSupportedMechanism} without a word, leaving the plan silently unauthenticated.
+ *
+ * <p>Jetty binds an {@code Authentication} to one challenge type, so a single {@code BASIC_DIGEST}
+ * row has to become two registrations - which is what these tests pin, along with the dedup that
+ * keeps them from piling up per sample.
+ */
+public class AuthBasicDigestMechanismTest extends HTTP2TestBase {
+
+  private static final String PREEMPTIVE_PROPERTY = "httpJettyClient.auth.preemptive";
+
+  private String originalPreemptiveProperty;
+  private TeardownableServer server;
+  private HTTP2JettyClient client;
+
+  @BeforeClass
+  public static void setupClass() {
+    JMeterTestUtils.setupJmeterEnv();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    originalPreemptiveProperty = JMeterUtils.getProperty(PREEMPTIVE_PROPERTY);
+    // Registering Jetty Authentications is the reactive path; preemptive mode registers Results
+    // instead and another test may have left the shared property on.
+    JMeterUtils.setProperty(PREEMPTIVE_PROPERTY, "false");
+    HTTP2JettyClientTestIsolation.resetSharedClientState();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (client != null) {
+      client.stop();
+    }
+    if (server != null && server.isStarted()) {
+      server.stop();
+    }
+    if (originalPreemptiveProperty == null) {
+      JMeterUtils.getJMeterProperties().remove(PREEMPTIVE_PROPERTY);
+    } else {
+      JMeterUtils.setProperty(PREEMPTIVE_PROPERTY, originalPreemptiveProperty);
+    }
+  }
+
+  @Test
+  public void authenticatesAgainstABasicServerWithABasicDigestRow() throws Exception {
+    int port = startAuthServer(new ServerBuilder().withHTTP1().withSSL().withBasicAuth());
+    HTTP2Sampler sampler = samplerWith(Mechanism.BASIC_DIGEST, port);
+
+    HTTPSampleResult result = sample(sampler);
+
+    assertThat(result.isSuccessful()).isTrue();
+    assertThat(result.getResponseCode()).isEqualTo("200");
+  }
+
+  @Test
+  public void authenticatesAgainstADigestServerWithABasicDigestRow() throws Exception {
+    int port = startAuthServer(new ServerBuilder().withHTTP1().withSSL().withDigestAuth());
+    HTTP2Sampler sampler = samplerWith(Mechanism.BASIC_DIGEST, port);
+
+    HTTPSampleResult result = sample(sampler);
+
+    assertThat(result.isSuccessful()).isTrue();
+    assertThat(result.getResponseCode()).isEqualTo("200");
+  }
+
+  @Test
+  public void registersOneBasicAndOneDigestAuthenticationForABasicDigestRow() throws Exception {
+    int port = startAuthServer(new ServerBuilder().withHTTP1().withSSL().withBasicAuth());
+    HTTP2Sampler sampler = samplerWith(Mechanism.BASIC_DIGEST, port);
+
+    sample(sampler);
+
+    assertThat(authenticationTypes()).containsExactlyInAnyOrder("Basic", "Digest");
+  }
+
+  @Test
+  public void registersOnlyTheMatchingAuthenticationForASingleMechanismRow() throws Exception {
+    int port = startAuthServer(new ServerBuilder().withHTTP1().withSSL().withBasicAuth());
+    HTTP2Sampler sampler = samplerWith(Mechanism.BASIC, port);
+
+    sample(sampler);
+
+    assertThat(authenticationTypes()).containsExactly("Basic");
+  }
+
+  @Test
+  public void keepsBothRegistrationsIdempotentAcrossSamples() throws Exception {
+    int port = startAuthServer(new ServerBuilder().withHTTP1().withSSL().withBasicAuth());
+    HTTP2Sampler sampler = samplerWith(Mechanism.BASIC_DIGEST, port);
+
+    for (int i = 0; i < 5; i++) {
+      assertThat(sample(sampler).isSuccessful())
+          .as("sample %d should authenticate", i)
+          .isTrue();
+    }
+
+    assertThat(authenticationTypes()).containsExactlyInAnyOrder("Basic", "Digest");
+  }
+
+  @Test
+  public void sendsThePreemptiveBasicHeaderForABasicDigestRow() throws Exception {
+    JMeterUtils.setProperty(PREEMPTIVE_PROPERTY, "true");
+    client = new HTTP2JettyClient(false, "auth-basic-digest-preemptive", http1OnlyProfile());
+    client.start();
+    URL url = new URL(HTTPConstants.PROTOCOL_HTTPS, HOST_NAME, 8443, SERVER_PATH_200);
+    HttpClient probeClient = http1OnlyClient(client);
+    Request request = probeClient.newRequest(URI.create(url.toString()));
+
+    invokePreemptiveHeader(client, request, url, authManagerWith(Mechanism.BASIC_DIGEST, url));
+
+    assertThat(request.getHeaders().get(HttpHeader.AUTHORIZATION)).startsWith("Basic ");
+  }
+
+  private int startAuthServer(ServerBuilder builder) throws Exception {
+    server = builder.buildServer();
+    server.start();
+    return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+  }
+
+  private HTTP2Sampler samplerWith(Mechanism mechanism, int port) throws Exception {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.GET);
+    sampler.setDomain(HOST_NAME);
+    sampler.setProtocol(HTTPConstants.PROTOCOL_HTTPS);
+    sampler.setPort(port);
+    sampler.setPath(SERVER_PATH_200);
+    sampler.setAuthManager(authManagerWith(mechanism,
+        new URL(HTTPConstants.PROTOCOL_HTTPS, HOST_NAME, port, SERVER_PATH_200)));
+    return sampler;
+  }
+
+  private AuthManager authManagerWith(Mechanism mechanism, URL url) {
+    Authorization authorization = new Authorization();
+    authorization.setURL(url.toString());
+    authorization.setUser(AUTH_USERNAME);
+    authorization.setPass(AUTH_PASSWORD);
+    authorization.setRealm(AUTH_REALM);
+    authorization.setMechanism(mechanism);
+    AuthManager authManager = new AuthManager();
+    authManager.addAuth(authorization);
+    return authManager;
+  }
+
+  private HTTPSampleResult sample(HTTP2Sampler sampler) throws Exception {
+    if (client == null) {
+      client = new HTTP2JettyClient(false, "auth-basic-digest", http1OnlyProfile());
+      client.start();
+    }
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setURL(sampler.getUrl());
+    result.setHTTPMethod(sampler.getMethod());
+    return client.sample(sampler, result, false, 0);
+  }
+
+  private List<String> authenticationTypes() throws Exception {
+    return registeredAuthentications(http1OnlyClient(client)).stream()
+        .map(authentication -> ((AbstractAuthentication) authentication).getType())
+        .collect(Collectors.toList());
+  }
+
+  private static HTTP2ClientProfileConfig http1OnlyProfile() {
+    // The auth servers here speak HTTP/1.1 only; racing HTTP/3 would just burn the samples.
+    return HTTP2ClientProfileConfig.builder()
+        .enableHttp1(true)
+        .enableHttp2(false)
+        .enableHttp3(false)
+        .build();
+  }
+
+  private static HttpClient http1OnlyClient(HTTP2JettyClient client) throws Exception {
+    Field field = HTTP2JettyClient.class.getDeclaredField("httpClientHttp1Only");
+    field.setAccessible(true);
+    return (HttpClient) field.get(client);
+  }
+
+  private static List<Authentication> registeredAuthentications(HttpClient httpClient)
+      throws Exception {
+    AuthenticationStore store = httpClient.getAuthenticationStore();
+    Field field = store.getClass().getDeclaredField("authentications");
+    field.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    List<Authentication> authentications = (List<Authentication>) field.get(store);
+    return authentications;
+  }
+
+  private static void invokePreemptiveHeader(HTTP2JettyClient client, Request request, URL url,
+                                             AuthManager authManager) throws Exception {
+    Method method = HTTP2JettyClient.class.getDeclaredMethod("addPreemptiveAuthorizationHeader",
+        Request.class, URL.class, AuthManager.class);
+    method.setAccessible(true);
+    method.invoke(client, request, url, authManager);
+  }
+}


### PR DESCRIPTION
This pull request improves support for the deprecated `BASIC_DIGEST` authentication mechanism in the `HTTP2JettyClient`, ensuring compatibility with legacy JMeter test plans and aligning behavior with the older HTTP client (`HTTPHC4Impl`). The changes ensure that a `BASIC_DIGEST` row can answer both Basic and Digest authentication challenges, and prevent duplicate authentications from being registered. Comprehensive tests have also been added to verify this behavior.

**Authentication mechanism improvements:**

* Added handling for the deprecated `BASIC_DIGEST` mechanism, allowing it to answer both Basic and Digest challenges, matching legacy JMeter behavior. Now, when a `BASIC_DIGEST` row is encountered, both Basic and Digest authentications are registered, and preemptive Basic headers are sent if configured. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR186-R194) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL3651-R3697) [[3]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL3677-R3725) [[4]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdL4003-R4048)

**Testing enhancements:**

* Introduced a new test class `AuthBasicDigestMechanismTest` to verify that `BASIC_DIGEST` authentication works as expected. The tests cover successful authentication against both Basic and Digest servers, correct registration of authentications, idempotency across samples, and preemptive header behavior.