### PR TITLE
Support source address for outgoing connections

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClient.java
@@ -17,7 +17,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
+import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -32,11 +35,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -317,6 +322,11 @@ public class HTTP2JettyClient {
    * {@code findAuthentication} (realm/URI matching quirks) and prevents per-sample list growth.
    */
   private final Set<String> registeredAuthFingerprints = ConcurrentHashMap.newKeySet();
+  /**
+   * Every {@link ClientConnector} this client builds, so {@link #setSourceAddress} can reach the
+   * QUIC one too - no transport {@code doStart} propagates the bind address to it.
+   */
+  private final List<ClientConnector> connectors = new ArrayList<>();
 
   public HTTP2JettyClient(boolean http1UpgradeRequired, String name) {
     this(http1UpgradeRequired, name, null);
@@ -3437,8 +3447,32 @@ public class HTTP2JettyClient {
         .resolve("http2-client-alpn.log");
   }
 
+  /**
+   * Binds every outgoing connection of this client to {@code sourceAddress} (JMeter's "Source
+   * address" field, a.k.a. IP spoofing), or restores the OS default when {@code null}.
+   *
+   * <p>Must be called before {@link #start()}: Jetty reads the bind address in
+   * {@code AbstractConnectorHttpClientTransport.doStart}, which then pushes it onto the transport's
+   * own connector. The QUIC connector used for HTTP/3 is not owned by any transport's
+   * {@code doStart}, so it is set here directly - which is also why the connectors are tracked.
+   *
+   * <p>Unlike HC4 this is per client rather than per request, because that is the granularity Jetty
+   * offers. {@code HTTP2Sampler} compensates by keying its per-thread client cache on the
+   * sampler's source-address configuration, so two samplers spoofing different IPs get their own
+   * client instead of silently sharing one.
+   */
+  public void setSourceAddress(InetAddress sourceAddress) {
+    SocketAddress bindAddress =
+        sourceAddress == null ? null : new InetSocketAddress(sourceAddress, 0);
+    forEachHttpClient(client -> client.setBindAddress(bindAddress));
+    for (ClientConnector connector : connectors) {
+      connector.setBindAddress(bindAddress);
+    }
+  }
+
   private ClientConnector createClientConnector(String name) {
     ClientConnector connector = new ClientConnector();
+    connectors.add(connector);
     if (sharedThreadPoolEnabled) {
       connector.setSelectors(-1);
     } else {

--- a/src/main/java/com/blazemeter/jmeter/http2/core/JMeterSourceAddressResolver.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/JMeterSourceAddressResolver.java
@@ -1,0 +1,123 @@
+package com.blazemeter.jmeter.http2.core;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase;
+import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase.SourceType;
+import org.apache.jmeter.util.JMeterUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resolves the local address a sample must go out from - JMeter's "Source address" field, also
+ * known as IP spoofing.
+ *
+ * <p>Port of {@code HTTPAbstractImpl.getIpSourceAddress()} plus the {@code httpclient.localaddress}
+ * fallback that {@code HTTPHCAbstractImpl} reads. It has to be a port rather than a delegation
+ * because that method is {@code protected} on the {@code HTTPAbstractImpl} hierarchy, which
+ * {@code HTTP2Sampler} does not extend - it extends {@link HTTPSamplerBase} directly.
+ *
+ * <p>Precedence matches {@code HTTPHC4Impl.setupRequest}: the sampler's own field wins, the global
+ * property is the fallback, and neither one means the OS picks the interface.
+ */
+public final class JMeterSourceAddressResolver {
+
+  private static final String LOCAL_ADDRESS_PROPERTY = "httpclient.localaddress";
+
+  private static final Logger LOG = LoggerFactory.getLogger(JMeterSourceAddressResolver.class);
+
+  private JMeterSourceAddressResolver() {
+  }
+
+  /**
+   * Returns the local address for {@code sampler}, or {@code null} to let the OS choose.
+   *
+   * @param sampler the sampler whose "Source address" field and type are read; its properties are
+   *     already variable-expanded by the time a sample runs, so the value may differ per iteration
+   * @return the address to bind outgoing connections to, or {@code null} when none applies
+   * @throws UnknownHostException if the configured host name, IP or interface cannot be resolved,
+   *     which is what HC4 propagates out of {@code setupRequest} to fail the sample
+   * @throws SocketException if the interface list cannot be read
+   */
+  public static InetAddress resolve(HTTPSamplerBase sampler)
+      throws UnknownHostException, SocketException {
+    InetAddress fromSampler = resolveIpSource(sampler.getIpSource(), sampler.getIpSourceType());
+    return fromSampler != null ? fromSampler : resolveLocalAddressProperty();
+  }
+
+  /**
+   * Whether {@code sampler} asks for any source address at all, without resolving it.
+   *
+   * <p>Lets callers keep an unconfigured plan on the cheap path: no interface enumeration, and no
+   * failure from a global property that a sampler-level field would have overridden anyway.
+   */
+  public static boolean isConfigured(HTTPSamplerBase sampler) {
+    String ipSource = sampler.getIpSource();
+    return (ipSource != null && !ipSource.trim().isEmpty())
+        || !JMeterUtils.getPropDefault(LOCAL_ADDRESS_PROPERTY, "").isEmpty();
+  }
+
+  private static InetAddress resolveIpSource(String ipSource, int ipSourceType)
+      throws UnknownHostException, SocketException {
+    if (ipSource == null || ipSource.trim().isEmpty()) {
+      return null; // did not want to spoof the IP address
+    }
+    Class<? extends InetAddress> ipClass;
+    switch (SourceType.values()[ipSourceType]) {
+      case DEVICE:
+        ipClass = InetAddress.class;
+        break;
+      case DEVICE_IPV4:
+        ipClass = Inet4Address.class;
+        break;
+      case DEVICE_IPV6:
+        ipClass = Inet6Address.class;
+        break;
+      case HOSTNAME:
+      default:
+        return InetAddress.getByName(ipSource);
+    }
+    return firstInterfaceAddress(ipSource, ipClass);
+  }
+
+  private static InetAddress firstInterfaceAddress(String device,
+                                                   Class<? extends InetAddress> ipClass)
+      throws UnknownHostException, SocketException {
+    NetworkInterface net = NetworkInterface.getByName(device);
+    if (net == null) {
+      throw new UnknownHostException("Cannot find interface " + device);
+    }
+    for (InterfaceAddress interfaceAddress : net.getInterfaceAddresses()) {
+      InetAddress address = interfaceAddress.getAddress();
+      if (ipClass.isInstance(address)) {
+        return address;
+      }
+    }
+    throw new UnknownHostException("Interface " + device
+        + " does not have address of type " + ipClass.getSimpleName());
+  }
+
+  /**
+   * HC4 logs a warning and carries on when this property does not resolve, so a typo degrades to
+   * "let the OS choose" instead of breaking every sample in the plan. Only a sampler-level field
+   * is allowed to fail a sample.
+   */
+  private static InetAddress resolveLocalAddressProperty() {
+    String localHostOrIp = JMeterUtils.getPropDefault(LOCAL_ADDRESS_PROPERTY, "");
+    if (localHostOrIp.isEmpty()) {
+      return null;
+    }
+    try {
+      return InetAddress.getByName(localHostOrIp);
+    } catch (UnknownHostException e) {
+      LOG.warn("Ignoring {}={}: {}", LOCAL_ADDRESS_PROPERTY, localHostOrIp,
+          e.getLocalizedMessage());
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/blazemeter/jmeter/http2/core/JMeterSourceAddressResolver.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/core/JMeterSourceAddressResolver.java
@@ -51,6 +51,29 @@ public final class JMeterSourceAddressResolver {
   }
 
   /**
+   * Identifies the source-address configuration a client would be built with, for use in a client
+   * cache key. Empty when no source address applies.
+   *
+   * <p>Mirrors the precedence in {@link #resolve} without resolving anything, so it stays off the
+   * per-sample path: resolving a device name walks the interface list.
+   *
+   * <p>{@code httpclient.localaddress} is included even though it is global and normally constant.
+   * Every sampler that falls back to it binds to the same address, so sharing one client is the
+   * right outcome and keying on it changes nothing in a normal run - but a plan can change a
+   * JMeter property at runtime, and a cached client keeps the address it was built with. Reading
+   * the raw value costs a property lookup and removes the assumption that it never moves.
+   */
+  public static String cacheKeyFor(HTTPSamplerBase sampler) {
+    String ipSource = sampler.getIpSource();
+    if (ipSource != null && !ipSource.trim().isEmpty()) {
+      return ipSource.trim() + "/" + sampler.getIpSourceType();
+    }
+    String localAddress = JMeterUtils.getPropDefault(LOCAL_ADDRESS_PROPERTY, "").trim();
+    // Prefixed so a property value can never collide with a sampler field of the same text.
+    return localAddress.isEmpty() ? "" : "@" + localAddress;
+  }
+
+  /**
    * Whether {@code sampler} asks for any source address at all, without resolving it.
    *
    * <p>Lets callers keep an unconfigured plan on the cheap path: no interface enumeration, and no

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -957,11 +957,10 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
    * off the per-sample path: resolving a device name walks the interface list.
    */
   private void appendSourceAddressKey(StringBuilder key) {
-    String ipSource = getIpSource();
-    if (ipSource == null || ipSource.trim().isEmpty()) {
-      return;
+    String sourceAddress = JMeterSourceAddressResolver.cacheKeyFor(this);
+    if (!sourceAddress.isEmpty()) {
+      key.append(";ipsrc=").append(sourceAddress);
     }
-    key.append(";ipsrc=").append(ipSource.trim()).append('/').append(getIpSourceType());
   }
 
   private void appendBooleanKey(StringBuilder key, String name, Boolean value) {

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Sampler.java
@@ -6,6 +6,7 @@ import com.blazemeter.jmeter.http2.core.HTTP2ClientProfileConfig;
 import com.blazemeter.jmeter.http2.core.HTTP2FutureResponseListener;
 import com.blazemeter.jmeter.http2.core.HTTP2JettyClient;
 import com.blazemeter.jmeter.http2.core.HpackFailureDetector;
+import com.blazemeter.jmeter.http2.core.JMeterSourceAddressResolver;
 import com.blazemeter.jmeter.http2.core.JmeterHttpClientExceptionMapper;
 import com.blazemeter.jmeter.http2.core.ProtocolErrorException;
 import com.blazemeter.jmeter.http2.util.BzmHttpPluginProperties;
@@ -16,6 +17,7 @@ import com.helger.commons.annotation.VisibleForTesting;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.ConnectException;
+import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.SocketTimeoutException;
 import java.net.URISyntaxException;
@@ -872,9 +874,15 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
 
   private HTTP2JettyClient buildClient() throws Exception {
     HTTP2ClientKey connectionKey = buildConnectionKey();
+    // Resolved before the client exists: a bad source address must fail the sample without
+    // leaving an orphaned client behind, and it is the cheapest thing here to get wrong.
+    InetAddress sourceAddress = resolveSourceAddress();
     HTTP2JettyClient client = new HTTP2JettyClient(isHttp1UpgradeEnabled(),
         "http2[" + connectionKey.target + ":" + Thread.currentThread().getId() + "]",
         buildProfileConfig());
+    if (sourceAddress != null) {
+      client.setSourceAddress(sourceAddress);
+    }
     client.start();
     CONNECTIONS.get().put(connectionKey, client);
     return client;
@@ -923,7 +931,37 @@ public class HTTP2Sampler extends HTTPSamplerBase implements LoopIterationListen
     appendLongKey(key, "h1cd", getHttp1OnlyCooldownMs());
     appendLongKey(key, "h2cttl", getH2cCacheTtlMs());
     appendBooleanKey(key, "h2cup", isHttp1UpgradeEnabled());
+    appendSourceAddressKey(key);
     return key.toString();
+  }
+
+  /**
+   * The local address outgoing connections must be bound to - the sampler's "Source address"
+   * field (IP spoofing), or the {@code httpclient.localaddress} property.
+   *
+   * <p>A bad host name, IP or interface propagates out and fails the sample, which is what HC4
+   * does by letting {@code getIpSourceAddress} throw out of {@code setupRequest}. Silently falling
+   * back to the default interface would make a spoofing plan look like it works while every
+   * request leaves from the wrong address.
+   */
+  private InetAddress resolveSourceAddress() throws Exception {
+    if (!JMeterSourceAddressResolver.isConfigured(this)) {
+      return null;
+    }
+    return JMeterSourceAddressResolver.resolve(this);
+  }
+
+  /**
+   * Jetty binds the source address per client, not per request, so a cached client carries the one
+   * it was built with. Keying on the raw configuration - not on the resolved address - keeps this
+   * off the per-sample path: resolving a device name walks the interface list.
+   */
+  private void appendSourceAddressKey(StringBuilder key) {
+    String ipSource = getIpSource();
+    if (ipSource == null || ipSource.trim().isEmpty()) {
+      return;
+    }
+    key.append(";ipsrc=").append(ipSource.trim()).append('/').append(getIpSourceType());
   }
 
   private void appendBooleanKey(StringBuilder key, String name, Boolean value) {

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientSourceAddressTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientSourceAddressTest.java
@@ -1,0 +1,254 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static com.blazemeter.jmeter.http2.core.ServerBuilder.SERVER_PATH_200;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.core.ServerBuilder.TeardownableServer;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
+import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase.SourceType;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.samplers.SampleResult;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * HC4 binds the source address per request; Jetty only offers it per client, so the binding has to
+ * reach every protocol-variant client and every connector this wrapper builds - including the QUIC
+ * one, which no transport {@code doStart} propagates to - and the per-thread client cache has to
+ * stop two samplers spoofing different IPs from sharing one client.
+ */
+public class HTTP2JettyClientSourceAddressTest extends HTTP2TestBase {
+
+  private static final String[] PROTOCOL_CLIENT_FIELDS = {
+      "httpClient", "httpClientNoH3", "httpClientHttp1Only", "httpClientH2cPrior",
+      "httpClientH2cUpgrade"
+  };
+
+  private TeardownableServer server;
+  private HTTP2JettyClient client;
+  private HTTP2Sampler sampler;
+
+  @Before
+  public void setUp() throws Exception {
+    HTTP2JettyClientTestIsolation.resetSharedClientState();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (sampler != null) {
+      // Drops any client the real factory cached on this thread while sampling.
+      sampler.threadFinished();
+    }
+    if (client != null) {
+      client.stop();
+    }
+    if (server != null && server.isStarted()) {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void bindsEveryProtocolClientToTheSourceAddress() throws Exception {
+    client = new HTTP2JettyClient(false, "source-address-clients");
+    InetAddress loopback = InetAddress.getLoopbackAddress();
+
+    client.setSourceAddress(loopback);
+
+    SocketAddress expected = new InetSocketAddress(loopback, 0);
+    for (HttpClient protocolClient : protocolClients(client)) {
+      assertThat(protocolClient.getBindAddress()).isEqualTo(expected);
+    }
+  }
+
+  @Test
+  public void bindsEveryConnectorToTheSourceAddress() throws Exception {
+    client = new HTTP2JettyClient(false, "source-address-connectors");
+    InetAddress loopback = InetAddress.getLoopbackAddress();
+
+    client.setSourceAddress(loopback);
+
+    SocketAddress expected = new InetSocketAddress(loopback, 0);
+    List<ClientConnector> connectors = trackedConnectors(client);
+    assertThat(connectors).isNotEmpty();
+    for (ClientConnector connector : connectors) {
+      assertThat(connector.getBindAddress()).isEqualTo(expected);
+    }
+  }
+
+  @Test
+  public void leavesTheBindAddressUnsetWhenNoSourceAddressApplies() throws Exception {
+    client = new HTTP2JettyClient(false, "source-address-none");
+
+    for (HttpClient protocolClient : protocolClients(client)) {
+      assertThat(protocolClient.getBindAddress()).isNull();
+    }
+  }
+
+  @Test
+  public void clearsTheBindAddressWhenTheSourceAddressIsRemoved() throws Exception {
+    client = new HTTP2JettyClient(false, "source-address-cleared");
+    client.setSourceAddress(InetAddress.getLoopbackAddress());
+
+    client.setSourceAddress(null);
+
+    for (HttpClient protocolClient : protocolClients(client)) {
+      assertThat(protocolClient.getBindAddress()).isNull();
+    }
+  }
+
+  @Test
+  public void samplesThroughTheConfiguredSourceAddress() throws Exception {
+    int port = startServer();
+    client = new HTTP2JettyClient(false, "source-address-sample");
+    client.setSourceAddress(InetAddress.getLoopbackAddress());
+    client.start();
+
+    HTTPSampleResult result = client.sample(newSampler("localhost", port),
+        newResult("localhost", port), false, 0);
+
+    assertThat(result.isSuccessful()).isTrue();
+    assertThat(result.getResponseCode()).isEqualTo("200");
+  }
+
+  @Test
+  public void connectionsActuallyLeaveFromTheConfiguredSourceAddress() throws Exception {
+    // The only assertion here that proves the bind reached the socket: without it the OS would
+    // pick 127.0.0.1 for a loopback connection. Needs an alias the platform actually owns -
+    // Linux and Windows hold all of 127.0.0.0/8, macOS only 127.0.0.1 unless one is added.
+    InetAddress alias = InetAddress.getByName("127.0.0.2");
+    assumeTrue("127.0.0.2 is not bindable on this platform", isBindable(alias));
+    int port = startServer();
+    List<String> remoteAddresses = new CopyOnWriteArrayList<>();
+    ((ServerConnector) server.getConnectors()[0]).addBean(new Connection.Listener() {
+      @Override
+      public void onOpened(Connection connection) {
+        remoteAddresses.add(connection.getEndPoint().getRemoteSocketAddress().toString());
+      }
+
+      @Override
+      public void onClosed(Connection connection) {
+        // Only the accepted address matters here.
+      }
+    });
+    client = new HTTP2JettyClient(false, "source-address-onwire");
+    client.setSourceAddress(alias);
+    client.start();
+
+    HTTPSampleResult result = client.sample(newSampler("127.0.0.1", port),
+        newResult("127.0.0.1", port), false, 0);
+
+    assertThat(result.isSuccessful()).isTrue();
+    assertThat(remoteAddresses).isNotEmpty();
+    assertThat(remoteAddresses).allSatisfy(
+        remote -> assertThat(remote).contains("127.0.0.2"));
+  }
+
+  @Test
+  public void failsTheSampleWhenTheConfiguredDeviceDoesNotExist() throws Exception {
+    int port = startServer();
+    sampler = newSampler("localhost", port);
+    sampler.setIpSource("no-such-interface");
+    sampler.setIpSourceType(SourceType.DEVICE.ordinal());
+
+    SampleResult result = sampler.sample();
+
+    // Same outcome as HC4, where getIpSourceAddress throws out of setupRequest.
+    assertThat(result.isSuccessful()).isFalse();
+    assertThat(result.getResponseCode())
+        .isEqualTo("Non HTTP response code: java.net.UnknownHostException");
+  }
+
+  @Test
+  public void clientCacheKeySeparatesSamplersByConfiguredSourceAddress() throws Exception {
+    HTTP2Sampler withoutSource = newSampler("localhost", 8080);
+    HTTP2Sampler withSource = newSampler("localhost", 8080);
+    withSource.setIpSource("127.0.0.1");
+    HTTP2Sampler withAnotherSource = newSampler("localhost", 8080);
+    withAnotherSource.setIpSource("127.0.0.2");
+    HTTP2Sampler withAnotherType = newSampler("localhost", 8080);
+    withAnotherType.setIpSource("127.0.0.1");
+    withAnotherType.setIpSourceType(SourceType.DEVICE.ordinal());
+
+    assertThat(profileKey(withoutSource)).isNotEqualTo(profileKey(withSource));
+    assertThat(profileKey(withSource)).isNotEqualTo(profileKey(withAnotherSource));
+    assertThat(profileKey(withSource)).isNotEqualTo(profileKey(withAnotherType));
+    assertThat(profileKey(withSource)).isEqualTo(profileKey(withSource));
+  }
+
+  private static boolean isBindable(InetAddress address) {
+    try (Socket probe = new Socket()) {
+      probe.bind(new InetSocketAddress(address, 0));
+      return true;
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  private int startServer() throws Exception {
+    server = new ServerBuilder().withHTTP1().buildServer();
+    server.start();
+    return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+  }
+
+  private static HTTP2Sampler newSampler(String domain, int port) {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setMethod(HTTPConstants.GET);
+    sampler.setDomain(domain);
+    sampler.setPort(port);
+    sampler.setPath(SERVER_PATH_200);
+    sampler.setProtocol("http");
+    return sampler;
+  }
+
+  private static HTTPSampleResult newResult(String domain, int port) throws Exception {
+    HTTPSampleResult result = new HTTPSampleResult();
+    result.setSampleLabel("GET_SOURCE_ADDRESS");
+    result.setHTTPMethod(HTTPConstants.GET);
+    result.setURL(new URL("http", domain, port, SERVER_PATH_200));
+    return result;
+  }
+
+  private static List<HttpClient> protocolClients(HTTP2JettyClient client) throws Exception {
+    List<HttpClient> clients = new ArrayList<>();
+    for (String fieldName : PROTOCOL_CLIENT_FIELDS) {
+      clients.add((HttpClient) readField(client, fieldName));
+    }
+    return clients;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<ClientConnector> trackedConnectors(HTTP2JettyClient client) throws Exception {
+    return (List<ClientConnector>) readField(client, "connectors");
+  }
+
+  private static Object readField(HTTP2JettyClient client, String fieldName) throws Exception {
+    Field field = HTTP2JettyClient.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.get(client);
+  }
+
+  private static String profileKey(HTTP2Sampler sampler) throws Exception {
+    Method method = HTTP2Sampler.class.getDeclaredMethod("buildProfileKey");
+    method.setAccessible(true);
+    return (String) method.invoke(sampler);
+  }
+}

--- a/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientSourceAddressTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/HTTP2JettyClientSourceAddressTest.java
@@ -22,6 +22,7 @@ import org.apache.jmeter.protocol.http.sampler.HTTPSampleResult;
 import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase.SourceType;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.util.JMeterUtils;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.io.Connection;
@@ -43,6 +44,8 @@ public class HTTP2JettyClientSourceAddressTest extends HTTP2TestBase {
       "httpClientH2cUpgrade"
   };
 
+  private final List<String[]> savedProperties = new ArrayList<>();
+
   private TeardownableServer server;
   private HTTP2JettyClient client;
   private HTTP2Sampler sampler;
@@ -63,6 +66,13 @@ public class HTTP2JettyClientSourceAddressTest extends HTTP2TestBase {
     }
     if (server != null && server.isStarted()) {
       server.stop();
+    }
+    for (String[] saved : savedProperties) {
+      if (saved[1] == null) {
+        JMeterUtils.getJMeterProperties().remove(saved[0]);
+      } else {
+        JMeterUtils.setProperty(saved[0], saved[1]);
+      }
     }
   }
 
@@ -192,6 +202,42 @@ public class HTTP2JettyClientSourceAddressTest extends HTTP2TestBase {
     assertThat(profileKey(withSource)).isNotEqualTo(profileKey(withAnotherSource));
     assertThat(profileKey(withSource)).isNotEqualTo(profileKey(withAnotherType));
     assertThat(profileKey(withSource)).isEqualTo(profileKey(withSource));
+  }
+
+  @Test
+  public void clientCacheKeyFollowsTheLocalAddressPropertyWhenNoSamplerFieldIsSet()
+      throws Exception {
+    // Two samplers with no Source address field bind to whatever httpclient.localaddress says, so
+    // sharing a client is right while that value holds - but a cached client keeps the address it
+    // was built with, and a plan can change a JMeter property at runtime.
+    HTTP2Sampler sampler = newSampler("localhost", 8080);
+    String withoutProperty = profileKey(sampler);
+
+    overrideProperty("httpclient.localaddress", "127.0.0.1");
+    String withProperty = profileKey(sampler);
+    overrideProperty("httpclient.localaddress", "127.0.0.2");
+    String withAnotherProperty = profileKey(sampler);
+
+    assertThat(withoutProperty).isNotEqualTo(withProperty);
+    assertThat(withProperty).isNotEqualTo(withAnotherProperty);
+  }
+
+  @Test
+  public void clientCacheKeyPrefersTheSamplerFieldOverTheLocalAddressProperty() throws Exception {
+    // The field wins in resolve(), so it has to win in the key too: the property is irrelevant to
+    // what these clients bind to.
+    HTTP2Sampler sampler = newSampler("localhost", 8080);
+    sampler.setIpSource("127.0.0.1");
+    String withoutProperty = profileKey(sampler);
+
+    overrideProperty("httpclient.localaddress", "127.0.0.2");
+
+    assertThat(profileKey(sampler)).isEqualTo(withoutProperty);
+  }
+
+  private void overrideProperty(String key, String value) {
+    savedProperties.add(new String[] {key, JMeterUtils.getProperty(key)});
+    JMeterUtils.setProperty(key, value);
   }
 
   private static boolean isBindable(InetAddress address) {

--- a/src/test/java/com/blazemeter/jmeter/http2/core/JMeterSourceAddressResolverTest.java
+++ b/src/test/java/com/blazemeter/jmeter/http2/core/JMeterSourceAddressResolverTest.java
@@ -1,0 +1,140 @@
+package com.blazemeter.jmeter.http2.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assume.assumeTrue;
+
+import com.blazemeter.jmeter.http2.HTTP2TestBase;
+import com.blazemeter.jmeter.http2.sampler.HTTP2Sampler;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.UnknownHostException;
+import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase.SourceType;
+import org.apache.jmeter.util.JMeterUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * JMeter's "Source address" field (IP spoofing) has four modes and a global fallback property, and
+ * {@code HTTPHC4Impl} resolves them in a precise order before binding the socket. This pins the
+ * port of that algorithm: the sampler field wins over {@code httpclient.localaddress}, a device
+ * mode walks the interface list for an address of the requested family, and a name that cannot be
+ * resolved throws instead of quietly falling back to the default interface.
+ */
+public class JMeterSourceAddressResolverTest extends HTTP2TestBase {
+
+  private static final String LOCAL_ADDRESS_PROPERTY = "httpclient.localaddress";
+
+  private String originalLocalAddressProperty;
+
+  @Before
+  public void setUp() {
+    originalLocalAddressProperty = JMeterUtils.getProperty(LOCAL_ADDRESS_PROPERTY);
+    JMeterUtils.getJMeterProperties().remove(LOCAL_ADDRESS_PROPERTY);
+  }
+
+  @After
+  public void tearDown() {
+    if (originalLocalAddressProperty == null) {
+      JMeterUtils.getJMeterProperties().remove(LOCAL_ADDRESS_PROPERTY);
+    } else {
+      JMeterUtils.setProperty(LOCAL_ADDRESS_PROPERTY, originalLocalAddressProperty);
+    }
+  }
+
+  @Test
+  public void resolvesNothingWhenNeitherFieldNorPropertyIsSet() throws Exception {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+
+    assertThat(JMeterSourceAddressResolver.isConfigured(sampler)).isFalse();
+    assertThat(JMeterSourceAddressResolver.resolve(sampler)).isNull();
+  }
+
+  @Test
+  public void resolvesTheFieldAsAHostNameByDefault() throws Exception {
+    HTTP2Sampler sampler = samplerWith("127.0.0.1", SourceType.HOSTNAME);
+
+    assertThat(JMeterSourceAddressResolver.isConfigured(sampler)).isTrue();
+    assertThat(JMeterSourceAddressResolver.resolve(sampler))
+        .isEqualTo(InetAddress.getByName("127.0.0.1"));
+  }
+
+  @Test
+  public void fallsBackToTheLocalAddressProperty() throws Exception {
+    JMeterUtils.setProperty(LOCAL_ADDRESS_PROPERTY, "127.0.0.1");
+    HTTP2Sampler sampler = new HTTP2Sampler();
+
+    assertThat(JMeterSourceAddressResolver.isConfigured(sampler)).isTrue();
+    assertThat(JMeterSourceAddressResolver.resolve(sampler))
+        .isEqualTo(InetAddress.getByName("127.0.0.1"));
+  }
+
+  @Test
+  public void prefersTheSamplerFieldOverTheLocalAddressProperty() throws Exception {
+    JMeterUtils.setProperty(LOCAL_ADDRESS_PROPERTY, "127.0.0.2");
+    HTTP2Sampler sampler = samplerWith("127.0.0.1", SourceType.HOSTNAME);
+
+    assertThat(JMeterSourceAddressResolver.resolve(sampler))
+        .isEqualTo(InetAddress.getByName("127.0.0.1"));
+  }
+
+  @Test
+  public void ignoresAnUnresolvableLocalAddressProperty() throws Exception {
+    // HC4 logs and carries on rather than breaking every sample in the plan over a typo in a
+    // global property; only a sampler-level field is allowed to fail a sample.
+    JMeterUtils.setProperty(LOCAL_ADDRESS_PROPERTY, "no.such.host.invalid");
+    HTTP2Sampler sampler = new HTTP2Sampler();
+
+    assertThat(JMeterSourceAddressResolver.resolve(sampler)).isNull();
+  }
+
+  @Test
+  public void resolvesTheLoopbackDeviceToAnIpv4Address() throws Exception {
+    String loopbackDevice = loopbackDeviceName();
+    assumeTrue("No named interface holds the loopback address here", loopbackDevice != null);
+    HTTP2Sampler sampler = samplerWith(loopbackDevice, SourceType.DEVICE_IPV4);
+
+    assertThat(JMeterSourceAddressResolver.resolve(sampler)).isInstanceOf(Inet4Address.class);
+  }
+
+  @Test
+  public void resolvesTheLoopbackDeviceInAnyFamilyMode() throws Exception {
+    String loopbackDevice = loopbackDeviceName();
+    assumeTrue("No named interface holds the loopback address here", loopbackDevice != null);
+    HTTP2Sampler sampler = samplerWith(loopbackDevice, SourceType.DEVICE);
+
+    assertThat(JMeterSourceAddressResolver.resolve(sampler)).isNotNull();
+  }
+
+  @Test
+  public void failsWhenTheConfiguredDeviceDoesNotExist() {
+    HTTP2Sampler sampler = samplerWith("no-such-interface", SourceType.DEVICE);
+
+    assertThatThrownBy(() -> JMeterSourceAddressResolver.resolve(sampler))
+        .isInstanceOf(UnknownHostException.class)
+        .hasMessageContaining("Cannot find interface no-such-interface");
+  }
+
+  @Test
+  public void failsWhenTheConfiguredHostNameCannotBeResolved() {
+    HTTP2Sampler sampler = samplerWith("no.such.host.invalid", SourceType.HOSTNAME);
+
+    assertThatThrownBy(() -> JMeterSourceAddressResolver.resolve(sampler))
+        .isInstanceOf(UnknownHostException.class);
+  }
+
+  private static HTTP2Sampler samplerWith(String ipSource, SourceType sourceType) {
+    HTTP2Sampler sampler = new HTTP2Sampler();
+    sampler.setIpSource(ipSource);
+    sampler.setIpSourceType(sourceType.ordinal());
+    return sampler;
+  }
+
+  private static String loopbackDeviceName() throws Exception {
+    NetworkInterface loopback =
+        NetworkInterface.getByInetAddress(InetAddress.getLoopbackAddress());
+    return loopback == null ? null : loopback.getName();
+  }
+}


### PR DESCRIPTION
This pull request adds support for binding outgoing HTTP connections to a specific local (source) address, enabling IP spoofing in HTTP sampler. This matches the behavior of the HTTPClient 4 (HC4) implementation, allowing users to specify which network interface or IP address to use for outgoing requests. The implementation ensures that all protocol-specific clients and connectors are correctly bound, and updates the client cache key to account for the source address configuration.

Key changes include:

**Source Address Binding Support:**
* Added a new method `setSourceAddress` to `HTTP2JettyClient` that binds all outgoing connections and connectors (including QUIC/HTTP/3) to a specified source address, or restores the OS default if none is specified. This ensures correct IP spoofing and matches user expectations from other JMeter HTTP implementations. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR325-R329) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR3450-R3475)

**Sampler Integration and Configuration:**
* Updated `HTTP2Sampler` to resolve the source address before client creation, fail the sample if the address is invalid, and ensure the client cache key separates clients by source address configuration. This prevents clients with different source addresses from being incorrectly shared. [[1]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R877-R885) [[2]](diffhunk://#diff-80ba2fa4fb3904168bfb1402070f1b21c5ca1ec91ac84311f473b7f9d01e3b30R934-R966)

**Utility and Resolution Logic:**
* Introduced `JMeterSourceAddressResolver`, a utility class that resolves the correct source address based on sampler and global configuration, emulating the logic from HTTPClient 4 and handling interface/device lookups and error scenarios gracefully.

**Testing:**
* Added comprehensive tests in `HTTP2JettyClientSourceAddressTest` to verify binding behavior, error handling, and correct cache key separation for different source addresses and types.

**Dependency and Import Updates:**
* Updated imports and internal data structures in `HTTP2JettyClient` to support the new functionality, including tracking connectors and handling additional networking classes. [[1]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR20-R23) [[2]](diffhunk://#diff-d21430b39fb6aa6d3414af9de25c1caaccbd02415a5a23571937c0c5bbaa52fdR38-R44)

These changes collectively ensure that JMeter users can reliably control the source address for HTTP requests, with robust error handling and test coverage.